### PR TITLE
feat: 添加用户微信号字段

### DIFF
--- a/app/actions/teams.ts
+++ b/app/actions/teams.ts
@@ -5,6 +5,7 @@ import {
   teams,
   teamMembers,
   locations,
+  users,
   TeamStatus,
 } from "@/db/schema";
 import { eq, and, desc, sql } from "drizzle-orm";
@@ -193,6 +194,16 @@ export async function joinTeam(teamId: string) {
   }
 
   const db = await getDB();
+
+  // 检查用户是否已填写微信号
+  const userRecord = await db.query.users.findFirst({
+    where: eq(users.id, user.id),
+    columns: { wechat: true },
+  });
+
+  if (!userRecord?.wechat) {
+    throw new Error(copy.errors.wechatRequired);
+  }
 
   // 获取队伍信息
   const team = await db.query.teams.findFirst({

--- a/app/actions/users.ts
+++ b/app/actions/users.ts
@@ -1,8 +1,8 @@
 "use server";
 
 import { getDB } from "@/db";
-import { users } from "@/db/schema";
-import { eq } from "drizzle-orm";
+import { users, teamMembers } from "@/db/schema";
+import { eq, and } from "drizzle-orm";
 import { getAuth } from "@/lib/auth";
 import { headers } from "next/headers";
 import { revalidateTag } from "next/cache";
@@ -39,6 +39,7 @@ export async function getUserProfile(userId: string) {
       bio: true,
       level: true,
       createdAt: true,
+      wechat: true,
     },
   });
 
@@ -51,6 +52,7 @@ export async function updateProfile(data: {
   bio?: string;
   level?: string;
   image?: string;
+  wechat?: string;
 }) {
   const auth = await getAuth();
   const session = await auth.api.getSession({
@@ -85,6 +87,7 @@ export async function updateProfile(data: {
       ...(data.bio !== undefined && { bio: data.bio }),
       ...(data.level && { level: data.level }),
       ...(data.image && { image: data.image }),
+      ...(data.wechat !== undefined && { wechat: data.wechat }),
       updatedAt: new Date(),
     })
     .where(eq(users.id, userId))
@@ -121,4 +124,68 @@ export async function isEmailVerified() {
   });
 
   return user?.emailVerified || false;
+}
+
+// 获取队友的微信号（仅限同队成员可见）
+export async function getTeammateWechat(userId: string) {
+  const auth = await getAuth();
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session?.user) {
+    throw new Error("请先登录");
+  }
+
+  const currentUserId = session.user.id;
+  const db = await getDB();
+
+  // 如果是查看自己的微信号，直接返回
+  if (currentUserId === userId) {
+    const user = await db.query.users.findFirst({
+      where: eq(users.id, userId),
+      columns: { wechat: true },
+    });
+    return user?.wechat || null;
+  }
+
+  // 检查是否是队友关系（两人都在同一个已审核通过的队伍中）
+  const currentUserTeams = await db
+    .selectDistinct({ teamId: teamMembers.teamId })
+    .from(teamMembers)
+    .where(
+      and(
+        eq(teamMembers.userId, currentUserId),
+        eq(teamMembers.status, "approved")
+      )
+    )
+    .execute();
+
+  const targetUserTeams = await db
+    .selectDistinct({ teamId: teamMembers.teamId })
+    .from(teamMembers)
+    .where(
+      and(
+        eq(teamMembers.userId, userId),
+        eq(teamMembers.status, "approved")
+      )
+    )
+    .execute();
+
+  // 检查是否有共同的队伍
+  const hasCommonTeam = currentUserTeams.some((t1) =>
+    targetUserTeams.some((t2) => t1.teamId === t2.teamId)
+  );
+
+  if (!hasCommonTeam) {
+    return null; // 不是队友，不返回微信号
+  }
+
+  // 返回目标用户的微信号
+  const targetUser = await db.query.users.findFirst({
+    where: eq(users.id, userId),
+    columns: { wechat: true },
+  });
+
+  return targetUser?.wechat || null;
 }

