### PR TITLE
feat: 申请加入队伍时发送邮件通知给队长

### DIFF
--- a/api/src/lib/email-i18n.ts
+++ b/api/src/lib/email-i18n.ts
@@ -9,7 +9,7 @@ import emailEn from "./locales/email.en.json";
 import emailJa from "./locales/email.ja.json";
 
 export type EmailLocale = "zh-CN" | "en" | "ja";
-export type EmailType = "passwordReset" | "welcome" | "contactForm" | "feedback";
+export type EmailType = "passwordReset" | "welcome" | "contactForm" | "feedback" | "teamJoinApplication";
 
 const EMAIL_TEMPLATES: Record<EmailLocale, Record<string, unknown>> = {
   "zh-CN": emailZhCn as unknown as Record<string, unknown>,

--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -130,6 +130,57 @@ export async function sendContactFormEmail(
 }
 
 /**
+ * 发送队伍加入申请通知邮件给队长
+ */
+export async function sendTeamJoinApplicationEmail(
+  data: {
+    leaderEmail: string;
+    leaderName: string;
+    applicantName: string;
+    teamTitle: string;
+    locationName: string;
+    teamUrl: string;
+  },
+  env: { RESEND_API_KEY?: string; RESEND_FROM_EMAIL?: string },
+  locale: EmailLocale = "zh-CN",
+): Promise<{ success: boolean; error?: string }> {
+  const apiKey = env.RESEND_API_KEY;
+  if (!apiKey) return { success: false, error: "Email service not configured" };
+
+  try {
+    const resend = new Resend(apiKey);
+    const fromEmail = env.RESEND_FROM_EMAIL || "GoMate <noreply@gomate.live>";
+    const vars = {
+      leaderName: data.leaderName,
+      applicantName: data.applicantName,
+      teamTitle: data.teamTitle,
+      locationName: data.locationName,
+    };
+
+    await resend.emails.send({
+      from: fromEmail,
+      to: data.leaderEmail,
+      subject: getEmailField(locale, "teamJoinApplication", "subject", vars),
+      html: `
+        <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
+          <h2 style="color: #16a34a;">${getEmailField(locale, "teamJoinApplication", "title")}</h2>
+          <p>${getEmailField(locale, "teamJoinApplication", "greeting", vars)}</p>
+          <p>${getEmailField(locale, "teamJoinApplication", "body", vars)}</p>
+          <p>${getEmailField(locale, "teamJoinApplication", "prompt")}</p>
+          <a href="${data.teamUrl}" style="display:inline-block;padding:12px 24px;background:#16a34a;color:#fff;text-decoration:none;border-radius:6px;margin:16px 0;">${getEmailField(locale, "teamJoinApplication", "viewApplicationBtn")}</a>
+          <p style="color:#6b7280;font-size:14px;">${getEmailField(locale, "teamJoinApplication", "signature")}</p>
+        </div>
+      `,
+    });
+
+    return { success: true };
+  } catch (error) {
+    console.error("[Email] Failed to send team join application email:", error);
+    return { success: false, error: (error as Error).message };
+  }
+}
+
+/**
  * 发送用户反馈邮件（功能建议 / Bug 反馈）
  */
 export async function sendFeedbackEmail(

--- a/api/src/lib/locales/email.en.json
+++ b/api/src/lib/locales/email.en.json
@@ -28,6 +28,15 @@
     "subjectLabel": "Subject:",
     "contentLabel": "Message:"
   },
+  "teamJoinApplication": {
+    "subject": "{applicantName} applied to join your team",
+    "title": "New Team Application",
+    "greeting": "Hello {leaderName},",
+    "body": "{applicantName} has applied to join your team \"{teamTitle}\" ({locationName}).",
+    "prompt": "Please review the application soon — the applicant is waiting for your reply.",
+    "viewApplicationBtn": "View Application",
+    "signature": "The GoMate Team"
+  },
   "feedback": {
     "bugSubject": "[GoMate Bug Report] from {name}",
     "suggestionSubject": "[GoMate Suggestion] from {name}",

--- a/api/src/lib/locales/email.ja.json
+++ b/api/src/lib/locales/email.ja.json
@@ -28,6 +28,15 @@
     "subjectLabel": "件名：",
     "contentLabel": "内容："
   },
+  "teamJoinApplication": {
+    "subject": "{applicantName} がチームへの参加を申請しました",
+    "title": "新しいチーム申請",
+    "greeting": "{leaderName}さん、こんにちは。",
+    "body": "{applicantName} が「{teamTitle}」（{locationName}）への参加を申請しました。",
+    "prompt": "申請者が返信を待っていますので、早めにご対応ください。",
+    "viewApplicationBtn": "申請を確認",
+    "signature": "GoMate チーム"
+  },
   "feedback": {
     "bugSubject": "[GoMate バグ報告] {name}より",
     "suggestionSubject": "[GoMate 提案] {name}より",

--- a/api/src/lib/locales/email.zh-CN.json
+++ b/api/src/lib/locales/email.zh-CN.json
@@ -28,6 +28,15 @@
     "subjectLabel": "主题：",
     "contentLabel": "内容："
   },
+  "teamJoinApplication": {
+    "subject": "{applicantName} 申请加入您的队伍",
+    "title": "新的组队申请",
+    "greeting": "您好 {leaderName}，",
+    "body": "{applicantName} 申请加入您的队伍「{teamTitle}」（{locationName}）。",
+    "prompt": "请及时处理申请，申请人正在等待您的回复。",
+    "viewApplicationBtn": "查看申请",
+    "signature": "GoMate 团队"
+  },
   "feedback": {
     "bugSubject": "[GoMate Bug反馈] 来自 {name}",
     "suggestionSubject": "[GoMate 建议反馈] 来自 {name}",

--- a/api/src/routes/teams.ts
+++ b/api/src/routes/teams.ts
@@ -4,6 +4,7 @@ import { createAuth } from "../lib/auth";
 import { createDb } from "../db";
 import * as schema from "../db/schema";
 import type { Env } from "../lib/auth";
+import { sendTeamJoinApplicationEmail } from "../lib/email";
 
 const teams = new Hono<{ Bindings: Env }>();
 
@@ -637,6 +638,7 @@ teams.post("/:id/join", async (c) => {
         await db.update(schema.teamMembers)
           .set({ status: "pending", createdAt: new Date(), statusUpdatedAt: new Date() })
           .where(eq(schema.teamMembers.id, existing.id));
+        notifyLeaderOfApplication(db, team, userId, c.env).catch(() => {});
         return c.json({ success: true, message: "重新申请已提交" });
       }
     }
@@ -645,6 +647,7 @@ teams.post("/:id/join", async (c) => {
     await db.insert(schema.teamMembers).values({
       id: memberId, teamId, userId, status: "pending", createdAt: new Date(),
     });
+    notifyLeaderOfApplication(db, team, userId, c.env).catch(() => {});
 
     return c.json({ success: true, message: "申请已提交，等待队长审核" });
   } catch (error) {
@@ -1170,5 +1173,36 @@ teams.delete("/:id", async (c) => {
     return c.json({ success: false, error: "删除队伍失败" }, 500);
   }
 });
+
+async function notifyLeaderOfApplication(
+  db: ReturnType<typeof createDb>,
+  team: typeof schema.teams.$inferSelect,
+  applicantUserId: string,
+  env: Env,
+) {
+  const [leaderRow, applicantRow, locationRow] = await Promise.all([
+    db.select({ email: schema.users.email, name: schema.users.name, nickname: schema.users.nickname })
+      .from(schema.users).where(eq(schema.users.id, team.leaderId)).then((r) => r[0]),
+    db.select({ name: schema.users.name, nickname: schema.users.nickname })
+      .from(schema.users).where(eq(schema.users.id, applicantUserId)).then((r) => r[0]),
+    db.select({ name: schema.locations.name })
+      .from(schema.locations).where(eq(schema.locations.id, team.locationId)).then((r) => r[0]),
+  ]);
+
+  if (!leaderRow || !applicantRow || !locationRow) return;
+
+  const frontendUrl = env.FRONTEND_URL || "https://gomate.live";
+  await sendTeamJoinApplicationEmail(
+    {
+      leaderEmail: leaderRow.email,
+      leaderName: leaderRow.nickname || leaderRow.name,
+      applicantName: applicantRow.nickname || applicantRow.name,
+      teamTitle: team.title,
+      locationName: locationRow.name,
+      teamUrl: `${frontendUrl}/teams/${team.id}`,
+    },
+    env,
+  );
+}
 
 export { teams as teamsRoute };


### PR DESCRIPTION
当用户申请加入或重新申请加入队伍时，异步发送邮件通知队长，
邮件包含申请人姓名、队伍名称、地点及查看申请的跳转链接。

https://claude.ai/code/session_01NzdmcCtoXbj2gqy1AdW6CJ