### PR TITLE
fix: add request timeout handling for external APIs

### DIFF
--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -1,5 +1,6 @@
 import { Resend } from "resend";
 import { getEmailField, EmailLocale } from "./email-i18n";
+import { withTimeout } from "./timeout";
 
 /**
  * 发送密码重置邮件
@@ -23,21 +24,25 @@ export async function sendPasswordResetEmail(
     const nameStr = name ? `，${name}` : "";
     const greeting = getEmailField(locale, "passwordReset", "greeting", { name: nameStr });
 
-    await resend.emails.send({
-      from: fromEmail,
-      to: email,
-      subject: getEmailField(locale, "passwordReset", "subject"),
-      html: `
-        <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
-          <h2>${getEmailField(locale, "passwordReset", "title")}</h2>
-          <p>${greeting}</p>
-          <p>${getEmailField(locale, "passwordReset", "body")}</p>
-          <a href="${resetUrl}" style="display:inline-block;padding:12px 24px;background:#22c55e;color:#fff;text-decoration:none;border-radius:6px;margin:16px 0;">${getEmailField(locale, "passwordReset", "btnText")}</a>
-          <p>${getEmailField(locale, "passwordReset", "expiryNote")}</p>
-          <p>${getEmailField(locale, "passwordReset", "ignoreNote")}</p>
-        </div>
-      `,
-    });
+    await withTimeout(
+      () => resend.emails.send({
+        from: fromEmail,
+        to: email,
+        subject: getEmailField(locale, "passwordReset", "subject"),
+        html: `
+          <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
+            <h2>${getEmailField(locale, "passwordReset", "title")}</h2>
+            <p>${greeting}</p>
+            <p>${getEmailField(locale, "passwordReset", "body")}</p>
+            <a href="${resetUrl}" style="display:inline-block;padding:12px 24px;background:#22c55e;color:#fff;text-decoration:none;border-radius:6px;margin:16px 0;">${getEmailField(locale, "passwordReset", "btnText")}</a>
+            <p>${getEmailField(locale, "passwordReset", "expiryNote")}</p>
+            <p>${getEmailField(locale, "passwordReset", "ignoreNote")}</p>
+          </div>
+        `,
+      }),
+      10000,
+      "Send password reset email timeout"
+    );
 
     return { success: true };
   } catch (error) {
@@ -62,26 +67,30 @@ export async function sendWelcomeEmail(
     const resend = new Resend(apiKey);
     const fromEmail = env.RESEND_FROM_EMAIL || "GoMate <noreply@gomate.live>";
 
-    await resend.emails.send({
-      from: fromEmail,
-      to: email,
-      subject: getEmailField(locale, "welcome", "subject"),
-      html: `
-        <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
-          <h2>${getEmailField(locale, "welcome", "title")}</h2>
-          <p>${getEmailField(locale, "welcome", "greeting", { name })}</p>
-          <p>${getEmailField(locale, "welcome", "body")}</p>
-          <p>${getEmailField(locale, "welcome", "featuresTitle")}</p>
-          <ul>
-            <li>${getEmailField(locale, "welcome", "feature1")}</li>
-            <li>${getEmailField(locale, "welcome", "feature2")}</li>
-            <li>${getEmailField(locale, "welcome", "feature3")}</li>
-          </ul>
-          <p>${getEmailField(locale, "welcome", "closing")}</p>
-          <p>${getEmailField(locale, "welcome", "signature")}</p>
-        </div>
-      `,
-    });
+    await withTimeout(
+      () => resend.emails.send({
+        from: fromEmail,
+        to: email,
+        subject: getEmailField(locale, "welcome", "subject"),
+        html: `
+          <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
+            <h2>${getEmailField(locale, "welcome", "title")}</h2>
+            <p>${getEmailField(locale, "welcome", "greeting", { name })}</p>
+            <p>${getEmailField(locale, "welcome", "body")}</p>
+            <p>${getEmailField(locale, "welcome", "featuresTitle")}</p>
+            <ul>
+              <li>${getEmailField(locale, "welcome", "feature1")}</li>
+              <li>${getEmailField(locale, "welcome", "feature2")}</li>
+              <li>${getEmailField(locale, "welcome", "feature3")}</li>
+            </ul>
+            <p>${getEmailField(locale, "welcome", "closing")}</p>
+            <p>${getEmailField(locale, "welcome", "signature")}</p>
+          </div>
+        `,
+      }),
+      10000,
+      "Send welcome email timeout"
+    );
 
     return { success: true };
   } catch (error) {
@@ -105,22 +114,26 @@ export async function sendContactFormEmail(
     const resend = new Resend(apiKey);
     const fromEmail = env.RESEND_FROM_EMAIL || "GoMate <noreply@gomate.live>";
 
-    await resend.emails.send({
-      from: fromEmail,
-      to: "support@gomate.live",
-      replyTo: data.email,
-      subject: getEmailField(locale, "contactForm", "subject", { subject: data.subject }),
-      html: `
-        <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
-          <h2>${getEmailField(locale, "contactForm", "title")}</h2>
-          <p><strong>${getEmailField(locale, "contactForm", "nameLabel")}</strong>${data.name}</p>
-          <p><strong>${getEmailField(locale, "contactForm", "emailLabel")}</strong>${data.email}</p>
-          <p><strong>${getEmailField(locale, "contactForm", "subjectLabel")}</strong>${data.subject}</p>
-          <p><strong>${getEmailField(locale, "contactForm", "contentLabel")}</strong></p>
-          <p style="white-space: pre-wrap;">${data.message}</p>
-        </div>
-      `,
-    });
+    await withTimeout(
+      () => resend.emails.send({
+        from: fromEmail,
+        to: "support@gomate.live",
+        replyTo: data.email,
+        subject: getEmailField(locale, "contactForm", "subject", { subject: data.subject }),
+        html: `
+          <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
+            <h2>${getEmailField(locale, "contactForm", "title")}</h2>
+            <p><strong>${getEmailField(locale, "contactForm", "nameLabel")}</strong>${data.name}</p>
+            <p><strong>${getEmailField(locale, "contactForm", "emailLabel")}</strong>${data.email}</p>
+            <p><strong>${getEmailField(locale, "contactForm", "subjectLabel")}</strong>${data.subject}</p>
+            <p><strong>${getEmailField(locale, "contactForm", "contentLabel")}</strong></p>
+            <p style="white-space: pre-wrap;">${data.message}</p>
+          </div>
+        `,
+      }),
+      10000,
+      "Send contact form email timeout"
+    );
 
     return { success: true };
   } catch (error) {
@@ -157,21 +170,25 @@ export async function sendTeamJoinApplicationEmail(
       locationName: data.locationName,
     };
 
-    await resend.emails.send({
-      from: fromEmail,
-      to: data.leaderEmail,
-      subject: getEmailField(locale, "teamJoinApplication", "subject", vars),
-      html: `
-        <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
-          <h2 style="color: #16a34a;">${getEmailField(locale, "teamJoinApplication", "title")}</h2>
-          <p>${getEmailField(locale, "teamJoinApplication", "greeting", vars)}</p>
-          <p>${getEmailField(locale, "teamJoinApplication", "body", vars)}</p>
-          <p>${getEmailField(locale, "teamJoinApplication", "prompt")}</p>
-          <a href="${data.teamUrl}" style="display:inline-block;padding:12px 24px;background:#16a34a;color:#fff;text-decoration:none;border-radius:6px;margin:16px 0;">${getEmailField(locale, "teamJoinApplication", "viewApplicationBtn")}</a>
-          <p style="color:#6b7280;font-size:14px;">${getEmailField(locale, "teamJoinApplication", "signature")}</p>
-        </div>
-      `,
-    });
+    await withTimeout(
+      () => resend.emails.send({
+        from: fromEmail,
+        to: data.leaderEmail,
+        subject: getEmailField(locale, "teamJoinApplication", "subject", vars),
+        html: `
+          <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
+            <h2 style="color: #16a34a;">${getEmailField(locale, "teamJoinApplication", "title")}</h2>
+            <p>${getEmailField(locale, "teamJoinApplication", "greeting", vars)}</p>
+            <p>${getEmailField(locale, "teamJoinApplication", "body", vars)}</p>
+            <p>${getEmailField(locale, "teamJoinApplication", "prompt")}</p>
+            <a href="${data.teamUrl}" style="display:inline-block;padding:12px 24px;background:#16a34a;color:#fff;text-decoration:none;border-radius:6px;margin:16px 0;">${getEmailField(locale, "teamJoinApplication", "viewApplicationBtn")}</a>
+            <p style="color:#6b7280;font-size:14px;">${getEmailField(locale, "teamJoinApplication", "signature")}</p>
+          </div>
+        `,
+      }),
+      10000,
+      "Send team join application email timeout"
+    );
 
     return { success: true };
   } catch (error) {
@@ -245,13 +262,17 @@ export async function sendFeedbackEmail(
 
     htmlContent += `</div>`;
 
-    await resend.emails.send({
-      from: fromEmail,
-      to: "support@gomate.live",
-      replyTo: data.email,
-      subject,
-      html: htmlContent,
-    });
+    await withTimeout(
+      () => resend.emails.send({
+        from: fromEmail,
+        to: "support@gomate.live",
+        replyTo: data.email,
+        subject,
+        html: htmlContent,
+      }),
+      10000,
+      "Send feedback email timeout"
+    );
 
     return { success: true };
   } catch (error) {

--- a/api/src/lib/timeout.ts
+++ b/api/src/lib/timeout.ts
@@ -1,0 +1,86 @@
+/**
+ * 请求超时处理工具
+ * 为 fetch 和数据库查询提供超时控制
+ */
+
+/**
+ * 带超时的 fetch 请求
+ * @param url - 请求 URL
+ * @param options - fetch 选项
+ * @param timeoutMs - 超时时间（毫秒），默认 5000ms
+ * @returns Promise<Response>
+ * @throws Error 当请求超时时抛出 "Request timeout"
+ */
+export async function fetchWithTimeout(
+  url: string,
+  options: RequestInit = {},
+  timeoutMs: number = 5000
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      ...options,
+      signal: controller.signal,
+    });
+    return response;
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(`Request timeout after ${timeoutMs}ms: ${url}`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * 带超时的异步函数包装器
+ * @param fn - 异步函数
+ * @param timeoutMs - 超时时间（毫秒）
+ * @param errorMessage - 超时错误信息
+ * @returns Promise<T>
+ * @throws Error 当操作超时时抛出指定错误
+ */
+export async function withTimeout<T>(
+  fn: () => Promise<T>,
+  timeoutMs: number,
+  errorMessage: string = "Operation timeout"
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error(errorMessage));
+    }, timeoutMs);
+
+    fn()
+      .then((result) => {
+        clearTimeout(timeoutId);
+        resolve(result);
+      })
+      .catch((error) => {
+        clearTimeout(timeoutId);
+        reject(error);
+      });
+  });
+}
+
+/**
+ * 数据库查询超时包装器
+ * 用于为 Drizzle ORM 查询添加超时控制
+ * @param query - 数据库查询 Promise
+ * @param timeoutMs - 超时时间（毫秒），默认 10000ms
+ * @param operation - 操作名称（用于错误信息）
+ * @returns Promise<T>
+ */
+export async function withQueryTimeout<T>(
+  query: Promise<T>,
+  timeoutMs: number = 10000,
+  operation: string = "Database query"
+): Promise<T> {
+  return withTimeout(
+    () => query,
+    timeoutMs,
+    `${operation} timeout after ${timeoutMs}ms`
+  );
+}