--- a/app/api/teams/[id]/route.ts
+++ b/app/api/teams/[id]/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getAuth } from "@/lib/auth";
+import { headers } from "next/headers";
 
 // 动态导入 @opennextjs/cloudflare 以避免构建时错误
 const getCloudflareContext = async () => {
@@ -30,13 +32,18 @@ export async function GET(
     // 使用 Drizzle ORM 查询
     const { drizzle } = await import("drizzle-orm/d1");
     const schema = await import("@/db/schema");
-    const { eq } = await import("drizzle-orm");
+    const { eq, and } = await import("drizzle-orm");
     const ormDb = drizzle(db, { schema });
 
     const teams = await ormDb.query.teams.findMany({
       where: eq(schema.teams.id, id),
       with: {
         leader: true,
+        members: {
+          with: {
+            user: true,
+          },
+        },
       },
       limit: 1,
     });
@@ -48,6 +55,28 @@ export async function GET(
         { error: "队伍不存在" },
         { status: 404 }
       );
+    }
+
+    // 获取当前用户（如果已登录）
+    let currentUserId: string | null = null;
+    try {
+      const auth = await getAuth();
+      const session = await auth.api.getSession({
+        headers: await headers(),
+      });
+      currentUserId = session?.user?.id || null;
+    } catch {
+      // 用户未登录，忽略
+    }
+
+    // 检查当前用户是否是该队伍的成员（已审核通过）
+    let isTeamMember = false;
+    if (currentUserId) {
+      const membership = team.members?.find(
+        (m: { userId: string; status: string }) =>
+          m.userId === currentUserId && m.status === "approved"
+      );
+      isTeamMember = !!membership;
     }
 
     // 从 startTime 提取日期和时间
@@ -89,7 +118,9 @@ export async function GET(
         avatar: team.leader.image || '',
         level: (team.leader.level || 'beginner') as 'beginner' | 'intermediate' | 'advanced' | 'expert',
         completedHikes: 0,
-        bio: '',
+        bio: team.leader.bio || '',
+        // 只有队长自己或队伍成员可以看到队长的微信号
+        wechat: (isTeamMember || currentUserId === team.leader.id) ? (team.leader.wechat || '') : undefined,
       } : {
         id: 'unknown',
         name: '未知用户',

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -61,6 +61,7 @@ export async function GET(request: NextRequest) {
         bio: user[0].bio,
         level: user[0].level || "beginner",
         completedHikes: user[0].completedHikes,
+        wechat: user[0].wechat,
         createdAt: user[0].createdAt,
         updatedAt: user[0].updatedAt,
       },

--- a/app/api/user/update/route.ts
+++ b/app/api/user/update/route.ts
@@ -29,7 +29,7 @@ export async function PATCH(request: NextRequest) {
 
     // 解析请求体
     const body = await request.json();
-    const { userId, name, bio, level, image } = body;
+    const { userId, name, bio, level, image, wechat } = body;
 
     if (!userId) {
       return NextResponse.json(
@@ -47,6 +47,7 @@ export async function PATCH(request: NextRequest) {
       updateData.level = level;
     }
     if (image !== undefined) updateData.image = image;
+    if (wechat !== undefined) updateData.wechat = wechat;
 
     // 手动设置 updatedAt（Drizzle ORM 会自动转换为时间戳）
     updateData.updatedAt = new Date();

--- a/app/profile/edit/page.tsx
+++ b/app/profile/edit/page.tsx
@@ -37,6 +37,7 @@ export default function EditProfilePage() {
     name: "",
     bio: "",
     level: "beginner" as const,
+    wechat: "",
   });
   const [isSaving, setIsSaving] = React.useState(false);
   const [message, setMessage] = React.useState<{ type: "success" | "error"; text: string } | null>(null);
@@ -54,6 +55,7 @@ export default function EditProfilePage() {
         name: user.name,
         bio: user.bio,
         level: user.level,
+        wechat: user.wechat || "",
       });
       setAvatarPreview(user.avatar);
     }
@@ -180,6 +182,7 @@ export default function EditProfilePage() {
           image: avatarUrl === DEFAULT_AVATAR ? null : avatarUrl,
           bio: formData.bio,
           level: formData.level,
+          wechat: formData.wechat,
         }),
       });
 
