### PR TITLE
feat: 申请加入队伍时邮件通知队长

### DIFF
--- a/api/src/routes/teams.ts
+++ b/api/src/routes/teams.ts
@@ -638,7 +638,11 @@ teams.post("/:id/join", async (c) => {
         await db.update(schema.teamMembers)
           .set({ status: "pending", createdAt: new Date(), statusUpdatedAt: new Date() })
           .where(eq(schema.teamMembers.id, existing.id));
-        notifyLeaderOfApplication(db, team, userId, c.env).catch(() => {});
+        c.executionCtx.waitUntil(
+          notifyLeaderOfApplication(db, team, userId, c.env).catch((err) => {
+            console.error("[Email] Team join notification failed:", err);
+          })
+        );
         return c.json({ success: true, message: "重新申请已提交" });
       }
     }
@@ -647,7 +651,11 @@ teams.post("/:id/join", async (c) => {
     await db.insert(schema.teamMembers).values({
       id: memberId, teamId, userId, status: "pending", createdAt: new Date(),
     });
-    notifyLeaderOfApplication(db, team, userId, c.env).catch(() => {});
+    c.executionCtx.waitUntil(
+      notifyLeaderOfApplication(db, team, userId, c.env).catch((err) => {
+        console.error("[Email] Team join notification failed:", err);
+      })
+    );
 
     return c.json({ success: true, message: "申请已提交，等待队长审核" });
   } catch (error) {


### PR DESCRIPTION
## Summary

- 当用户申请加入队伍（新申请或被拒后重新申请）时，自动发送邮件通知队长
- 邮件包含申请人姓名、队伍名称、所在地点，以及跳转到队伍详情页的按钮
- 支持中/英/日三语邮件模板
- 使用 `c.executionCtx.waitUntil()` 注册后台邮件任务，避免 Cloudflare Workers 响应后提前终止导致邮件丢失

## 改动文件

- `api/src/lib/email.ts` — 新增 `sendTeamJoinApplicationEmail()` 函数
- `api/src/lib/email-i18n.ts` — `EmailType` 新增 `"teamJoinApplication"`
- `api/src/lib/locales/email.zh-CN.json` / `en.json` / `ja.json` — 新增邮件模板
- `api/src/routes/teams.ts` — join 端点调用邮件通知，用 `waitUntil` 注册后台任务

## Test plan

- [ ] 用普通账号申请加入一个招募中的队伍，确认队长邮箱收到通知邮件
- [ ] 被拒后重新申请，确认同样触发邮件通知
- [ ] 邮件内容包含申请人昵称、队伍名称、地点名称及正确的跳转链接

https://claude.ai/code/session_01NzdmcCtoXbj2gqy1AdW6CJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzdmcCtoXbj2gqy1AdW6CJ)_