### PR TITLE
feat: 添加队伍分享功能

### DIFF
--- a/app/components/features/team-header.tsx
+++ b/app/components/features/team-header.tsx
@@ -11,6 +11,7 @@ import {
   Clock,
   MapPin,
 } from "lucide-react";
+import { ShareTeamDialog } from "@/components/features/share-team-dialog";
 import { Badge } from "@/components/ui/badge";
 import type { Team, Location } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -96,6 +97,14 @@ function TeamHeader({ team, location, className }: TeamHeaderProps) {
           </div>
         </div>
       </div>
+
+      {/* Share Dialog */}
+      <ShareTeamDialog
+        open={isShareOpen}
+        onOpenChange={setIsShareOpen}
+        team={team}
+        location={location}
+      />
     </motion.div>
   );
 }

--- a/app/components/providers.tsx
+++ b/app/components/providers.tsx
@@ -3,6 +3,7 @@
 import { AuthProvider } from "@/lib/auth-context";
 import { LocationsProvider } from "@/lib/locations-context";
 import { TeamsProvider } from "@/lib/teams-context";
+import { ToastProvider } from "@/components/ui/toast";
 
 console.log("[Providers] Rendering...");
 
@@ -12,7 +13,9 @@ export function AppProviders({ children }: { children: React.ReactNode }) {
     <AuthProvider>
       <LocationsProvider>
         <TeamsProvider>
-          {children}
+          <ToastProvider>
+            {children}
+          </ToastProvider>
         </TeamsProvider>
       </LocationsProvider>
     </AuthProvider>

--- a/components/features/share-team-dialog.tsx
+++ b/components/features/share-team-dialog.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import * as React from "react";
+import { createPortal } from "react-dom";
+import { X, Copy, Share2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/components/ui/toast";
+import type { Team, Location } from "@/lib/types";
+import { copy } from "@/lib/copy";
+import { cn } from "@/lib/utils";
+
+interface ShareTeamDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  team: Team;
+  location: Location;
+}
+
+function ShareTeamDialog({
+  open,
+  onOpenChange,
+  team,
+  location,
+}: ShareTeamDialogProps) {
+  const { showToast } = useToast();
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  // 生成分享链接
+  const shareUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}/teams/${team.id}`
+      : "";
+
+  // 复制链接
+  const handleCopyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      showToast(copy.share.linkCopied);
+    } catch {
+      // 降级方案：选中输入框内容
+      inputRef.current?.select();
+      document.execCommand("copy");
+      showToast(copy.share.linkCopied);
+    }
+  };
+
+  // 原生分享（移动端）
+  const handleNativeShare = async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: `${team.title} - GoMate`,
+          text: `${copy.share.inviteText}：${team.title}`,
+          url: shareUrl,
+        });
+      } catch {
+        // 用户取消分享或分享失败，不做处理
+      }
+    }
+  };
+
+  // 是否支持原生分享
+  const canNativeShare = typeof navigator !== "undefined" && !!navigator.share;
+
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[500] flex items-center justify-center p-4"
+      onClick={() => onOpenChange(false)}
+    >
+      {/* 背景遮罩 */}
+      <div className="absolute inset-0 bg-black/50" />
+
+      {/* 弹窗内容 */}
+      <div
+        className={cn(
+          "relative w-full max-w-md bg-white rounded-xl shadow-xl",
+          "animate-in fade-in-0 zoom-in-95 duration-200"
+        )}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* 头部 */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-stone-200">
+          <h2 className="text-lg font-semibold text-stone-900">
+            {copy.share.title}
+          </h2>
+          <button
+            onClick={() => onOpenChange(false)}
+            className="p-1 text-stone-400 hover:text-stone-600 rounded-full hover:bg-stone-100 transition-colors"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* 内容 */}
+        <div className="px-4 py-4 space-y-4">
+          {/* 队伍信息 */}
+          <div className="space-y-1">
+            <p className="font-medium text-stone-900">{team.title}</p>
+            <p className="text-sm text-stone-500">{location.name}</p>
+          </div>
+
+          {/* 分享链接 */}
+          <div className="space-y-2">
+            <label className="text-sm text-stone-600">分享链接</label>
+            <div className="flex gap-2">
+              <Input
+                ref={inputRef}
+                value={shareUrl}
+                readOnly
+                className="flex-1 text-sm"
+                onClick={() => inputRef.current?.select()}
+              />
+              <Button onClick={handleCopyLink} variant="outline" size="icon">
+                <Copy className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+
+          {/* 操作按钮 */}
+          <div className="flex gap-2">
+            <Button onClick={handleCopyLink} className="flex-1">
+              <Copy className="h-4 w-4 mr-2" />
+              {copy.share.copyLink}
+            </Button>
+            {canNativeShare && (
+              <Button onClick={handleNativeShare} variant="outline" className="flex-1">
+                <Share2 className="h-4 w-4 mr-2" />
+                {copy.share.shareVia}
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+export { ShareTeamDialog };

--- a/components/features/team-header.tsx
+++ b/components/features/team-header.tsx
@@ -11,7 +11,7 @@ import {
   Clock,
   MapPin,
 } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
+import { ShareTeamDialog } from "@/components/features/share-team-dialog";
 import type { Team, Location } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -50,7 +50,7 @@ function TeamHeader({ team, location, className }: TeamHeaderProps) {
             返回地点
           </Link>
           <button
-            onClick={() => setIsShareOpen(!isShareOpen)}
+            onClick={() => setIsShareOpen(true)}
             className="p-2 text-stone-400 hover:text-stone-600 hover:bg-stone-100 rounded-full transition-colors"
             aria-label="分享"
           >
@@ -96,6 +96,14 @@ function TeamHeader({ team, location, className }: TeamHeaderProps) {
           </div>
         </div>
       </div>
+
+      {/* Share Dialog */}
+      <ShareTeamDialog
+        open={isShareOpen}
+        onOpenChange={setIsShareOpen}
+        team={team}
+        location={location}
+      />
     </motion.div>
   );
 }

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import * as React from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/lib/utils";
+import { Check } from "lucide-react";
+
+interface ToastContextValue {
+  showToast: (message: string) => void;
+}
+
+const ToastContext = React.createContext<ToastContextValue | null>(null);
+
+function useToast() {
+  const context = React.useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return context;
+}
+
+function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = React.useState<{ id: number; message: string }[]>([]);
+  const [mounted, setMounted] = React.useState(false);
+
+  // 只在客户端挂载后才渲染 portal
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const showToast = React.useCallback((message: string) => {
+    const id = Date.now();
+    setToasts((prev) => [...prev, { id, message }]);
+
+    // 3秒后自动消失
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 3000);
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      {mounted &&
+        createPortal(
+          <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-[600] flex flex-col gap-2">
+            {toasts.map((toast) => (
+              <Toast key={toast.id} message={toast.message} />
+            ))}
+          </div>,
+          document.body
+        )}
+    </ToastContext.Provider>
+  );
+}
+
+function Toast({ message }: { message: string }) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 px-4 py-3 rounded-lg",
+        "bg-stone-900 text-white text-sm font-medium",
+        "shadow-lg animate-in fade-in-0 slide-in-from-bottom-4",
+        "duration-300"
+      )}
+    >
+      <Check className="h-4 w-4 text-emerald-400" />
+      <span>{message}</span>
+    </div>
+  );
+}
+
+export { ToastProvider, useToast };

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -499,6 +499,15 @@ export const copy = {
     userNotFoundWithId: "User not found with ID",
   },
 
+  // ─── 分享 ─────────────────────────────────────────────────────────────────
+  share: {
+    title: "分享队伍",
+    linkCopied: "链接已复制到剪贴板",
+    copyLink: "复制链接",
+    shareVia: "通过应用分享",
+    inviteText: "邀请你加入徒步队伍",
+  },
+
   // ─── 枚举标签（与数据库枚举值一一对应）──────────────────────────────────
   enums: {
     difficulty: {


### PR DESCRIPTION
## Summary

- 新增 `ShareTeamDialog` 组件，支持复制链接和移动端原生分享
- 新增 `ToastProvider` 和 `useToast` 用于提示消息
- 在 `TeamHeader` 中集成分享对话框，点击分享按钮可弹出分享弹窗
- 添加分享相关的文案配置到 `lib/copy.ts`

## Test plan

- [ ] 访问队伍详情页，点击右上角分享按钮
- [ ] 验证分享弹窗正常弹出
- [ ] 点击"复制链接"按钮，验证链接已复制到剪贴板并显示提示
- [ ] 在移动端验证"通过应用分享"按钮是否出现并正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)