### PR TITLE
perf(bundle): Phase 1 - 优化首屏 JS 加载

### DIFF
--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -171,6 +171,6 @@ function getHreflangUrl(loc: Locale) {
   <body class={["min-h-screen", isDark ? "dark bg-[#12100d]" : "bg-[#faf8f5]"].join(" ")}>
     {showNavbar && <Navbar client:load />}
     <slot />
-    {showFooter && <Footer client:load />}
+    {showFooter && <Footer client:idle />}
   </body>
 </html>

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -10,5 +10,5 @@ declareI18nNs(Astro.locals, ["home", "locations", "teams", "content"]);
 ---
 
 <Layout title="GoMate - 发现趣处，组队同行">
-  <HomeClient client:load />
+  <HomeClient client:visible />
 </Layout>

--- a/frontend/src/pages/locations/index.astro
+++ b/frontend/src/pages/locations/index.astro
@@ -10,5 +10,5 @@ declareI18nNs(Astro.locals, ["locations", "filter", "content"]);
 ---
 
 <Layout title="探索地点 - GoMate" showNavbar={false} showFooter={false}>
-  <LocationsClient client:load />
+  <LocationsClient client:visible />
 </Layout>


### PR DESCRIPTION
## 优化内容

将非关键组件的 hydrate 策略从 `client:load` 改为 `client:idle`/`client:visible`

### 改动文件

| 文件 | 改动 | 理由 |
|------|------|------|
| `Layout.astro:174` | `client:load` → `client:idle` | Footer 非关键，可延迟 hydrate |
| `index.astro:13` | `client:load` → `client:visible` | Home 首屏 SSR 已渲染，滚动后才需交互 |
| `locations/index.astro:13` | `client:load` → `client:visible` | Locations 列表滚动后才需交互 |

### Astro 指令说明

- `client:idle` - 浏览器空闲时 hydrate
- `client:visible` - 元素进入视口后才 hydrate

### 验证

- ✅ `npm run build` 成功（7.14s）
- ✅ 页面正常渲染

### 预期收益

首屏 JS 减少 ~15%