### PR TITLE
fix: remove hardcoded secret fallback

### DIFF
--- a/api/src/lib/auth.ts
+++ b/api/src/lib/auth.ts
@@ -78,6 +78,11 @@ export interface Env {
  * 创建 Better Auth 实例（适用于 Cloudflare Workers 环境）
  */
 export function createAuth(env: Env) {
+  // 强制检查 BETTER_AUTH_SECRET，生产环境必须有值
+  if (!env.BETTER_AUTH_SECRET) {
+    throw new Error("BETTER_AUTH_SECRET is required");
+  }
+
   const db = createDb(env.DB);
 
   return betterAuth({
@@ -138,7 +143,7 @@ export function createAuth(env: Env) {
         extra: { type: "string", required: false },
       },
     },
-    secret: env.BETTER_AUTH_SECRET || "dev-secret-key",
+    secret: env.BETTER_AUTH_SECRET,
     baseURL: env.APP_URL || "http://localhost:8799",
     basePath: "/auth",
     trustedOrigins: [


### PR DESCRIPTION
## Summary

修复 Secrets 管理不规范问题，移除硬编码 secret 回退值。

## Changes

- 在 `createAuth()` 函数开头添加 BETTER_AUTH_SECRET 强制检查
- 如果环境变量缺失，抛出明确错误 "BETTER_AUTH_SECRET is required"
- 移除 `|| "dev-secret-key"` 硬编码回退

## Security Impact

**修复前:** 生产环境若未设置 BETTER_AUTH_SECRET，会使用硬编码的 "dev-secret-key"
**修复后:** 启动时强制检查，缺失则立即报错，阻止服务启动

## Testing

- [x] 本地代码审查通过
- [ ] 需要 @Martin CodeReview
- [ ] 需要 @jiahong-wu 审核

## Related

任务 #2: 修复 Secrets 管理