@@ -377,6 +380,21 @@ export default function EditProfilePage() {
                       </label>
                     ))}
                   </div>
+                </div>
+
+                {/* WeChat ID */}
+                <div className="space-y-2">
+                  <Label htmlFor="wechat">{copy.profile.wechat}</Label>
+                  <Input
+                    id="wechat"
+                    name="wechat"
+                    value={formData.wechat}
+                    onChange={handleInputChange}
+                    maxLength={50}
+                    className="border-stone-200"
+                    placeholder={copy.profile.wechatPlaceholder}
+                  />
+                  <p className="text-xs text-stone-500">{copy.profile.wechatHint}</p>
                 </div>
 
                 {/* Email (Read-only) */}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -15,6 +15,7 @@ import {
   Calendar,
   Award,
   Users,
+  MessageCircle,
 } from "lucide-react";
 
 import { Navbar } from "@/app/components/layout/navbar";
@@ -150,6 +151,14 @@ export default function ProfilePage() {
                   <p className="mt-4 text-stone-600 leading-relaxed">
                     {user.bio}
                   </p>
+                )}
+
+                {/* WeChat - only visible to self */}
+                {user.wechat && (
+                  <div className="mt-4 flex items-center gap-2 text-stone-500">
+                    <MessageCircle className="h-4 w-4" />
+                    <span className="text-sm">微信号：{user.wechat}</span>
+                  </div>
                 )}
               </div>
             </CardContent>

--- a/components/features/join-button.tsx
+++ b/components/features/join-button.tsx
@@ -2,12 +2,13 @@
 
 import * as React from "react";
 import { motion } from "framer-motion";
-import { Check, Loader2, Users } from "lucide-react";
+import { Check, Loader2, Users, AlertCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { Team } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/lib/auth-context";
 import { copy } from "@/lib/copy";
+import Link from "next/link";
 
 interface JoinButtonProps {
   team: Team;
@@ -15,7 +16,7 @@ interface JoinButtonProps {
   onJoin?: () => void;
 }
 
-type JoinState = "idle" | "loading" | "success" | "full" | "closed";
+type JoinState = "idle" | "loading" | "success" | "full" | "closed" | "wechat_required";
 
 function JoinButton({ team, className, onJoin }: JoinButtonProps) {
   const { user } = useAuth();
@@ -52,8 +53,13 @@ function JoinButton({ team, className, onJoin }: JoinButtonProps) {
           setJoinState(team.status === "full" ? "full" : team.status === "closed" ? "closed" : "idle");
         }, 2000);
       } else {
-        alert(result.error || copy.api.failed);
-        setJoinState(team.status === "full" ? "full" : team.status === "closed" ? "closed" : "idle");
+        // 检查是否是微信号缺失错误
+        if (result.error?.includes("微信号")) {
+          setJoinState("wechat_required");
+        } else {
+          alert(result.error || copy.api.failed);
+          setJoinState(team.status === "full" ? "full" : team.status === "closed" ? "closed" : "idle");
+        }
       }
     } catch (error) {
       console.error("Join team error:", error);
@@ -93,6 +99,12 @@ function JoinButton({ team, className, onJoin }: JoinButtonProps) {
       variant: "secondary" as const,
       className: "bg-stone-200 text-stone-500 cursor-not-allowed",
     },
+    wechat_required: {
+      text: "请先填写微信号",
+      icon: AlertCircle,
+      variant: "outline" as const,
+      className: "border-amber-500 text-amber-600",
+    },
   };
 
   const config = buttonConfig[joinState];
