### PR TITLE
fix(frontend): 同步检查 SSR 缓存消除 i18n 闪烁

### DIFF
--- a/frontend/src/hooks/useI18n.ts
+++ b/frontend/src/hooks/useI18n.ts
@@ -4,6 +4,7 @@
  * - Accepts optional namespace list for auto-loading
  * - Reads locale from cookie on client side
  * - Provides t() function with loaded translations
+ * - 同步检查 SSR 缓存，避免首屏闪烁
  */
 
 import * as React from "react";
@@ -23,6 +24,15 @@ interface UseI18nReturn {
 }
 
 /**
+ * 同步检查所有 namespace 是否已在缓存中
+ * 用于 SSR  hydration 后立即判断 loading 状态
+ */
+function areAllNsCached(nsList: string[] | undefined, locale: Locale): boolean {
+  if (!nsList || nsList.length === 0) return true;
+  return nsList.every((ns) => getNamespaceData(ns, locale) !== null);
+}
+
+/**
  * Hook for Islands components to access i18n
  *
  * @param nsList - Optional list of namespaces to auto-load
@@ -34,10 +44,17 @@ interface UseI18nReturn {
  */
 export function useI18n(nsList?: string[]): UseI18nReturn {
   const [locale, setLocale] = React.useState<Locale>(getLocale());
-  const [loading, setLoading] = React.useState(true);
+  // 同步检查缓存：如果 SSR 数据已注入，直接设置 loading=false
+  const [loading, setLoading] = React.useState(() => !areAllNsCached(nsList, getLocale()));
 
   React.useEffect(() => {
     if (!nsList || nsList.length === 0) {
+      setLoading(false);
+      return;
+    }
+
+    // 如果数据已在缓存中，跳过加载
+    if (areAllNsCached(nsList, locale)) {
       setLoading(false);
       return;
     }


### PR DESCRIPTION
## 修复内容

修复 i18n 刷新页面时先显示 key 后显示翻译的问题。

## 改动点

- `frontend/src/hooks/useI18n.ts`
  - 新增 `areAllNsCached()` 同步检查缓存函数
  - `loading` 初始值改为同步检查 SSR 缓存状态
  - `useEffect` 中增加缓存命中短路逻辑

## 修复原理

1. SSR 渲染时 `Layout.astro` 预加载 namespace → 注入 `window.__I18N_DATA__`
2. 客户端 `hydrate-client.ts` 将数据写入内存缓存
3. React 组件渲染时同步检查缓存 → SSR 数据存在时直接 `loading=false`
4. `t()` 函数同步从缓存读取翻译，无需等待异步加载

## 测试范围

- 各页面刷新无 key 闪烁
- 语言切换正常
- 首屏加载时间不劣化
- Lighthouse LCP 无回归
- 降级行为正常（无 SSR 数据时异步加载）

## 相关 Issue

i18n SSR 预加载优化