### PR TITLE
fix: TypeScript error in useMessages.ts

### DIFF
--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -19,6 +19,7 @@ bucket_name = "gomate"
 binding = "DB"
 database_name = "gomate-db"
 database_id = "7d17d076-202f-48f8-b343-24209cdb0ba1"
+migrations_dir = "db/migrations"
 
 # KV namespace for session cache
 [[kv_namespaces]]
@@ -68,6 +69,7 @@ bucket_name = "gomate"
 binding = "DB"
 database_name = "gomate-db"
 database_id = "7d17d076-202f-48f8-b343-24209cdb0ba1"
+migrations_dir = "db/migrations"
 
 [[env.production.kv_namespaces]]
 binding = "GOMATE_KV"

--- a/frontend/src/hooks/useMessages.ts
+++ b/frontend/src/hooks/useMessages.ts
@@ -127,7 +127,7 @@ export function useMessages(conversationId: string | undefined): UseMessagesRetu
           // Merge new messages
           const newMessages = data.data || [];
           const existingIds = new Set(messages.map((m) => m.id));
-          const merged = [...newMessages.filter((m) => !existingIds.has(m.id)), ...messages];
+          const merged = [...newMessages.filter((m: Message) => !existingIds.has(m.id)), ...messages];
           // Sort by createdAt
           merged.sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0));
           setMessages(merged);


### PR DESCRIPTION
## 修复内容

修复 frontend/src/hooks/useMessages.ts 中的 TypeScript 类型错误

### 问题
```
src/hooks/useMessages.ts:130:50
error ts(7006): Parameter 'm' implicitly has an 'any' type.
```

### 修复
```typescript
// 从
newMessages.filter((m) => !existingIds.has(m.id))
// 改为  
newMessages.filter((m: Message) => !existingIds.has(m.id))
```

### 验证
- ✅ pnpm type-check 通过
- ✅ pnpm build 通过

## 变更文件
- frontend/src/hooks/useMessages.ts
- api/wrangler.toml (添加 migrations_dir 配置)

---
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>