@@ -113,6 +125,8 @@ function JoinButton({ team, className, onJoin }: JoinButtonProps) {
                 ? copy.errors.teamFull
                 : joinState === "closed"
                 ? copy.errors.teamNotAccepting
+                : joinState === "wechat_required"
+                ? copy.errors.wechatRequired
                 : joinState === "success"
                 ? copy.teams.leader
                 : `已有 ${team.currentMembers} 人报名，还剩 ${
@@ -122,28 +136,41 @@ function JoinButton({ team, className, onJoin }: JoinButtonProps) {
           </div>
           {/* 如果不是队长，则显示申请加入按钮 */}
           {!isLeader && (
-            <Button
-              size="lg"
-              variant={config.variant}
-              onClick={handleJoin}
-              disabled={joinState === "loading" || joinState === "full" || joinState === "closed"}
-              className={cn(
-                "px-8 transition-all duration-300",
-                config.className
-              )}
-            >
-              <motion.div
-                animate={joinState === "loading" ? { rotate: 360 } : {}}
-                transition={
-                  joinState === "loading"
-                    ? { duration: 1, repeat: Infinity, ease: "linear" }
-                    : {}
-                }
+            joinState === "wechat_required" ? (
+              <Button
+                size="lg"
+                variant="outline"
+                asChild
+                className="px-8 border-amber-500 text-amber-600 hover:bg-amber-50"
               >
-                <Icon className="h-5 w-5 mr-2" />
-              </motion.div>
-              {config.text}
-            </Button>
+                <Link href="/profile/edit">
+                  去填写
+                </Link>
+              </Button>
+            ) : (
+              <Button
+                size="lg"
+                variant={config.variant}
+                onClick={handleJoin}
+                disabled={joinState === "loading" || joinState === "full" || joinState === "closed"}
+                className={cn(
+                  "px-8 transition-all duration-300",
+                  config.className
+                )}
+              >
+                <motion.div
+                  animate={joinState === "loading" ? { rotate: 360 } : {}}
+                  transition={
+                    joinState === "loading"
+                      ? { duration: 1, repeat: Infinity, ease: "linear" }
+                      : {}
+                  }
+                >
+                  <Icon className="h-5 w-5 mr-2" />
+                </motion.div>
+                {config.text}
+              </Button>
+            )
           )}
         </div>
       </div>

--- a/components/features/leader-card.tsx
+++ b/components/features/leader-card.tsx
@@ -8,6 +8,8 @@ import {
   Star,
   MessageCircle,
   Shield,
+  Copy,
+  Check,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -16,6 +18,7 @@ import { Button } from "@/components/ui/button";
 import type { Team } from "@/lib/types";
 import { leaderLevelLabels } from "@/lib/constants";
 import { cn } from "@/lib/utils";
+import { copy as copyText } from "@/lib/copy";
 
 interface LeaderCardProps {
   team: Team;
@@ -38,6 +41,15 @@ const levelStars: Record<string, number> = {
 
 function LeaderCard({ team, className }: LeaderCardProps) {
   const { leader } = team;
+  const [copied, setCopied] = React.useState(false);
+
+  const handleCopyWechat = async () => {
+    if (leader.wechat) {
+      await navigator.clipboard.writeText(leader.wechat);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
 
   return (
     <motion.div
@@ -121,13 +133,39 @@ function LeaderCard({ team, className }: LeaderCardProps) {
           </div>
 
           {/* Contact Button */}
-          <Button
-            variant="outline"
-            className="w-full border-stone-300 hover:bg-stone-50"
-          >
-            <MessageCircle className="h-4 w-4 mr-2" />
-            联系领队
-          </Button>
+          {leader.wechat ? (
+            <div className="space-y-3">
+              <div className="flex items-center justify-between p-3 bg-stone-100 rounded-lg">
+                <div>
+                  <p className="text-xs text-stone-500">微信号</p>
+                  <p className="font-medium text-stone-900">{leader.wechat}</p>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleCopyWechat}
+                  className="h-8 w-8 p-0"
+                >
+                  {copied ? (
+                    <Check className="h-4 w-4 text-emerald-600" />
+                  ) : (
+                    <Copy className="h-4 w-4 text-stone-600" />
+                  )}
+                </Button>
+              </div>
+              <p className="text-xs text-stone-400 text-center">
+                复制微信号，添加领队为好友
+              </p>
+            </div>
+          ) : (
+            <Button
+              variant="outline"
+              className="w-full border-stone-300 hover:bg-stone-50"
+            >
+              <MessageCircle className="h-4 w-4 mr-2" />
+              联系领队
+            </Button>
+          )}
         </CardContent>
       </Card>
     </motion.div>

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -20,6 +20,7 @@ export const users = sqliteTable(
     image: text("image"), // 用户头像 URL
     bio: text("bio"), // 个人简介
     level: text("level").default("beginner"), // 领队等级: beginner(新手), intermediate(进阶), advanced(资深), expert(专家)
+    wechat: text("wechat"), // 微信号（可选，加入队伍时必填）
     completedHikes: integer("completed_hikes").default(0), // 完成徒步次数
     createdAt: integer("created_at", { mode: "timestamp" }).$defaultFn(() => new Date()).notNull(), // 账号创建时间
     updatedAt: integer("updated_at", { mode: "timestamp" }).$defaultFn(() => new Date()).notNull(), // 资料更新时间

--- a/drizzle/0001_colorful_serpent_society.sql
+++ b/drizzle/0001_colorful_serpent_society.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` ADD `wechat` text;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1003 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7ccbc07f-ad4c-4340-bef8-c09745afafc5",
+  "prevId": "e5008283-6ed6-4466-9e31-4f79d0e4e3da",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "accounts_user_idx": {
+          "name": "accounts_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "accounts_provider_idx": {
+          "name": "accounts_provider_idx",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "distance": {
+          "name": "distance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "elevation": {
+          "name": "elevation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "best_season": {
+          "name": "best_season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_image": {
+          "name": "cover_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "images": {
+          "name": "images",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "route_description": {
+          "name": "route_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "route_guide": {
+          "name": "route_guide",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "waypoints": {
+          "name": "waypoints",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tips": {
+          "name": "tips",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "equipment_needed": {
+          "name": "equipment_needed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "coordinates": {
+          "name": "coordinates",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "facilities": {
+          "name": "facilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "locations_slug_unique": {
+          "name": "locations_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "locations_slug_idx": {
+          "name": "locations_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "locations_difficulty_idx": {
+          "name": "locations_difficulty_idx",
+          "columns": [
+            "difficulty"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_resets": {
+      "name": "password_resets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "password_resets_token_unique": {
+          "name": "password_resets_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "password_resets_token_idx": {
+          "name": "password_resets_token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        },
+        "password_resets_user_idx": {
+          "name": "password_resets_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "password_resets_email_idx": {
+          "name": "password_resets_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "password_resets_user_id_users_id_fk": {
+          "name": "password_resets_user_id_users_id_fk",
+          "tableFrom": "password_resets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "sessions_token_idx": {
+          "name": "sessions_token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_members": {
+      "name": "team_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_members_team_idx": {
+          "name": "team_members_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "team_members_user_idx": {
+          "name": "team_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "team_members_team_user_idx": {
+          "name": "team_members_team_user_idx",
+          "columns": [
+            "team_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teams": {
+      "name": "teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "leader_id": {
+          "name": "leader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_members": {
+          "name": "max_members",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "current_members": {
+          "name": "current_members",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'recruiting'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "teams_location_idx": {
+          "name": "teams_location_idx",
+          "columns": [
+            "location_id"
+          ],
+          "isUnique": false
+        },
+        "teams_leader_idx": {
+          "name": "teams_leader_idx",
+          "columns": [
+            "leader_id"
+          ],
+          "isUnique": false
+        },
+        "teams_status_idx": {
+          "name": "teams_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "teams_start_time_idx": {
+          "name": "teams_start_time_idx",
+          "columns": [
+            "start_time"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "teams_location_id_locations_id_fk": {
+          "name": "teams_location_id_locations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "teams_leader_id_users_id_fk": {
+          "name": "teams_leader_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "leader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'beginner'"
+        },
+        "wechat": {
+          "name": "wechat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_hikes": {
+          "name": "completed_hikes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verifications": {
+      "name": "verifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1772211821267,
       "tag": "0000_shallow_blockbuster",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1772354373387,
+      "tag": "0001_colorful_serpent_society",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -13,6 +13,7 @@ export interface AuthUser {
   level: "beginner" | "intermediate" | "advanced" | "expert";
   completedHikes: number;
   bio: string;
+  wechat?: string;
   createdAt: string;
 }
 
@@ -82,6 +83,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         level: (fullUser?.level !== undefined ? fullUser.level : session.user.level as AuthUser["level"]) || "beginner",
         completedHikes: fullUser?.completedHikes !== undefined ? fullUser.completedHikes : ((session.user as unknown as { completedHikes?: number }).completedHikes || 0),
         bio: fullUser?.bio !== undefined ? fullUser.bio : "新人户外爱好者，期待与你一起探索山野。",
+        wechat: fullUser?.wechat,
         createdAt: fullUser?.createdAt !== undefined ? fullUser.createdAt : createdAtStr,
       };
       setUser(authUser);
@@ -118,6 +120,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             bio: fullUser.bio !== undefined ? fullUser.bio : prev.bio,
             level: (fullUser.level !== undefined ? fullUser.level : prev.level) || "beginner",
             completedHikes: fullUser.completedHikes !== undefined ? fullUser.completedHikes : prev.completedHikes,
+            wechat: fullUser.wechat !== undefined ? fullUser.wechat : prev.wechat,
           };
         });
       }

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -254,6 +254,9 @@ export const copy = {
     levelCurrent: "当前",
     emailLabel: "邮箱",
     emailReadonly: "邮箱暂不支持修改",
+    wechat: "微信号",
+    wechatPlaceholder: "请输入微信号",
+    wechatHint: "方便队友联系你（加入队伍时需要填写）",
     changeAvatar: "点击更换头像",
     avatarHint: "支持 JPEG、PNG、GIF、WebP，最大 5MB",
     avatarSelected: "已选择", // 「已选择：filename」，filename 在组件内拼接
@@ -468,6 +471,7 @@ export const copy = {
     teamTitleTooLong: "标题最多100个字符",
     teamDescTooLong: "描述最多1000个字符",
     teamReqsTooLong: "要求最多500个字符",
+    wechatRequired: "请先在个人资料中填写微信号，以便队友联系您",
   },
 
   // ─── 操作成功消息 ─────────────────────────────────────────────────────────

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -56,6 +56,7 @@ export interface Team {
     level: 'beginner' | 'intermediate' | 'advanced' | 'expert';
     completedHikes: number;
     bio: string;
+    wechat?: string; // 微信号（仅队友可见）
   };
   status: 'open' | 'full' | 'closed';
   createdAt: string;


### PR DESCRIPTION
## Summary

- 数据库：users 表添加 wechat 字段，支持存储用户微信号
- 个人资料：编辑页支持填写微信号，资料页显示微信号（仅自己可见）
- 加入队伍：未填写微信号时禁止加入队伍，引导用户去填写
- 可见性控制：只有自己和同队成员可见微信号
- 领队卡片：队友可查看领队微信号并一键复制

## Test plan

- [ ] 登录后访问个人资料编辑页面，填写微信号并保存
- [ ] 刷新页面确认微信号正确显示
- [ ] 未填写微信号时尝试加入队伍，应提示"请先填写微信号"
- [ ] 作为队员查看队伍详情，应能看到领队微信号
- [ ] 非队友查看用户资料，不应看到微信号

🤖 Generated with [Claude Code](https://claude.com/claude-code)