### PR TITLE
fix: 修复队伍详情页出发时间更新和预计耗时展示问题

### DIFF
--- a/api/src/routes/teams.ts
+++ b/api/src/routes/teams.ts
@@ -564,8 +564,16 @@ teams.put("/:id", async (c) => {
       let newStartTime = originalStartTime;
       if (time) {
         const [hours, minutes] = time.split(":").map(Number);
-        newStartTime = new Date(originalStartTime);
-        newStartTime.setHours(hours, minutes, 0, 0);
+        // time is in Beijing (UTC+8); get the Beijing date of original startTime
+        const BEIJING_OFFSET_MS = 8 * 60 * 60 * 1000;
+        const originalInBeijing = new Date(originalStartTime.getTime() + BEIJING_OFFSET_MS);
+        const beijingMs = Date.UTC(
+          originalInBeijing.getUTCFullYear(),
+          originalInBeijing.getUTCMonth(),
+          originalInBeijing.getUTCDate(),
+          hours, minutes, 0, 0
+        );
+        newStartTime = new Date(beijingMs - BEIJING_OFFSET_MS);
         updateData.startTime = newStartTime;
       }
       updateData.endTime = new Date(newStartTime.getTime() + currentDurationMin * 60000);

--- a/frontend/src/components/features/team-detail/team-detail-sidebar.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-sidebar.tsx
@@ -56,7 +56,7 @@ function TeamTimeInfo({ team }: { team: Team; }) {
       {team.durationMin && team.durationMin > 0 && (
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <Timer className="w-4 h-4" />
-          <span>{t('teams.estimatedPrefix')} {formatDuration(team.durationMin)}</span>
+          <span>{t('teams.estimatedPrefix')} {formatDuration(team.durationMin / 60)}</span>
         </div>
       )}
     </div>


### PR DESCRIPTION
- API PUT /teams/:id：更新时间时，接收到的是北京时间（UTC+8），
  用 setHours 直接设 UTC 导致每次保存+8小时偏移；
  改用 Date.UTC + 北京日期分量 - 8h 偏移正确转换为 UTC 存储
- 前端侧栏：formatDuration(team.durationMin) 将分钟值当小时传入，
  导致 240 分钟显示为 240h；改为 formatDuration(team.durationMin / 60)

https://claude.ai/code/session_017xodMDFhLV3kquHXTLazkb