### PR TITLE
fix(frontend): 修复 i18n SSR 数据未正确注入缓存导致闪烁

### DIFF
--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -72,6 +72,21 @@ function getFromCache(ns: string, locale: Locale): Record<string, unknown> | nul
     return mem.data;
   }
 
+  // 检查 SSR 预注入的内存缓存（Layout.astro 内联脚本设置）
+  if (typeof window !== "undefined") {
+    const ssrMemCache = (window as unknown as Record<string, unknown>).__I18N_MEMORY_CACHE__ as
+      | Map<string, CacheEntry<Record<string, unknown>>>
+      | undefined;
+    if (ssrMemCache) {
+      const ssrEntry = ssrMemCache.get(memKey);
+      if (ssrEntry && ssrEntry.expiresAt > Date.now()) {
+        // 同步到模块内存缓存
+        memoryCache.set(memKey, ssrEntry);
+        return ssrEntry.data;
+      }
+    }
+  }
+
   // 兜底：直接从 SSR 内联数据读取（防止 hydration 未执行或时序问题）
   if (typeof window !== "undefined") {
     const ssrData = (window as unknown as Record<string, unknown>).__I18N_DATA__ as

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -144,9 +144,28 @@ function getHreflangUrl(loc: Locale) {
 
     {/* 客户端 hydration 时优先读取 SSR 内联数据 */}
     <script is:inline>
-      if (window.__I18N_DATA__) {
-        // SSR 数据将在客户端 JS 加载后通过 hydrateSSRData() 处理
-      }
+      (function() {
+        const ssrData = window.__I18N_DATA__;
+        if (!ssrData) return;
+
+        // 内联 hydrateSSRData 逻辑：将 SSR 数据写入内存缓存
+        // 注意：这里模拟 i18n/index.ts 中的内存缓存逻辑
+        if (typeof window !== 'undefined') {
+          window.__I18N_MEMORY_CACHE__ = window.__I18N_MEMORY_CACHE__ || new Map();
+          for (const [locale, nsMap] of Object.entries(ssrData)) {
+            for (const [ns, nsData] of Object.entries(nsMap)) {
+              const memKey = `${locale}:${ns}`;
+              const entry = {
+                data: nsData,
+                expiresAt: Date.now() + 24 * 60 * 60 * 1000 // 24h TTL
+              };
+              window.__I18N_MEMORY_CACHE__.set(memKey, entry);
+            }
+          }
+          // 清理全局变量避免重复处理
+          delete window.__I18N_DATA__;
+        }
+      })();
     </script>
   </head>
   <body class={["min-h-screen", isDark ? "dark bg-[#12100d]" : "bg-[#faf8f5]"].join(" ")}>


### PR DESCRIPTION
## 修复内容

修复 i18n 刷新页面时先显示 key 后显示翻译的问题（PR #57 未完全解决）。

## 根因分析

`i18n/hydrate-client.ts` 从未被导入执行，导致 SSR 预加载的翻译数据未注入内存缓存。组件首次渲染时读不到翻译，直接显示 key。

## 改动点

### 1. `Layout.astro`
- 内联执行 hydrateSSRData 逻辑
- 将 SSR 数据直接写入 `window.__I18N_MEMORY_CACHE__`
- 确保在 React Islands 挂载前完成缓存注入

### 2. `i18n/index.ts`
- `getFromCache` 增加检查 `window.__I18N_MEMORY_CACHE__`
- 确保客户端能读取到 SSR 预注入的数据
- 自动同步到模块内存缓存

## 测试范围

- [ ] 各页面首屏刷新无 key 闪烁
- [ ] 语言切换正常
- [ ] Lighthouse LCP 无回归
- [ ] 降级行为正常（无 SSR 数据时异步加载）

## 相关 Issue

i18n SSR 预加载优化 - 彻底修复版

Fixes #57 后续问题