### PR TITLE
docs: 移除 mobile 相关说明，添加归档仓库链接

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,13 +12,14 @@ GoMate 是一个极简的「地点组队」平台，专注于深圳徒步场景�
 gomate/
 ├── api/          # 后端 - Hono 4 + Cloudflare Workers + Drizzle ORM
 ├── frontend/     # 前端 - Astro 4 + React 18 + Tailwind CSS 4
-├── mobile/       # 移动端 - Flutter 3.24 + Riverpod 2.6
 ├── packages/
 │   ├── types/    # 共享 TypeScript 类型 (@gomate/types)
 │   └── config/   # 共享 tsconfig 配置 (@gomate/config)
 ├── package.json
 └── pnpm-workspace.yaml
 ```
+
+> 📱 **移动端已归档**：原 Flutter mobile 代码已迁移至 [redisread/gomate-mobile](https://github.com/redisread/gomate-mobile)
 
 ## 技术栈
 
@@ -37,12 +38,6 @@ gomate/
 - **语言**: TypeScript 5（严格模式）
 - **架构**: Astro 薄壳 + React Islands（client:load）
 
-### 移动端（mobile/）
-- **框架**: Flutter 3.24+
-- **状态管理**: Riverpod 2.6
-- **路由**: GoRouter 14
-- **HTTP**: Dio 5.7
-
 ## 开发命令
 
 ```bash
@@ -55,7 +50,6 @@ pnpm dev
 # 单独启动
 pnpm api:dev        # API: localhost:8799
 pnpm web:dev        # Frontend: localhost:5432
-cd mobile && flutter run
 
 # 本地调试检查
 # 启动本地调试前先检查是否已启动：

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ GoMate 地点组队平台 - Monorepo 架构
 gomate/
 ├── api/                  # 后端 API（Hono + Cloudflare Workers）
 ├── frontend/             # Web 前端（Astro 6 + React + Cloudflare Pages）
-├── mobile/               # 移动端（Flutter iOS/Android）
 ├── packages/
 │   ├── types/            # 共享类型定义
 │   └── config/           # 共享配置（tsconfig 等）
@@ -20,13 +19,14 @@ gomate/
 └── pnpm-workspace.yaml   # workspace 包路径定义
 ```
 
+> 📱 **移动端已归档**：原 Flutter mobile 代码已迁移至 [redisread/gomate-mobile](https://github.com/redisread/gomate-mobile)
+
 ## 开发
 
 ### 前置要求
 
 - Node.js >= 20
 - pnpm >= 9
-- Flutter >= 3.24（移动端开发）
 
 ### 安装依赖
 
@@ -38,17 +38,21 @@ pnpm install
 
 后端 API：
 ```bash
+pnpm api:dev
+# 或
 pnpm --filter @gomate/api dev
 ```
 
 Web 前端：
 ```bash
+pnpm web:dev
+# 或
 pnpm --filter @gomate/frontend dev
 ```
 
-移动端：
+或者同时启动：
 ```bash
-cd mobile && flutter run
+pnpm dev
 ```
 
 ## 部署
@@ -65,15 +69,13 @@ cd mobile && flutter run
 - **生产地址**: https://gomate.live
 - **部署命令**: `pnpm web:build && cd frontend && wrangler pages deploy dist --project-name=gomate-frontend --branch=main`
 
-### 移动端
-
-- App Store / Google Play
+> 📱 **移动端已归档**：原 Flutter mobile 代码已迁移至 [redisread/gomate-mobile](https://github.com/redisread/gomate-mobile)
 
 ## 共享包
 
 ### @gomate/types
 
-共享类型定义，供 `api`、`frontend`、`mobile` 各子包共享使用：
+共享类型定义，供 `api`、`frontend` 各子包共享使用：
 
 - 枚举类型：`Difficulty`、`TeamStatus`、`TeamMemberStatus` 等
 - 数据模型：`Location`、`Route`、`Team`、`TeamMember`、`UserPublicProfile` 等
@@ -91,7 +93,6 @@ cd mobile && flutter run
 |--------|----------|------|
 | `api-deploy.yml` | `api/**` 变更推送到 main | 部署后端到 Cloudflare Workers |
 | `frontend-deploy.yml` | `frontend/**` 或 `packages/**` 变更推送到 main | 部署前端到 Cloudflare Pages |
-| `mobile-build.yml` | `mobile/**` 变更推送到 main | 构建 Android APK 和 iOS IPA |
 
 ## 数据库表
 


### PR DESCRIPTION
## 改动

- 移除 README.md 中的 mobile/ 目录说明
- 移除 Flutter 开发要求
- 移除 CLAUDE.md 中的 mobile 架构和 flutter run 命令
- 添加归档仓库链接：https://github.com/redisread/gomate-mobile

## 背景

mobile 端已拆分到独立仓库并归档，原仓库现在仅包含 web 端和后端。

## 验证

- [x] README.md 更新正确
- [x] CLAUDE.md 更新正确
- [x] 无 mobile 残留引用