### PR TITLE
feat: 实现联系表单邮件发送功能

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sendContactFormEmail } from "@/lib/email/resend";
+
+interface ContactFormData {
+  name: string;
+  email: string;
+  subject: string;
+  message: string;
+}
+
+/**
+ * 联系表单 API
+ * POST /api/contact
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as ContactFormData;
+    const { name, email, subject, message } = body;
+
+    // 验证必填字段
+    if (!name || !email || !subject || !message) {
+      return NextResponse.json(
+        { error: "请填写所有必填字段" },
+        { status: 400 }
+      );
+    }
+
+    // 验证邮箱格式
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      return NextResponse.json(
+        { error: "请输入有效的邮箱地址" },
+        { status: 400 }
+      );
+    }
+
+    // 验证字段长度
+    if (name.length > 100) {
+      return NextResponse.json(
+        { error: "姓名长度不能超过 100 个字符" },
+        { status: 400 }
+      );
+    }
+
+    if (subject.length > 200) {
+      return NextResponse.json(
+        { error: "主题长度不能超过 200 个字符" },
+        { status: 400 }
+      );
+    }
+
+    if (message.length > 5000) {
+      return NextResponse.json(
+        { error: "建议内容不能超过 5000 个字符" },
+        { status: 400 }
+      );
+    }
+
+    // 发送邮件
+    const result = await sendContactFormEmail({
+      name: name.trim(),
+      email: email.trim().toLowerCase(),
+      subject: subject.trim(),
+      message: message.trim(),
+    });
+
+    if (!result.success) {
+      console.error("Failed to send contact email:", result.error);
+      return NextResponse.json(
+        { error: "发送失败，请稍后重试" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: "您的建议已成功提交，我们会尽快查看并回复。",
+    });
+  } catch (error) {
+    console.error("Contact API error:", error);
+    return NextResponse.json(
+      { error: "服务器错误，请稍后重试" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { motion } from "framer-motion";
-import { Mountain, Send, Mail, MessageSquare, CheckCircle } from "lucide-react";
+import { Mountain, Send, Mail, MessageSquare, CheckCircle, Loader2 } from "lucide-react";
 import Link from "next/link";
 
 import { Navbar } from "@/app/components/layout/navbar";
@@ -29,6 +29,8 @@ const contactMethods = [
 
 export default function ContactPage() {
   const [isSubmitted, setIsSubmitted] = React.useState(false);
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
   const [formData, setFormData] = React.useState({
     name: "",
     email: "",
@@ -36,10 +38,32 @@ export default function ContactPage() {
     message: "",
   });
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // 这里可以添加实际的提交逻辑
-    setIsSubmitted(true);
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/contact", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(formData),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || "提交失败，请稍后重试");
+      }
+
+      setIsSubmitted(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "提交失败，请稍后重试");
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const handleChange = (
@@ -144,6 +168,7 @@ export default function ContactPage() {
                   onClick={() => {
                     setIsSubmitted(false);
                     setFormData({ name: "", email: "", subject: "", message: "" });
+                    setError(null);
                   }}
                 >
                   继续提交
@@ -151,6 +176,11 @@ export default function ContactPage() {
               </motion.div>
             ) : (
               <form onSubmit={handleSubmit} className="space-y-6">
+                {error && (
+                  <div className="p-4 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+                    {error}
+                  </div>
+                )}
                 <div className="grid sm:grid-cols-2 gap-6">
                   <div className="space-y-2">
                     <Label htmlFor="name">您的姓名</Label>
@@ -206,10 +236,20 @@ export default function ContactPage() {
                   <Button
                     type="submit"
                     size="lg"
+                    disabled={isLoading}
                     className="bg-stone-800 hover:bg-stone-700 text-white px-8"
                   >
-                    <Send className="mr-2 h-4 w-4" />
-                    提交建议
+                    {isLoading ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        提交中...
+                      </>
+                    ) : (
+                      <>
+                        <Send className="mr-2 h-4 w-4" />
+                        提交建议
+                      </>
+                    )}
                   </Button>
                   <Button
                     type="button"

--- a/lib/email/resend.ts
+++ b/lib/email/resend.ts
@@ -473,3 +473,241 @@ function getWelcomeText(userName: string): string {
 &copy; ${new Date().getFullYear()} ${APP_NAME}. All rights reserved.
   `.trim();
 }
+
+/**
+ * 发送联系表单邮件
+ * @param data 表单数据
+ * @param env 环境变量（Cloudflare Workers 环境需要传入）
+ */
+export async function sendContactFormEmail(
+  data: {
+    name: string;
+    email: string;
+    subject: string;
+    message: string;
+  },
+  env?: EmailEnv
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const resend = createResendClientWithEnv(env);
+    const contactEmail = getEnv("CONTACT_EMAIL") || "gomate@jiahongw.com";
+
+    const { data: result, error } = await resend.emails.send({
+      from: getFromEmailWithEnv(env),
+      to: [contactEmail],
+      subject: `[GoMate 建议] ${data.subject}`,
+      html: getContactFormTemplate(data),
+      text: getContactFormText(data),
+      replyTo: data.email,
+    });
+
+    if (error) {
+      console.error("Resend email error:", error);
+      return { success: false, error: error.message };
+    }
+
+    console.log("Contact form email sent:", result?.id);
+    return { success: true };
+  } catch (error) {
+    console.error("Send contact form email error:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "发送邮件失败",
+    };
+  }
+}
+
+/**
+ * 联系表单邮件 HTML 模板
+ */
+function getContactFormTemplate(data: {
+  name: string;
+  email: string;
+  subject: string;
+  message: string;
+}): string {
+  const timestamp = new Date().toLocaleString("zh-CN", {
+    timeZone: "Asia/Shanghai",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  return `
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>[GoMate 建议] ${data.subject}</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      line-height: 1.6;
+      color: #44403c;
+      background-color: #fafaf9;
+      margin: 0;
+      padding: 0;
+    }
+    .container {
+      max-width: 600px;
+      margin: 0 auto;
+      padding: 40px 20px;
+    }
+    .card {
+      background-color: #ffffff;
+      border-radius: 12px;
+      padding: 40px;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    }
+    .logo {
+      text-align: center;
+      margin-bottom: 32px;
+    }
+    .logo-text {
+      font-size: 24px;
+      font-weight: 700;
+      color: #1c1917;
+      text-decoration: none;
+    }
+    .title {
+      font-size: 20px;
+      font-weight: 600;
+      color: #1c1917;
+      margin-bottom: 24px;
+      text-align: center;
+    }
+    .info-block {
+      background-color: #f5f5f4;
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 20px;
+    }
+    .info-row {
+      display: flex;
+      margin-bottom: 12px;
+    }
+    .info-row:last-child {
+      margin-bottom: 0;
+    }
+    .info-label {
+      font-weight: 600;
+      color: #1c1917;
+      min-width: 80px;
+    }
+    .info-value {
+      color: #57534e;
+    }
+    .message-block {
+      background-color: #fff;
+      border: 1px solid #e7e5e4;
+      border-radius: 8px;
+      padding: 20px;
+      margin: 24px 0;
+    }
+    .message-title {
+      font-weight: 600;
+      color: #1c1917;
+      margin-bottom: 12px;
+    }
+    .message-content {
+      color: #57534e;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .divider {
+      border-top: 1px solid #e7e5e4;
+      margin: 32px 0;
+    }
+    .footer {
+      font-size: 14px;
+      color: #a8a29e;
+      text-align: center;
+    }
+    .timestamp {
+      font-size: 14px;
+      color: #78716c;
+      text-align: right;
+      margin-top: 16px;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="card">
+      <div class="logo">
+        <span class="logo-text">GoMate</span>
+      </div>
+      <h1 class="title">新的用户建议</h1>
+
+      <div class="info-block">
+        <div class="info-row">
+          <span class="info-label">用户姓名</span>
+          <span class="info-value">${data.name}</span>
+        </div>
+        <div class="info-row">
+          <span class="info-label">联系邮箱</span>
+          <span class="info-value"><a href="mailto:${data.email}">${data.email}</a></span>
+        </div>
+        <div class="info-row">
+          <span class="info-label">主题</span>
+          <span class="info-value">${data.subject}</span>
+        </div>
+      </div>
+
+      <div class="message-block">
+        <div class="message-title">详细建议</div>
+        <div class="message-content">${data.message}</div>
+      </div>
+
+      <div class="timestamp">提交时间：${timestamp}</div>
+
+      <div class="divider"></div>
+      <div class="footer">
+        <p>此邮件由 GoMate 联系表单自动发送</p>
+        <p>回复此邮件将直接发送至用户邮箱</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>
+  `;
+}
+
+/**
+ * 联系表单邮件纯文本模板
+ */
+function getContactFormText(data: {
+  name: string;
+  email: string;
+  subject: string;
+  message: string;
+}): string {
+  const timestamp = new Date().toLocaleString("zh-CN", {
+    timeZone: "Asia/Shanghai",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  return `
+[GoMate 建议] ${data.subject}
+
+用户姓名：${data.name}
+联系邮箱：${data.email}
+主题：${data.subject}
+
+详细建议：
+${data.message}
+
+提交时间：${timestamp}
+
+---
+此邮件由 GoMate 联系表单自动发送
+回复此邮件将直接发送至用户邮箱
+  `.trim();
+}


### PR DESCRIPTION
## Summary

- 新增 `/api/contact` API 端点处理联系表单提交
- 添加 `sendContactFormEmail` 函数发送建议通知邮件
- 更新联系页面表单提交逻辑，支持 loading 状态和错误处理
- 邮件默认发送至 `gomate@jiahongw.com`，可通过 `CONTACT_EMAIL` 环境变量配置

## 功能说明

1. **表单提交流程**：
   - 用户填写表单后点击"提交建议"
   - 调用 `POST /api/contact` API
   - 显示 loading 状态（按钮禁用 + 转圈图标）
   - 成功后显示感谢页面，失败则显示错误提示

2. **API 验证**：
   - 必填字段验证
   - 邮箱格式验证
   - 字段长度限制（姓名100、主题200、建议5000字符）

3. **邮件内容**：
   - 主题：`[GoMate 建议] {用户填写的主题}`
   - 包含：用户姓名、邮箱、主题、详细建议、提交时间
   - `replyTo` 设置为用户邮箱，方便直接回复

## Test plan

- [ ] 启动本地开发服务器 `npm run dev`
- [ ] 访问 `http://localhost:8787/contact`
- [ ] 填写表单并提交
- [ ] 验证成功提示显示正确
- [ ] 检查管理员邮箱收到邮件

🤖 Generated with [Claude Code](https://claude.com/claude-code)