### PR TITLE
feat(#95): 北京时间日期筛选 + 快捷按钮高亮

### DIFF
--- a/api/src/lib/date.ts
+++ b/api/src/lib/date.ts
@@ -1,0 +1,176 @@
+/**
+ * 北京时间日期工具
+ * 处理 UTC ↔ 北京时间 (UTC+8) 转换，支持快捷筛选选项
+ */
+
+export interface DateRange {
+  start: Date;   // UTC 时间，用于数据库查询
+  end: Date;     // UTC 时间，用于数据库查询
+  label: string; // 显示文案
+}
+
+export type QuickType = 'today' | 'tomorrow' | 'weekend' | 'next7' | 'next30' | 'custom';
+
+const BEIJING_OFFSET_HOURS = 8;
+const MS_PER_HOUR = 60 * 60 * 1000;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+
+/**
+ * UTC 转北京时间（用于显示）
+ */
+export function toBeijingTime(utcDate: Date): Date {
+  return new Date(utcDate.getTime() + BEIJING_OFFSET_HOURS * MS_PER_HOUR);
+}
+
+/**
+ * 北京时间转 UTC（用于查询）
+ */
+export function fromBeijingTime(beijingDate: Date): Date {
+  return new Date(beijingDate.getTime() - BEIJING_OFFSET_HOURS * MS_PER_HOUR);
+}
+
+/**
+ * 获取指定北京时间当天的起始和结束（UTC）
+ */
+function getBeijingDayRange(beijingDate: Date): { start: Date; end: Date } {
+  const year = beijingDate.getUTCFullYear();
+  const month = beijingDate.getUTCMonth();
+  const date = beijingDate.getUTCDate();
+
+  // 北京时间当天 00:00:00
+  const beijingStart = new Date(Date.UTC(year, month, date, 0, 0, 0));
+  // 北京时间当天 23:59:59.999
+  const beijingEnd = new Date(Date.UTC(year, month, date, 23, 59, 59, 999));
+
+  return {
+    start: fromBeijingTime(beijingStart),
+    end: fromBeijingTime(beijingEnd),
+  };
+}
+
+/**
+ * 获取北京时间的今天范围（UTC）
+ */
+export function getTodayRange(now: Date = new Date()): DateRange {
+  const beijingNow = toBeijingTime(now);
+  const range = getBeijingDayRange(beijingNow);
+
+  return {
+    ...range,
+    label: '今天',
+  };
+}
+
+/**
+ * 获取北京时间的明天范围（UTC）
+ */
+export function getTomorrowRange(now: Date = new Date()): DateRange {
+  const beijingNow = toBeijingTime(now);
+  const beijingTomorrow = new Date(beijingNow.getTime() + MS_PER_DAY);
+  const range = getBeijingDayRange(beijingTomorrow);
+
+  return {
+    ...range,
+    label: '明天',
+  };
+}
+
+/**
+ * 获取北京时间的本周末范围（UTC）
+ * 周末定义为周六 00:00 - 周日 23:59:59
+ */
+export function getThisWeekendRange(now: Date = new Date()): DateRange {
+  const beijingNow = toBeijingTime(now);
+  const dayOfWeek = beijingNow.getUTCDay(); // 0=周日, 1=周一, ..., 6=周六
+
+  // 计算到周六的天数差
+  const daysToSaturday = dayOfWeek === 0 ? -1 : 6 - dayOfWeek;
+
+  // 本周六北京时间 00:00
+  const beijingSaturday = new Date(beijingNow.getTime() + daysToSaturday * MS_PER_DAY);
+  const saturdayStart = new Date(Date.UTC(
+    beijingSaturday.getUTCFullYear(),
+    beijingSaturday.getUTCMonth(),
+    beijingSaturday.getUTCDate(),
+    0, 0, 0
+  ));
+
+  // 本周日北京时间 23:59:59.999
+  const beijingSunday = new Date(saturdayStart.getTime() + MS_PER_DAY);
+  const sundayEnd = new Date(Date.UTC(
+    beijingSunday.getUTCFullYear(),
+    beijingSunday.getUTCMonth(),
+    beijingSunday.getUTCDate(),
+    23, 59, 59, 999
+  ));
+
+  return {
+    start: fromBeijingTime(saturdayStart),
+    end: fromBeijingTime(sundayEnd),
+    label: '本周末',
+  };
+}
+
+/**
+ * 获取未来7天范围（UTC）
+ * 从今天开始，包含今天，共7天
+ */
+export function getNext7DaysRange(now: Date = new Date()): DateRange {
+  const today = getTodayRange(now);
+  const beijingEnd = new Date(toBeijingTime(today.start).getTime() + 6 * MS_PER_DAY);
+  const endRange = getBeijingDayRange(beijingEnd);
+
+  return {
+    start: today.start,
+    end: endRange.end,
+    label: '未来7天',
+  };
+}
+
+/**
+ * 获取未来30天范围（UTC）
+ * 从今天开始，包含今天，共30天
+ */
+export function getNext30DaysRange(now: Date = new Date()): DateRange {
+  const today = getTodayRange(now);
+  const beijingEnd = new Date(toBeijingTime(today.start).getTime() + 29 * MS_PER_DAY);
+  const endRange = getBeijingDayRange(beijingEnd);
+
+  return {
+    start: today.start,
+    end: endRange.end,
+    label: '未来30天',
+  };
+}
+
+/**
+ * 判断某 UTC 时间是否在北京时间的周末
+ */
+export function isInBeijingWeekend(utcDate: Date): boolean {
+  const beijingDate = toBeijingTime(utcDate);
+  const dayOfWeek = beijingDate.getUTCDay(); // 0=周日, 6=周六
+  return dayOfWeek === 0 || dayOfWeek === 6;
+}
+
+/**
+ * 根据日期范围反推高亮哪个快捷按钮
+ * 返回匹配的 quickType，如果没有完全匹配的返回 'custom'
+ */
+export function getActiveQuickType(start: Date, end: Date, now: Date = new Date()): QuickType {
+  const today = getTodayRange(now);
+  const tomorrow = getTomorrowRange(now);
+  const weekend = getThisWeekendRange(now);
+  const next7 = getNext7DaysRange(now);
+  const next30 = getNext30DaysRange(now);
+
+  // 使用毫秒时间戳比较，避免浮点误差
+  const isMatch = (a: Date, b: Date) => Math.abs(a.getTime() - b.getTime()) < 1000;
+
+  if (isMatch(start, today.start) && isMatch(end, today.end)) return 'today';
+  if (isMatch(start, tomorrow.start) && isMatch(end, tomorrow.end)) return 'tomorrow';
+  if (isMatch(start, weekend.start) && isMatch(end, weekend.end)) return 'weekend';
+  if (isMatch(start, next7.start) && isMatch(end, next7.end)) return 'next7';
+  if (isMatch(start, next30.start) && isMatch(end, next30.end)) return 'next30';
+
+  return 'custom';
+}

--- a/frontend/src/components/features/teams/teams-main.tsx
+++ b/frontend/src/components/features/teams/teams-main.tsx
@@ -32,6 +32,7 @@ export function TeamsClient() {
             availableTags={ctx.availableTags}
             selectedTags={ctx.selectedTags}
             activeFiltersCount={ctx.activeFiltersCount}
+            activeDateQuickType={ctx.activeDateQuickType}
             onDateQuickSelect={ctx.handleDateQuickSelect}
             onDifficultyToggle={ctx.handleDifficultyToggle}
             onTagToggle={ctx.handleTagToggle}

--- a/frontend/src/components/features/teams/teams-ui.tsx
+++ b/frontend/src/components/features/teams/teams-ui.tsx
@@ -209,6 +209,7 @@ interface FilterPanelProps {
   availableTags: { id: string; name: string }[];
   selectedTags: string[];
   activeFiltersCount: number;
+  activeDateQuickType: string | null;
   onDateQuickSelect: (type: string) => void;
   onDifficultyToggle: (id: string) => void;
   onTagToggle: (tagId: string) => void;
@@ -216,7 +217,7 @@ interface FilterPanelProps {
 }
 
 export function FilterPanel({
-  startDate, endDate, selectedDifficulty, availableTags, selectedTags, activeFiltersCount,
+  startDate, endDate, selectedDifficulty, availableTags, selectedTags, activeFiltersCount, activeDateQuickType,
   onDateQuickSelect, onDifficultyToggle, onTagToggle, onClearAll,
 }: FilterPanelProps) {
   const { t } = useI18n(["teams", "filter", "common"]);
@@ -230,12 +231,20 @@ export function FilterPanel({
             { key: "tomorrow", label: t("filter.dateQuickTomorrow") },
             { key: "weekend", label: t("filter.dateQuickWeekend") },
             { key: "7days", label: t("filter.dateQuick7Days") },
-          ].map((opt) => (
-            <button key={opt.key} onClick={() => onDateQuickSelect(opt.key)}
-              className="px-3 py-1.5 text-xs rounded-full border border-border bg-card text-stone-600 dark:text-stone-400 hover:border-amber-300 dark:hover:border-amber-700 hover:text-amber-700 dark:hover:text-amber-400 transition-colors">
-              {opt.label}
-            </button>
-          ))}
+          ].map((opt) => {
+            const isSelected = activeDateQuickType === opt.key;
+            return (
+              <button key={opt.key} onClick={() => onDateQuickSelect(opt.key)}
+                className={cn(
+                  "px-3 py-1.5 text-xs rounded-full border transition-all duration-200",
+                  isSelected
+                    ? "bg-amber-100 dark:bg-amber-900/30 border-amber-400 dark:border-amber-700 text-amber-800 dark:text-amber-300"
+                    : "border-border bg-card text-stone-600 dark:text-stone-400 hover:border-amber-300 dark:hover:border-amber-700 hover:text-amber-700 dark:hover:text-amber-400"
+                )}>
+                {opt.label}
+              </button>
+            );
+          })}
           {(startDate || endDate) && (
             <button onClick={() => onDateQuickSelect("clear")}
               className="px-3 py-1.5 text-xs rounded-full border border-border text-stone-400 dark:text-stone-500 hover:text-stone-600 dark:hover:text-stone-300 transition-colors">

--- a/frontend/src/components/features/teams/use-teams.ts
+++ b/frontend/src/components/features/teams/use-teams.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 import type { Team } from "@/lib/types";
 import { fetchAPI } from "@/lib/api";
+import {
+  getDateRangeByQuickType,
+  getActiveDateQuickType,
+} from "@/lib/date-beijing";
 
 export function useTeams() {
   const [teams, setTeams] = React.useState<Team[]>([]);
@@ -105,50 +109,15 @@ export function useTeams() {
   }, [selectedTags]);
 
   const handleDateQuickSelect = React.useCallback((type: string) => {
-    const today = new Date();
-    const formatDate = (d: Date) => d.toISOString().split("T")[0];
-
-    switch (type) {
-      case "today":
-        setStartDate(formatDate(today));
-        setEndDate(formatDate(today));
-        break;
-      case "tomorrow": {
-        const tomorrow = new Date(today);
-        tomorrow.setDate(tomorrow.getDate() + 1);
-        setStartDate(formatDate(tomorrow));
-        setEndDate(formatDate(tomorrow));
-        break;
+    if (type === "clear") {
+      setStartDate("");
+      setEndDate("");
+    } else {
+      const range = getDateRangeByQuickType(type);
+      if (range) {
+        setStartDate(range.start);
+        setEndDate(range.end);
       }
-      case "weekend": {
-        const day = today.getDay();
-        const daysUntilSaturday = day === 0 ? 6 : 6 - day;
-        const saturday = new Date(today);
-        saturday.setDate(today.getDate() + daysUntilSaturday);
-        const sunday = new Date(saturday);
-        sunday.setDate(saturday.getDate() + 1);
-        setStartDate(formatDate(saturday));
-        setEndDate(formatDate(sunday));
-        break;
-      }
-      case "7days": {
-        const next7Days = new Date(today);
-        next7Days.setDate(today.getDate() + 7);
-        setStartDate(formatDate(today));
-        setEndDate(formatDate(next7Days));
-        break;
-      }
-      case "30days": {
-        const next30Days = new Date(today);
-        next30Days.setDate(today.getDate() + 30);
-        setStartDate(formatDate(today));
-        setEndDate(formatDate(next30Days));
-        break;
-      }
-      case "clear":
-        setStartDate("");
-        setEndDate("");
-        break;
     }
     setCurrentPage(1);
   }, []);
@@ -169,7 +138,12 @@ export function useTeams() {
     setShowFilters(false);
   }, []);
 
-  const activeFiltersCount = selectedDifficulty.length + (startDate ? 1 : 0) + (endDate ? 1 : 0) + selectedTags.length;
+  const activeFiltersCount = selectedDifficulty.length + (startDate && endDate ? 1 : 0) + selectedTags.length;
+
+  const activeDateQuickType = React.useMemo(
+    () => getActiveDateQuickType(startDate, endDate),
+    [startDate, endDate]
+  );
 
   return {
     teams,
@@ -184,6 +158,7 @@ export function useTeams() {
     availableTags,
     selectedTags,
     activeFiltersCount,
+    activeDateQuickType,
     setSearchQuery,
     setShowFilters,
     setStartDate,

--- a/frontend/src/lib/date-beijing.ts
+++ b/frontend/src/lib/date-beijing.ts
@@ -1,0 +1,155 @@
+/**
+ * Beijing Time (UTC+8) Date Utilities
+ * For filtering teams by "today", "tomorrow", "weekend" in Beijing time
+ */
+
+const BEIJING_OFFSET_MS = 8 * 60 * 60 * 1000;
+
+export interface DateRange {
+  start: string; // ISO date string (YYYY-MM-DD) for API query
+  end: string;   // ISO date string (YYYY-MM-DD) for API query
+  quickType: string | null; // 'today' | 'tomorrow' | 'weekend' | '7days' | '30days' | null
+}
+
+/** Convert UTC Date to Beijing Date */
+export function toBeijingDate(utcDate: Date): Date {
+  return new Date(utcDate.getTime() + BEIJING_OFFSET_MS);
+}
+
+/** Convert Beijing Date to UTC Date */
+export function fromBeijingDate(beijingDate: Date): Date {
+  return new Date(beijingDate.getTime() - BEIJING_OFFSET_MS);
+}
+
+/** Get current time in Beijing */
+export function getBeijingNow(): Date {
+  return toBeijingDate(new Date());
+}
+
+/** Format date to YYYY-MM-DD */
+export function formatDateISO(date: Date): string {
+  return date.toISOString().split("T")[0];
+}
+
+/** Get Beijing today's date range (for API query) */
+export function getBeijingTodayRange(): { start: string; end: string } {
+  const beijingNow = getBeijingNow();
+  const dateStr = formatDateISO(fromBeijingDate(beijingNow));
+  return { start: dateStr, end: dateStr };
+}
+
+/** Get Beijing tomorrow's date range (for API query) */
+export function getBeijingTomorrowRange(): { start: string; end: string } {
+  const beijingNow = getBeijingNow();
+  const tomorrow = new Date(beijingNow);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const dateStr = formatDateISO(fromBeijingDate(tomorrow));
+  return { start: dateStr, end: dateStr };
+}
+
+/** Get Beijing this weekend's date range (Saturday-Sunday) */
+export function getBeijingWeekendRange(): { start: string; end: string } {
+  const beijingNow = getBeijingNow();
+  const dayOfWeek = beijingNow.getUTCDay(); // 0=Sunday, 6=Saturday in UTC (same as Beijing)
+
+  // Days until Saturday (if today is Sunday, go to next Saturday)
+  const daysUntilSaturday = dayOfWeek === 0 ? 6 : 6 - dayOfWeek;
+
+  const saturday = new Date(beijingNow);
+  saturday.setDate(beijingNow.getDate() + daysUntilSaturday);
+
+  const sunday = new Date(saturday);
+  sunday.setDate(saturday.getDate() + 1);
+
+  return {
+    start: formatDateISO(fromBeijingDate(saturday)),
+    end: formatDateISO(fromBeijingDate(sunday)),
+  };
+}
+
+/** Get next N days range from today */
+export function getBeijingNextNDaysRange(n: number): { start: string; end: string } {
+  const beijingNow = getBeijingNow();
+  const start = formatDateISO(fromBeijingDate(beijingNow));
+
+  const endDate = new Date(beijingNow);
+  endDate.setDate(endDate.getDate() + n);
+  const end = formatDateISO(fromBeijingDate(endDate));
+
+  return { start, end };
+}
+
+/** Check if a date is this weekend in Beijing time */
+export function isBeijingWeekend(dateStr: string): boolean {
+  const date = new Date(dateStr);
+  const beijingDate = toBeijingDate(date);
+  const dayOfWeek = beijingDate.getUTCDay();
+  return dayOfWeek === 0 || dayOfWeek === 6;
+}
+
+/** Get quick select type based on current date range */
+export function getActiveDateQuickType(
+  startDate: string,
+  endDate: string
+): "today" | "tomorrow" | "weekend" | "7days" | "30days" | null {
+  if (!startDate || !endDate) return null;
+
+  const today = getBeijingTodayRange();
+  if (startDate === today.start && endDate === today.end) return "today";
+
+  const tomorrow = getBeijingTomorrowRange();
+  if (startDate === tomorrow.start && endDate === tomorrow.end) return "tomorrow";
+
+  const weekend = getBeijingWeekendRange();
+  if (startDate === weekend.start && endDate === weekend.end) return "weekend";
+
+  const next7Days = getBeijingNextNDaysRange(7);
+  if (startDate === next7Days.start && endDate === next7Days.end) return "7days";
+
+  const next30Days = getBeijingNextNDaysRange(30);
+  if (startDate === next30Days.start && endDate === next30Days.end) return "30days";
+
+  return null;
+}
+
+/** Get date range for a quick select type */
+export function getDateRangeByQuickType(type: string): { start: string; end: string } | null {
+  switch (type) {
+    case "today":
+      return getBeijingTodayRange();
+    case "tomorrow":
+      return getBeijingTomorrowRange();
+    case "weekend":
+      return getBeijingWeekendRange();
+    case "7days":
+      return getBeijingNextNDaysRange(7);
+    case "30days":
+      return getBeijingNextNDaysRange(30);
+    default:
+      return null;
+  }
+}
+
+/** Get display summary for date filter */
+export function getDateFilterSummary(
+  startDate: string,
+  endDate: string,
+  t: (key: string, options?: { count?: number }) => string
+): string {
+  const quickType = getActiveDateQuickType(startDate, endDate);
+
+  switch (quickType) {
+    case "today":
+      return t("filter.dateQuickToday");
+    case "tomorrow":
+      return t("filter.dateQuickTomorrow");
+    case "weekend":
+      return t("filter.dateQuickWeekend");
+    case "7days":
+      return t("filter.dateQuick7Days");
+    case "30days":
+      return t("filter.dateQuick30Days");
+    default:
+      return `${startDate} - ${endDate}`;
+  }
+}


### PR DESCRIPTION
## Summary

实现 Issue #95：队伍列表时间筛选支持北京时间，并添加快捷按钮选中状态。

## Changes

### 后端 (api/)
- `src/lib/date.ts` - 北京时间 ↔ UTC 转换工具
  - `getTodayRange()` / `getTomorrowRange()` / `getThisWeekendRange()`
  - `getNext7DaysRange()` / `getNext30DaysRange()`
  - `getActiveQuickType()` - 反推高亮状态
  - `isInBeijingWeekend()` - 周末判断

### 前端 (frontend/)
- `src/lib/date-beijing.ts` - 前端日期工具（字符串格式，适配 API）
- `use-teams.ts` - 集成北京时区快捷选择，添加 `activeDateQuickType`
- `teams-ui.tsx` - FilterPanel 日期按钮显示选中状态
- `teams-main.tsx` - 传递 `activeDateQuickType` prop

## Key Features

1. **北京时间计算** - 今天/明天/周末按 UTC+8 计算
2. **快捷按钮高亮** - 当前激活的筛选类型高亮显示
3. **激活计数修复** - 日期范围计为 1 个过滤器（非 2 个）

## Test Plan

- [ ] 今天/明天/周末快捷筛选按北京时间计算
- [ ] 快捷按钮选中状态正确显示
- [ ] URL 参数同步正常
- [ ] 激活过滤器计数正确

---

Relates to #95