--- a/api/src/routes/amap.ts
+++ b/api/src/routes/amap.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import type { Env } from "../lib/auth";
+import { fetchWithTimeout } from "../lib/timeout";
 
 export const amapRoute = new Hono<{ Bindings: Env }>();
 
@@ -13,9 +14,14 @@ amapRoute.get("/inputtips", async (c) => {
   if (!keywords.trim()) return c.json({ status: "0", tips: [] });
 
   const url = `https://restapi.amap.com/v3/assistant/inputtips?key=${AMAP_KEY}&keywords=${encodeURIComponent(keywords)}&city=${encodeURIComponent(city)}&datatype=all`;
-  const resp = await fetch(url);
-  const data = await resp.json();
-  return c.json(data);
+  try {
+    const resp = await fetchWithTimeout(url, {}, 8000);
+    const data = await resp.json();
+    return c.json(data);
+  } catch (error) {
+    console.error("[Amap] inputtips timeout:", error);
+    return c.json({ error: "Request timeout", status: "0", tips: [] }, 504);
+  }
 });
 
 /** 正地理编码（地址 → 坐标） */
@@ -27,9 +33,14 @@ amapRoute.get("/geocode", async (c) => {
   if (!address.trim()) return c.json({ status: "0", geocodes: [] });
 
   const url = `https://restapi.amap.com/v3/geocode/geo?key=${AMAP_KEY}&address=${encodeURIComponent(address)}`;
-  const resp = await fetch(url);
-  const data = await resp.json();
-  return c.json(data);
+  try {
+    const resp = await fetchWithTimeout(url, {}, 8000);
+    const data = await resp.json();
+    return c.json(data);
+  } catch (error) {
+    console.error("[Amap] geocode timeout:", error);
+    return c.json({ error: "Request timeout", status: "0", geocodes: [] }, 504);
+  }
 });
 
 /** 逆地理编码（坐标 → 地址） */
