### PR TITLE
fix: 修复用户资料更新后 KV 缓存未清除问题

### DIFF
--- a/app/api/user/update/route.ts
+++ b/app/api/user/update/route.ts
@@ -97,6 +97,22 @@ export async function PATCH(request: NextRequest) {
       );
     }
 
+    // 清除 KV 缓存中的用户相关数据
+    // Better Auth 使用 KV 作为 secondaryStorage，需要清除缓存以保持一致性
+    if ((env as { GOMATE_KV?: KVNamespace }).GOMATE_KV) {
+      const kv = (env as { GOMATE_KV: KVNamespace }).GOMATE_KV;
+      const keysToDelete = [`user:${targetUserId}`];
+
+      for (const key of keysToDelete) {
+        try {
+          await kv.delete(key);
+          console.log("[KV] Deleted cache key:", key);
+        } catch (err) {
+          console.warn("[KV] Failed to delete key:", key, err);
+        }
+      }
+    }
+
     return NextResponse.json({
       success: true,
       user: updatedUser[0],

--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -81,7 +81,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         email: session.user.email,
         level: (fullUser?.level !== undefined ? fullUser.level : session.user.level as AuthUser["level"]) || "beginner",
         completedHikes: fullUser?.completedHikes !== undefined ? fullUser.completedHikes : ((session.user as unknown as { completedHikes?: number }).completedHikes || 0),
-        bio: "新人户外爱好者，期待与你一起探索山野。",
+        bio: fullUser?.bio !== undefined ? fullUser.bio : "新人户外爱好者，期待与你一起探索山野。",
         createdAt: fullUser?.createdAt !== undefined ? fullUser.createdAt : createdAtStr,
       };
       setUser(authUser);


### PR DESCRIPTION
## Summary
- 在 `/api/user/update` 中添加 KV 缓存清除逻辑，修复用户资料更新后刷新页面显示旧数据的问题
- 修复 `auth-context.tsx` 中 bio 字段未从 fullUser 读取的问题

## 问题原因
Better Auth 使用 KV 作为 `secondaryStorage` 缓存 session 数据。`/api/user/update` 只更新了 D1 数据库，没有清除 KV 中的缓存。刷新页面时，Better Auth 从 KV 读取缓存的 session，返回旧的用户信息。

## 修改内容
1. `app/api/user/update/route.ts`: 数据库更新成功后，清除 KV 中 `user:{userId}` 缓存键
2. `lib/auth-context.tsx`: bio 字段正确从 fullUser 读取，而非硬编码默认值

## Test plan
- [ ] 登录用户，进入 `/profile/edit`
- [ ] 修改个人简介，点击保存
- [ ] 刷新页面，确认显示的是新值
- [ ] 检查控制台无错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)