### PR TITLE
fix: correct login redirect path from /auth/login to /login

### DIFF
--- a/frontend/src/pages/messages/[id].astro
+++ b/frontend/src/pages/messages/[id].astro
@@ -74,7 +74,7 @@ const { id } = Astro.params;
         const sessionData = await sessionRes.json();
 
         if (!sessionData.user) {
-          window.location.href = "/auth/login?redirect=/messages";
+          window.location.href = "/login?redirect=/messages";
           return;
         }
 
@@ -82,7 +82,7 @@ const { id } = Astro.params;
         await loadMessages();
       } catch (err) {
         console.error("Auth check failed:", err);
-        window.location.href = "/auth/login?redirect=/messages";
+        window.location.href = "/login?redirect=/messages";
       }
     }
 
@@ -93,7 +93,7 @@ const { id } = Astro.params;
         });
 
         if (res.status === 401) {
-          window.location.href = "/auth/login?redirect=/messages";
+          window.location.href = "/login?redirect=/messages";
           return;
         }
 

--- a/frontend/src/pages/messages/index.astro
+++ b/frontend/src/pages/messages/index.astro
@@ -53,14 +53,14 @@ declareI18nNs(Astro.locals, ["messages", "common"]);
         const sessionData = await sessionRes.json();
 
         if (!sessionData.user) {
-          window.location.href = "/auth/login?redirect=/messages";
+          window.location.href = "/login?redirect=/messages";
           return;
         }
 
         await loadConversations();
       } catch (err) {
         console.error("Auth check failed:", err);
-        window.location.href = "/auth/login?redirect=/messages";
+        window.location.href = "/login?redirect=/messages";
       }
     }
 
@@ -72,7 +72,7 @@ declareI18nNs(Astro.locals, ["messages", "common"]);
         const data = await res.json();
 
         if (res.status === 401) {
-          window.location.href = "/auth/login?redirect=/messages";
+          window.location.href = "/login?redirect=/messages";
           return;
         }
 


### PR DESCRIPTION
修复消息页面登录重定向 404 问题。

**问题：**
PR #83 后登录页面路径改为 /login，但消息页面仍重定向到 /auth/login 导致 404。

**修复：**
将 /auth/login?redirect=/messages 改为 /login?redirect=/messages

**文件：**
- messages/index.astro
- messages/[id].astro

**验证：**
未登录访问 /messages 应正确跳转到 /login?redirect=/messages