### PR TITLE
fix(ci): add i18n:build step to fix pipeline failure

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: '20', cache: 'pnpm' }
       - run: pnpm install --frozen-lockfile
+      - name: Generate i18n locales
+        run: pnpm i18n:build
       - name: Type Check
         run: pnpm --filter @gomate/frontend type-check
       - name: i18n Key Validation


### PR DESCRIPTION
修复 CI 流水线失败：在 type-check 前添加 i18n:build 步骤。PR #83 将 locales-data.ts 改为构建时生成，但 CI 未更新导致失败。本地已验证通过。