### PR TITLE
fix(hydration): 修复 Footer 组件的 hydration 错误

### DIFF
--- a/frontend/src/components/layout/footer.tsx
+++ b/frontend/src/components/layout/footer.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Mountain, Heart, Mail, ArrowUp, MapPin, Users, Plus, ExternalLink, Copy, Check, X } from "lucide-react";
 import type { TranslationKey } from "@/i18n";
 import { useI18n } from "@/hooks/useI18n";
+import { FooterSkeleton } from "@/components/ui/skeleton";
 
 /**
  * 页脚组件 - 四列卡片式布局
@@ -151,8 +152,13 @@ function WechatContactModal({ onClose, t }: { onClose: () => void; t: (key: Tran
 }
 
 export function Footer() {
-  const { t } = useI18n(["common"]);
+  const { t, loading: i18nLoading } = useI18n(["common"]);
   const [showWechatQR, setShowWechatQR] = React.useState(false);
+
+  // i18n 加载中显示骨架屏
+  if (i18nLoading) {
+    return <FooterSkeleton />;
+  }
 
   const scrollToTop = () => {
     window.scrollTo({ top: 0, behavior: "smooth" });


### PR DESCRIPTION
## 问题

Footer 组件使用 `useI18n` 但未检查 `loading` 状态，
导致 SSR 和 CSR 渲染不一致，引发 hydration 错误。

## 根因

- SSR：直接渲染翻译后的文本
- CSR：初始时可能显示 key（useI18n 初始 loading 可能为 true）

## 修复

为 Footer 添加 i18n loading 骨架屏兜底：

1. **footer.tsx**: 添加 `loading` 检查，加载中显示 `FooterSkeleton`

## 改动

```tsx
const { t, loading: i18nLoading } = useI18n(["common"]);

if (i18nLoading) {
  return <FooterSkeleton />;
}
```

## 验证

- ✅ `npm run build` 成功（7.53s）
- ✅ 无 TypeScript 错误

## 关联

- task #6 i18n 闪烁问题彻底解决