@@ -41,7 +52,12 @@ amapRoute.get("/regeo", async (c) => {
   if (!location) return c.json({ status: "0" });
 
   const url = `https://restapi.amap.com/v3/geocode/regeo?key=${AMAP_KEY}&location=${encodeURIComponent(location)}&radius=100&extensions=base`;
-  const resp = await fetch(url);
-  const data = await resp.json();
-  return c.json(data);
+  try {
+    const resp = await fetchWithTimeout(url, {}, 8000);
+    const data = await resp.json();
+    return c.json(data);
+  } catch (error) {
+    console.error("[Amap] regeo timeout:", error);
+    return c.json({ error: "Request timeout", status: "0" }, 504);
+  }
 });


### PR DESCRIPTION
## Summary

为外部 API 请求添加超时处理，防止请求挂起。

## Changes

- 新增 `api/src/lib/timeout.ts` 工具模块：
  - `fetchWithTimeout()` - 带超时的 fetch 请求
  - `withTimeout()` - 通用异步操作超时包装器
  - `withQueryTimeout()` - 数据库查询超时包装器

- 高德地图 API (`amap.ts`)：
  - 所有接口添加 8 秒超时
  - 超时返回 504 状态码

- 邮件发送 (`email.ts`)：
  - 所有邮件操作添加 10 秒超时
  - 包含：密码重置、欢迎邮件、联系表单、队伍申请、反馈邮件

## Timeout 配置

| 服务 | 超时时间 |
|------|----------|
| Amap API | 8s |
| Resend Email | 10s |
| Database | 10s (默认值) |

## Testing

- [x] 本地代码审查通过
- [ ] 需要 @Martin CodeReview
- [ ] 需要 @jiahong-wu 审核

## Related

任务 #3: 添加请求超时处理