### PR TITLE
fix: 修复 Cloudflare Workers 环境变量读取问题

### DIFF
--- a/lib/email/resend.ts
+++ b/lib/email/resend.ts
@@ -7,9 +7,9 @@ const APP_NAME = "GoMate";
  * 获取环境变量（支持 Cloudflare Workers 和 Node.js 环境）
  */
 function getEnv(key: string): string | undefined {
-  // Cloudflare Workers 环境
-  if (typeof globalThis !== 'undefined' && (globalThis as Record<string, unknown>)[key]) {
-    return (globalThis as Record<string, unknown>)[key] as string;
+  // Cloudflare Workers 环境 - 环境变量在 globalThis.env 上
+  if (typeof globalThis !== 'undefined' && (globalThis as { env?: Record<string, string> }).env) {
+    return (globalThis as { env: Record<string, string> }).env[key];
   }
   // Node.js 环境
   if (typeof process !== 'undefined' && process.env) {


### PR DESCRIPTION
## 问题
忘记密码功能在生产环境无法发送邮件，报错 "RESEND_API_KEY is not configured"。

## 原因
Cloudflare Workers 环境变量存储在 `globalThis.env` 对象上，而不是直接挂在 `globalThis` 上。
lib/email/resend.ts 的 getEnv() 函数读取方式错误。

## 修复
- 修正 getEnv() 从 `globalThis.env[key]` 读取环境变量
- 添加 getCloudflareEnv() 函数统一获取环境变量
- 传递 env 参数到 sendPasswordResetEmail

## 影响
确保 Cloudflare Workers 环境能正确访问 RESEND_API_KEY 和其他环境变量