### PR TITLE
fix: remove ssr.external Node API configuration

### DIFF
--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -28,9 +28,8 @@ export default defineConfig({
   },
   vite: {
     plugins: [tailwindcss()],
-    ssr: {
-      external: ["node:fs", "node:path"],
-    },
+    // 移除 ssr.external 配置 - Cloudflare Workers 不支持 Node API
+    // 如需文件操作，使用 Web File API
     define: {
       "import.meta.env.PUBLIC_API_URL": JSON.stringify(
         env.PUBLIC_API_URL || "http://localhost:8799"


### PR DESCRIPTION
## Summary

移除前端 SSR external 配置，修复 Cloudflare Workers 兼容性问题。

## Changes

```diff
- ssr: {
-   external: ["node:fs", "node:path"],
- },
+ // 移除 ssr.external 配置 - Cloudflare Workers 不支持 Node API
+ // 如需文件操作，使用 Web File API
```

## 问题

Cloudflare Workers 不支持 Node.js 内置模块（`node:fs`, `node:path`），`external` 配置会导致运行时错误。

## 修复

- 移除 `ssr.external` 配置
- 添加注释说明原因
- 如需文件操作，应使用 Web File API

## Testing

- [x] 本地构建测试通过
- [ ] 需要 @Martin CodeReview
- [ ] 需要 @jiahong-wu 审核

## Related

任务 #6: 修复前端 SSR Node API external 配置