### PR TITLE
fix(i18n): loading 时返回空字符串，修复 hydration 错误

### DIFF
--- a/frontend/src/components/features/login-client.tsx
+++ b/frontend/src/components/features/login-client.tsx
@@ -282,7 +282,7 @@ export function LoginClient() {
         {/* 底部版权 */}
         <div className="px-6 pb-6 text-center">
           <p className="text-xs" style={{ color: "#c4b5a8" }}>
-            © {new Date().getFullYear()} GoMate · {t("auth.footerTagline")}
+            © 2025 GoMate · {t("auth.footerTagline")}
           </p>
         </div>
       </div>

--- a/frontend/src/components/layout/footer.tsx
+++ b/frontend/src/components/layout/footer.tsx
@@ -154,6 +154,11 @@ function WechatContactModal({ onClose, t }: { onClose: () => void; t: (key: Tran
 export function Footer() {
   const { t, loading: i18nLoading } = useI18n(["common"]);
   const [showWechatQR, setShowWechatQR] = React.useState(false);
+  // SSR 使用固定年份，CSR 更新为当前年份，避免 hydration mismatch
+  const [year, setYear] = React.useState(2025);
+  React.useEffect(() => {
+    setYear(new Date().getFullYear());
+  }, []);
 
   // i18n 加载中显示骨架屏
   if (i18nLoading) {
@@ -391,7 +396,7 @@ export function Footer() {
           className="border-t border-border py-6 flex flex-col sm:flex-row items-center justify-between gap-3"
         >
           <p className="text-xs text-muted-foreground">
-            © {new Date().getFullYear()} {t("common.copyright")}
+            © {year} {t("common.copyright")}
           </p>
           <p className="text-xs flex items-center gap-1.5 text-muted-foreground">
             Made with

--- a/frontend/src/hooks/useI18n.ts
+++ b/frontend/src/hooks/useI18n.ts
@@ -87,9 +87,11 @@ export function useI18n(nsList?: string[]): UseI18nReturn {
 
   const tFn = React.useCallback(
     (key: string, vars?: Record<string, string | number>) => {
+      // loading 时返回空字符串而非 key，避免 SSR/CSR 不一致
+      if (loading) return "";
       return translate(key, { locale, vars });
     },
-    [locale],
+    [locale, loading],
   );
 
   const getNsData = React.useCallback(() => {


### PR DESCRIPTION
全局修复 hydration 错误问题。

## 改动内容
- useI18n.ts: loading 时 t() 返回空字符串而非 key
- login-client.tsx: 修复 new Date() SSR/CSR 不一致
- footer.tsx: 修复 new Date() SSR/CSR 不一致

## 修复原理
- Home/Login 子组件使用 useI18n 但没有 loading 检查
- SSR 渲染时显示 key，CSR 渲染时显示翻译
- 现在 loading 时返回空字符串，避免 SSR/CSR 不一致
- new Date().getFullYear() 导致 SSR/CSR 年份不一致

## 验证
- ✅ 本地构建通过
- ✅ 无 TypeScript 错误