### PR TITLE
fix: 移除 Layout.astro 中不存在的 suppressHydrationWarning 属性

### DIFF
--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -103,7 +103,7 @@ function getHreflangUrl(loc: Locale) {
 ---
 
 <!doctype html>
-<html lang={locale} class={isDark ? "dark" : ""} suppressHydrationWarning>
+<html lang={locale} class={isDark ? "dark" : ""}>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
修复 TypeScript 错误：



该属性是 React 特有的，在 Astro 的 html 标签中不存在。

**改动：**
- 移除 html 标签的 suppressHydrationWarning 属性

**验证：**
- ✅ npm run type-check 通过
- ✅ npm run build 通过