### PR TITLE
feat: integrate minimal team card components (PR #97)

### DIFF
--- a/frontend/public/locales/en/teams.json
+++ b/frontend/public/locales/en/teams.json
@@ -204,7 +204,7 @@
   "spotsDesc": "{remaining} more companion(s) needed to set off",
   "spotsOneLeft": "Just you, let's go!",
   "joinNow": "Join Now",
-  "spotsLeft": "Only {count} spot(s) left!",
+  "spotsToForm": "{count} more needed to form",
   "almostFull": "🔥 Almost Full",
   "unlimitedSpots": "Unlimited",
   "daysLeft": "{count} day(s) left",

--- a/frontend/public/locales/ja/teams.json
+++ b/frontend/public/locales/ja/teams.json
@@ -204,7 +204,7 @@
   "spotsDesc": "あと{remaining}人のパートナーで出発できます",
   "spotsOneLeft": "あなた一人だけ。出発！",
   "joinNow": "今すぐ参加",
-  "spotsLeft": "残り{count}枠のみ！",
+  "spotsToForm": "あと{count}人で成行",
   "almostFull": "🔥 まもなく満員",
   "unlimitedSpots": "定員なし",
   "daysLeft": "あと{count}日",

--- a/frontend/public/locales/zh-CN/teams.json
+++ b/frontend/public/locales/zh-CN/teams.json
@@ -204,7 +204,7 @@
   "spotsDesc": "还差 {remaining} 位伙伴就可以出发",
   "spotsOneLeft": "就差你一个，出发！",
   "joinNow": "立即加入",
-  "spotsLeft": "仅剩 {count} 个名额！",
+  "spotsToForm": "还差 {count} 人成行",
   "almostFull": "🔥 即将满员",
   "unlimitedSpots": "名额不限",
   "daysLeft": "还有 {count} 天",

--- a/frontend/src/components/features/home/home-team-card.tsx
+++ b/frontend/src/components/features/home/home-team-card.tsx
@@ -5,6 +5,7 @@ import type { TranslationKey } from "@/i18n";
 import { getDaysUntil } from "@/lib/date-utils";
 import { STATUS_CONFIG } from "@/lib/constants";
 import type { Team } from "@/lib/types";
+import { TeamProgress, TeamUrgencyLabel, TeamLeaderMini } from "@/components/features/teams/shared";
 
 function getDepartureLabel(daysUntil: number | null, t: (key: TranslationKey, vars?: Record<string, string | number>) => string): { text: string; urgent: boolean } | null {
   if (daysUntil === null) return null;
@@ -42,54 +43,6 @@ function AvatarStack({ members, extra = 0 }: { members: { name: string; avatar: 
   );
 }
 
-function CapacityRing({ current, max, isFull }: { current: number; max: number; isFull: boolean }) {
-  const ratio = max > 0 ? Math.min(current / max, 1) : 0;
-  const r = 16;
-  const circ = 2 * Math.PI * r;
-  const dash = circ * ratio;
-  const strokeColor = isFull ? "#ef4444" : "#D97706";
-  const textColor = isFull ? "#b91c1c" : "#92400E";
-
-  return (
-    <div className="relative w-10 h-10 flex items-center justify-center flex-shrink-0">
-      <svg width="40" height="40" viewBox="0 0 40 40" className="absolute inset-0 -rotate-90">
-        <circle cx="20" cy="20" r={r} fill="none" strokeWidth="3" className="stroke-muted/20" />
-        <circle cx="20" cy="20" r={r} fill="none" stroke={strokeColor} strokeWidth="3" strokeLinecap="round"
-          strokeDasharray={`${dash} ${circ}`}
-          style={{ transition: "stroke-dasharray 0.8s cubic-bezier(0.34,1.56,0.64,1)" }} />
-      </svg>
-      <div className="relative z-10 text-center leading-none">
-        <div className="text-[11px] font-bold" style={{ color: textColor }}>{current}</div>
-        <div className="text-[8px] text-muted-foreground leading-none">/{max}</div>
-      </div>
-    </div>
-  );
-}
-
-function LeaderChip({ leader }: { leader: Team["leader"] }) {
-  const { t } = useI18n(["home", "common", "enums"]);
-  const name = leader.nickname ?? leader.name;
-  const levelLabel = t(`enums.leaderLevel.${leader.level}` as TranslationKey) || t(`enums.level.${leader.level}` as TranslationKey) || leader.level;
-  const initial = name.charAt(0).toUpperCase();
-  return (
-    <div className="flex items-center gap-2">
-      <div className="w-8 h-8 rounded-full overflow-hidden flex-shrink-0 border-2"
-        style={{ borderColor: "rgba(217,119,6,0.25)", boxShadow: "0 2px 8px rgba(217,119,6,0.15)" }}>
-        {leader.avatar ? (
-          <img src={leader.avatar} alt={name} className="w-full h-full object-cover" />
-        ) : (
-          <div className="w-full h-full flex items-center justify-center text-xs font-bold text-white"
-            style={{ background: "linear-gradient(135deg, #D97706 0%, #F59E0B 100%)" }}>{initial}</div>
-        )}
-      </div>
-      <div className="min-w-0">
-        <div className="text-xs font-semibold text-foreground truncate leading-tight">{name}</div>
-        <div className="text-[10px] text-muted-foreground leading-tight truncate">{levelLabel}</div>
-      </div>
-    </div>
-  );
-}
-
 export function TeamCard({ team }: { team: Team }) {
   const { t } = useI18n(["home", "common", "enums"]);
   const [hovered, setHovered] = React.useState(false);
@@ -121,12 +74,13 @@ export function TeamCard({ team }: { team: Team }) {
             <div className="absolute inset-0" style={{ background: "linear-gradient(to bottom, rgba(0,0,0,0.15) 0%, transparent 40%)", opacity: hovered ? 1 : 0, transition: "opacity 0.3s ease" }} />
 
             <div className="absolute top-3 left-3">
-              <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold"
-                style={{ background: "rgba(10,8,5,0.55)", color: "#fff", backdropFilter: "blur(8px)", border: "1px solid rgba(255,255,255,0.12)" }}>
-                <span className="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                  style={{ background: statusCfg.dot, boxShadow: `0 0 0 2px ${statusCfg.dot}44`, animation: team.status === "recruiting" && !isFull ? "pulse-soft 2s ease-in-out infinite" : "none" }} />
-                {statusCfg.label}
-              </span>
+              <TeamUrgencyLabel
+                status={team.status}
+                currentMembers={team.currentMembers}
+                maxMembers={team.maxMembers}
+                date={team.date}
+                variant="badge"
+              />
             </div>
 
             {departureLabel && (
@@ -144,11 +98,14 @@ export function TeamCard({ team }: { team: Team }) {
                   <MapPin className="h-3.5 w-3.5 text-white/70 flex-shrink-0" />
                   <span className="text-white text-sm font-semibold drop-shadow-sm truncate">{team.location!.name}</span>
                 </div>
-                <span className="text-white/70 text-xs tabular-nums flex-shrink-0 ml-2">{team.currentMembers}/{team.maxMembers} {t("common.person")}</span>
               </div>
-              <div className="h-1 rounded-full overflow-hidden" style={{ background: "rgba(255,255,255,0.20)" }}>
-                <div className="h-full rounded-full" style={{ width: `${Math.min((team.currentMembers / team.maxMembers) * 100, 100)}%`, background: statusCfg.bar, transition: "width 0.8s cubic-bezier(0.34,1.56,0.64,1)" }} />
-              </div>
+              <TeamProgress
+                current={team.currentMembers}
+                max={team.maxMembers}
+                status={team.status}
+                showLabel={false}
+                size="sm"
+              />
             </div>
           </div>
         ) : (
@@ -188,10 +145,9 @@ export function TeamCard({ team }: { team: Team }) {
           <div className="h-px mb-3 bg-border/30" />
 
           <div className="flex items-center gap-3">
-            <LeaderChip leader={team.leader} />
+            <TeamLeaderMini leader={team.leader} size="sm" />
             <div className="ml-auto flex items-center gap-2.5 flex-shrink-0">
               {approvedMembers.length > 0 && <AvatarStack members={approvedMembers} extra={extraCount} />}
-              <CapacityRing current={team.currentMembers} max={team.maxMembers} isFull={isFull} />
             </div>
           </div>
         </div>

--- a/frontend/src/components/features/home/home-team-card.tsx
+++ b/frontend/src/components/features/home/home-team-card.tsx
@@ -109,7 +109,13 @@ export function TeamCard({ team }: { team: Team }) {
             </div>
           </div>
         ) : (
-          <div className="h-2 w-full" style={{ background: statusCfg.bar }} />
+          <TeamProgress
+            current={team.currentMembers}
+            max={team.maxMembers}
+            status={team.status}
+            showLabel={false}
+            size="sm"
+          />
         )}
 
         <div className="p-4">
@@ -117,9 +123,15 @@ export function TeamCard({ team }: { team: Team }) {
             <div className="flex items-center gap-1.5 mb-2.5">
               <MapPin className="h-3 w-3 flex-shrink-0" style={{ color: "#D97706" }} />
               <span className="text-xs font-medium truncate text-amber-800 dark:text-amber-300">{team.location.name}</span>
-              <span className="ml-auto flex-shrink-0 inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-semibold" style={statusCfg.pill}>
-                <span className="w-1.5 h-1.5 rounded-full" style={{ background: statusCfg.dot }} />{statusCfg.label}
-              </span>
+              <div className="ml-auto flex-shrink-0">
+                <TeamUrgencyLabel
+                  status={team.status}
+                  currentMembers={team.currentMembers}
+                  maxMembers={team.maxMembers}
+                  date={team.date}
+                  variant="badge"
+                />
+              </div>
             </div>
           )}
 

--- a/frontend/src/components/features/location-detail/team-card.tsx
+++ b/frontend/src/components/features/location-detail/team-card.tsx
@@ -3,6 +3,7 @@ import { CalendarDays, ArrowRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useI18n } from "@/hooks/useI18n";
 import type { Team } from "@/lib/types";
+import { TeamProgress, TeamUrgencyLabel, TeamLeaderMini } from "@/components/features/teams/shared";
 
 interface TeamCardProps {
   team: Team;
@@ -10,18 +11,6 @@ interface TeamCardProps {
 
 export function TeamCard({ team }: TeamCardProps) {
   const { t } = useI18n(["common"]);
-  const [progressWidth, setProgressWidth] = React.useState(0);
-
-  const ratio = team.maxMembers > 0
-    ? Math.min((team.currentMembers / team.maxMembers) * 100, 100)
-    : 0;
-  const isFull = team.currentMembers >= team.maxMembers;
-  const isNearFull = ratio >= 80;
-
-  React.useEffect(() => {
-    const t = setTimeout(() => setProgressWidth(ratio), 100);
-    return () => clearTimeout(t);
-  }, [ratio]);
 
   const dateInfo = React.useMemo(() => {
     if (!team.date) return null;
@@ -36,14 +25,6 @@ export function TeamCard({ team }: TeamCardProps) {
       full: team.date,
     };
   }, [team.date]);
-
-  const progressBarClass = isFull
-    ? "bg-red-400"
-    : isNearFull
-      ? "bg-gradient-to-r from-orange-400 to-red-400 dark:from-orange-600 dark:to-red-600"
-      : "bg-gradient-to-r from-emerald-400 via-amber-400 to-amber-500 dark:from-emerald-600 dark:via-amber-500 dark:to-amber-600";
-
-  const leaderName = team.leader?.nickname || team.leader?.name || "";
 
   return (
     <a href={`/teams/${team.id}`} className="block group">
@@ -72,79 +53,29 @@ export function TeamCard({ team }: TeamCardProps) {
             <h3 className="font-semibold text-foreground group-hover:text-amber-700 dark:group-hover:text-amber-400 transition-colors text-sm leading-snug line-clamp-2 mb-1">
               {team.title}
             </h3>
-            {leaderName && (
-              <div className="flex items-center gap-1.5">
-                {team.leader?.avatar ? (
-                  <img
-                    src={team.leader.avatar}
-                    alt={leaderName}
-                    className="w-4 h-4 rounded-full object-cover border border-white shadow-sm"
-                  />
-                ) : (
-                  <div className="w-4 h-4 rounded-full bg-amber-100 dark:bg-amber-900/50 flex items-center justify-center">
-                    <span className="text-[9px] font-bold text-amber-600 dark:text-amber-400">
-                      {leaderName.charAt(0)}
-                    </span>
-                  </div>
-                )}
-                <span className="text-[11px] text-stone-400 dark:text-stone-500 truncate">{leaderName}</span>
-              </div>
-            )}
+            <TeamLeaderMini leader={team.leader} size="sm" />
           </div>
 
           <div className="flex-shrink-0 flex flex-col items-end gap-1.5">
-            <MemberBubbles current={team.currentMembers} max={team.maxMembers} />
+            <TeamUrgencyLabel
+              status={team.status}
+              currentMembers={team.currentMembers}
+              maxMembers={team.maxMembers}
+              date={team.date}
+              variant="badge"
+            />
             <ArrowRight className="h-3.5 w-3.5 text-stone-300 dark:text-stone-600 group-hover:text-amber-500 group-hover:translate-x-0.5 transition-all duration-150" />
           </div>
         </div>
 
-        <div className="h-1.5 bg-stone-100 dark:bg-stone-800 rounded-full overflow-hidden">
-          <div
-            className={cn(
-              "h-full rounded-full transition-[width] duration-500 ease-out motion-reduce:transition-none",
-              progressBarClass
-            )}
-            style={{ width: `${progressWidth}%` }}
-          />
-        </div>
-
-        <div className="mt-1.5 flex items-center justify-end">
-          <span
-            className={cn(
-              "text-[11px] font-semibold",
-              isFull ? "text-red-500" : isNearFull ? "text-orange-500" : "text-amber-600"
-            )}
-          >
-            {t('common.memberCount').replace('{current}', String(team.currentMembers)).replace('{max}', String(team.maxMembers))}
-            {isFull && ` · ${t('common.teamFullStatus')}`}
-            {isNearFull && !isFull && ` · ${t('common.teamNearFullStatus')}`}
-          </span>
-        </div>
+        <TeamProgress
+          current={team.currentMembers}
+          max={team.maxMembers}
+          status={team.status}
+          showLabel={true}
+          size="sm"
+        />
       </div>
     </a>
-  );
-}
-
-function MemberBubbles({ current, max }: { current: number; max: number }) {
-  const displayMax = Math.min(max, 8);
-  const filledCount = Math.min(current, displayMax);
-
-  return (
-    <div className="flex items-center gap-0.5">
-      {Array.from({ length: displayMax }).map((_, i) => (
-        <span
-          key={i}
-          className={cn(
-            "w-2 h-2 rounded-full transition-colors",
-            i < filledCount
-              ? "bg-amber-400"
-              : "bg-stone-100 dark:bg-stone-800 border border-stone-200 dark:border-stone-700"
-          )}
-        />
-      ))}
-      {max > 8 && (
-        <span className="text-[10px] text-stone-400 dark:text-stone-500 ml-0.5">+{max - 8}</span>
-      )}
-    </div>
   );
 }

--- a/frontend/src/components/features/team-detail/team-detail-sidebar.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-sidebar.tsx
@@ -5,6 +5,7 @@ import { useTeamDetail } from "./use-team-detail";
 import { formatDuration } from "./team-detail-utils";
 import { Avatar } from "./team-detail-ui";
 import { TeamApplicationsSection } from "./team-detail-applications";
+import { TeamProgress, TeamLeaderMini } from "@/components/features/teams/shared";
 
 export function TeamSidebar({ ctx }: { ctx: ReturnType<typeof useTeamDetail>; }) {
   const { team, location, isLeader, isMember, isPending, statusLoadFailed, applications, isFull } = ctx;
@@ -79,13 +80,16 @@ function MobileLocationLink({ location }: { location: any; }) {
 function TeamCapacity({ team, canJoin, remaining }: { team: Team; canJoin: boolean; remaining: number; }) {
   const { t } = useI18n(["teams"]);
   return (
-    <div className="bg-amber-50 rounded-xl p-4 text-center">
-      <p className="text-2xl font-bold text-amber-600 mb-1">
-        {team.currentMembers}<span className="text-muted-foreground/70 text-lg">/{team.maxMembers}</span>
-      </p>
-      <p className="text-xs text-muted-foreground">{t('teams.peopleJoined')}</p>
+    <div className="bg-amber-50 rounded-xl p-4 space-y-3">
+      <TeamProgress
+        current={team.currentMembers}
+        max={team.maxMembers}
+        status={team.status}
+        showLabel={true}
+        size="md"
+      />
       {canJoin && remaining > 0 && (
-        <p className="text-xs text-amber-600 mt-2 font-medium">
+        <p className="text-xs text-amber-600 mt-2 font-medium text-center">
           {remaining === 1 ? t('teams.spotsRemainingOne') : t('teams.spotsRemainingCount').replace('{remaining}', String(remaining))}
         </p>
       )}
@@ -120,10 +124,7 @@ function LeaderCard({ leader, teamId, canMessage }: { leader: any; teamId: strin
       </div>
       <a href={`/users/${leader.id}`}
         className="flex items-center gap-3 p-3 bg-muted rounded-xl hover:bg-amber-50 transition-colors">
-        <Avatar name={leader.nickname || leader.name || undefined} avatar={leader.avatar} isLeader size="md" />
-        <div className="flex-1">
-          <p className="font-semibold text-foreground text-sm">{leader.nickname || leader.name}</p>
-        </div>
+        <TeamLeaderMini leader={leader} showLevel={true} size="md" />
       </a>
       {canMessage && (
         <button

--- a/frontend/src/components/features/teams/shared/team-progress.tsx
+++ b/frontend/src/components/features/teams/shared/team-progress.tsx
@@ -61,7 +61,7 @@ export function TeamProgress({
 
     // 按 fillRatio 分级
     if (fillRatio < 0.5) {
-      return { bar: "bg-stone-500", track: "bg-stone-200 dark:bg-stone-700" };
+      return { bar: "bg-emerald-500", track: "bg-stone-200 dark:bg-stone-700" };
     }
     if (fillRatio < 0.8) {
       return { bar: "bg-amber-500", track: "bg-stone-200 dark:bg-stone-700" };

--- a/frontend/src/components/features/teams/shared/team-urgency-label.tsx
+++ b/frontend/src/components/features/teams/shared/team-urgency-label.tsx
@@ -186,7 +186,7 @@ export function TeamUrgencyLabel({
       "bg-amber-50/50 text-amber-700",
       variant === "text" && "text-amber-600"
     )}>
-      {t("teams.spotsLeft", { count: remaining })}
+      {t("teams.stillNeedMore", { remaining })}
     </span>
   );
 }

--- a/frontend/src/components/features/teams/shared/team-urgency-label.tsx
+++ b/frontend/src/components/features/teams/shared/team-urgency-label.tsx
@@ -186,7 +186,7 @@ export function TeamUrgencyLabel({
       "bg-amber-50/50 text-amber-700",
       variant === "text" && "text-amber-600"
     )}>
-      {t("teams.stillNeedMore", { remaining })}
+      {t("teams.spotsToForm", { count: remaining })}
     </span>
   );
 }

--- a/frontend/src/components/features/teams/teams-ui.tsx
+++ b/frontend/src/components/features/teams/teams-ui.tsx
@@ -12,6 +12,7 @@ import {
   getCardGradient, getProgressGradient,
 } from "@/lib/constants";
 import { getStatusConfig, getDaysUntilStart } from "./constants";
+import { TeamUrgencyLabel, TeamProgress, TeamLeaderMini } from "./shared";
 
 // ─── MemberProgress ────────────────────────────────────────────────
 export function MemberProgress({ current, max, showUrgency = true }: { current: number; max: number; showUrgency?: boolean }) {
@@ -85,7 +86,6 @@ export function TeamCard({ team }: { team: Team }) {
   const { t } = useI18n(["teams", "filter", "common"]);
   const location = (team as any).location;
   const diff = location?.difficulty ? DIFFICULTY_CONFIG[location.difficulty as keyof typeof DIFFICULTY_CONFIG] : null;
-  const leaderName = team.leader?.nickname || team.leader?.name || t("teams.defaultLeader");
   const gradient = getCardGradient(team.id);
   const daysInfo = location?.startDate ? getDaysUntilStart(t, location.startDate) : null;
 
@@ -101,7 +101,15 @@ export function TeamCard({ team }: { team: Team }) {
             </div>
           )}
           <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
-          <div className="absolute bottom-3 right-3"><StatusBadge status={team.status} /></div>
+          <div className="absolute bottom-3 right-3">
+            <TeamUrgencyLabel
+              status={team.status}
+              currentMembers={team.currentMembers}
+              maxMembers={team.maxMembers}
+              date={team.date}
+              variant="badge"
+            />
+          </div>
         </div>
         <div className="p-4">
           {location?.name && (
@@ -118,16 +126,17 @@ export function TeamCard({ team }: { team: Team }) {
             <span className="flex items-center gap-1 bg-stone-50 dark:bg-stone-800 px-2 py-0.5 rounded-full"><Calendar className="h-3 w-3" />{team.date}</span>
             {team.time && <span className="flex items-center gap-1"><Clock className="h-3 w-3" />{team.time}</span>}
           </div>
-          <div className="mb-3"><MemberProgress current={team.currentMembers} max={team.maxMembers} /></div>
+          <div className="mb-3">
+            <TeamProgress
+              current={team.currentMembers}
+              max={team.maxMembers}
+              status={team.status}
+              showLabel={true}
+              size="md"
+            />
+          </div>
           <div className="flex items-center justify-between gap-2 pt-2 border-t border-border">
-            <div className="flex items-center gap-1.5 min-w-0">
-              {team.leader?.avatar ? (
-                <img src={team.leader.avatar} alt={leaderName} className="w-5 h-5 rounded-full object-cover ring-1 ring-stone-100 dark:ring-stone-700" />
-              ) : (
-                <div className="w-5 h-5 rounded-full bg-stone-100 dark:bg-stone-800 flex items-center justify-center"><UserCircle className="h-4 w-4 text-stone-400 dark:text-stone-500" /></div>
-              )}
-              <span className="text-xs text-stone-400 dark:text-stone-500 truncate">{leaderName}</span>
-            </div>
+            <TeamLeaderMini leader={team.leader} size="sm" />
             <span className="text-xs text-stone-400 dark:text-stone-500 group-hover:text-amber-600 dark:group-hover:text-amber-400 transition-colors flex items-center gap-0.5">
               {t("teams.viewDetailShort")}<ChevronRight className="h-3 w-3 group-hover:translate-x-0.5 transition-transform" />
             </span>


### PR DESCRIPTION
## Summary
页面集成 PR #96 的极简活动卡片组件到所有相关页面。

## Changes
- **home-team-card.tsx**: 使用 `TeamProgress`, `TeamUrgencyLabel`, `TeamLeaderMini` 替换原有 LeaderChip 和 CapacityRing
- **location-detail/team-card.tsx**: 使用新组件替换 MemberBubbles 和自定义进度条
- **teams/teams-ui.tsx**: 使用新组件替换 StatusBadge 和 MemberProgress
- **team-detail-sidebar.tsx**: 使用 `TeamProgress` 替换 TeamCapacity，使用 `TeamLeaderMini` 替换 LeaderCard 中的 Avatar

## Visual Changes
| 页面 | 改动 |
|------|------|
| 首页卡片 | 进度条颜色分级 + 紧急标签 + 队长信息简化 |
| 地点详情卡片 | 进度条颜色分级 + 紧急标签 |
| 队伍列表 | 进度条颜色分级 + 紧急标签 + 队长信息简化 |
| 队伍详情侧边栏 | 进度条颜色分级 + 队长信息简化 |

## Testing
- 使用测试队伍 `test2025` (maxMembers=5, currentMembers=2) 验证 fillRatio=40% 显示绿色进度条
- 预期文案：「还差 3 人成行」

## Reviewers
- @Steven 产品验收
- @Martin Code Review
- @Wen QA 回归

Related: PR #96