### PR TITLE
feat(#39): Phase A 搜索 - 前缀匹配 + 高亮

### DIFF
--- a/api/src/db/migrations/0012_add_locations_name_index.sql
+++ b/api/src/db/migrations/0012_add_locations_name_index.sql
@@ -1,0 +1,3 @@
+-- 为 locations.name 添加前缀搜索索引
+-- 用于优化前缀匹配搜索（LIKE 'keyword%'）
+CREATE INDEX IF NOT EXISTS locations_name_idx ON locations(name);

--- a/api/src/routes/locations.ts
+++ b/api/src/routes/locations.ts
@@ -598,4 +598,52 @@ locations.put("/:id/pois", async (c) => {
   }
 });
 
+/**
+ * GET /locations/search
+ * 前缀搜索地点（用于搜索框实时提示）
+ * Query: q=keyword&limit=10
+ */
+locations.get("/search", async (c) => {
+  try {
+    const db = createDb(c.env.DB);
+    const query = c.req.query("q") || "";
+    const limit = Math.min(20, Math.max(1, parseInt(c.req.query("limit") || "10", 10)));
+
+    if (!query.trim()) {
+      return c.json({ success: true, locations: [], suggestions: [] });
+    }
+
+    // 前缀匹配搜索（使用 LIKE 'keyword%' 走索引）
+    const searchResults = await db
+      .select({
+        id: schema.locations.id,
+        name: schema.locations.name,
+        slug: schema.locations.slug,
+        coverImage: schema.locations.coverImage,
+        cityName: schema.locations.cityName,
+      })
+      .from(schema.locations)
+      .where(like(schema.locations.name, `${query}%`))
+      .limit(limit);
+
+    // 获取热门地点作为搜索建议（按队伍数量排序）
+    const suggestions = await db
+      .select({
+        name: schema.locations.name,
+      })
+      .from(schema.locations)
+      .orderBy(sql`(SELECT COUNT(*) FROM teams WHERE teams.location_id = locations.id) DESC`)
+      .limit(5);
+
+    return c.json({
+      success: true,
+      locations: searchResults,
+      suggestions: suggestions.map(s => s.name),
+    });
+  } catch (error) {
+    console.error("Search locations error:", error);
+    return c.json({ error: "搜索失败" }, 500);
+  }
+});
+
 export { locations as locationsRoute };

--- a/frontend/src/components/layout/navbar.tsx
+++ b/frontend/src/components/layout/navbar.tsx
@@ -10,6 +10,7 @@ import { LanguageSwitcher } from "@/components/layout/language-switcher";
 import { type Locale, SUPPORTED_LOCALES, getLocale, setLocale, getLocaleName } from "@/i18n";
 import { useI18n } from "@/hooks/useI18n";
 import { useIPLocation, getCityDisplay } from "@/hooks/useIPLocation";
+import { SearchInput } from "@/components/ui/search-input";
 
 const navLinks = (t: (key: any) => string) => [
   { href: "/",          label: t("nav.home") },
@@ -174,6 +175,9 @@ export function Navbar({ className }: NavbarProps) {
 
             {/* ---- 桌面端操作区 ---- */}
             <div className="hidden md:flex items-center gap-2">
+              {/* 搜索框 */}
+              <SearchInput className="w-56" />
+
               {/* 语言切换 */}
               <LanguageSwitcher />
 

--- a/frontend/src/components/ui/search-input.tsx
+++ b/frontend/src/components/ui/search-input.tsx
@@ -1,0 +1,190 @@
+import React, { useState, useRef, useEffect, useCallback } from "react";
+import { fetchAPI } from "@/lib/api";
+import { SearchResultItem, SearchSuggestions } from "./search";
+
+interface Location {
+  id: string;
+  name: string;
+  slug: string;
+  coverImage: string | null;
+  cityName: string | null;
+}
+
+interface SearchDropdownProps {
+  query: string;
+  onSelect: (location: Location) => void;
+  onClose: () => void;
+}
+
+/**
+ * 搜索下拉框组件
+ * 显示搜索结果和建议
+ */
+function SearchDropdown({ query, onSelect, onClose }: SearchDropdownProps) {
+  const [results, setResults] = useState<Location[]>([]);
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // 点击外部关闭
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [onClose]);
+
+  // 搜索请求
+  useEffect(() => {
+    if (!query.trim()) {
+      setResults([]);
+      return;
+    }
+
+    const fetchResults = async () => {
+      setLoading(true);
+      try {
+        const res = await fetchAPI(`/api/locations/search?q=${encodeURIComponent(query)}&limit=10`);
+        const data = await res.json();
+        if (data.success) {
+          setResults(data.locations);
+          setSuggestions(data.suggestions);
+        }
+      } catch (error) {
+        console.error("Search error:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    // 防抖 300ms
+    const timeout = setTimeout(fetchResults, 300);
+    return () => clearTimeout(timeout);
+  }, [query]);
+
+  if (!query.trim() && suggestions.length === 0) return null;
+
+  return (
+    <div
+      ref={dropdownRef}
+      className="absolute top-full left-0 right-0 mt-2 bg-white dark:bg-stone-900 rounded-xl shadow-xl border border-stone-200 dark:border-stone-700 overflow-hidden z-50"
+    >
+      {loading && (
+        <div className="p-4 text-center text-stone-500">
+          <div className="animate-spin inline-block w-5 h-5 border-2 border-amber-500 border-t-transparent rounded-full" />
+        </div>
+      )}
+
+      {!loading && results.length > 0 && (
+        <div className="max-h-80 overflow-y-auto">
+          {results.map((location) => (
+            <SearchResultItem
+              key={location.id}
+              {...location}
+              keyword={query}
+              onClick={() => onSelect(location)}
+            />
+          ))}
+        </div>
+      )}
+
+      {!loading && query.trim() && results.length === 0 && (
+        <div className="p-4 text-center text-stone-500">未找到相关地点</div>
+      )}
+
+      <SearchSuggestions
+        suggestions={suggestions}
+        onSuggestionClick={(suggestion) => {
+          // 可以触发搜索或跳转
+          window.location.href = `/locations?search=${encodeURIComponent(suggestion)}`;
+        }}
+      />
+    </div>
+  );
+}
+
+interface SearchInputProps {
+  placeholder?: string;
+  className?: string;
+}
+
+/**
+ * 搜索输入框组件
+ * 带实时下拉搜索结果
+ */
+export function SearchInput({ placeholder = "搜索地点...", className = "" }: SearchInputProps) {
+  const [query, setQuery] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleSelect = useCallback((location: Location) => {
+    window.location.href = `/locations/${location.slug}`;
+    setIsOpen(false);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  // 键盘快捷键
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        inputRef.current?.focus();
+        setIsOpen(true);
+      }
+      if (e.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  return (
+    <div className={`relative ${className}`}>
+      <div className="relative">
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setIsOpen(true);
+          }}
+          onFocus={() => setIsOpen(true)}
+          placeholder={placeholder}
+          className="w-full pl-10 pr-4 py-2.5 bg-stone-100 dark:bg-stone-800 border-0 rounded-xl text-stone-900 dark:text-stone-100 placeholder:text-stone-500 focus:ring-2 focus:ring-amber-500 dark:focus:ring-amber-600"
+        />
+        <svg
+          className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-stone-500"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+          />
+        </svg>
+        <kbd className="absolute right-3 top-1/2 -translate-y-1/2 hidden sm:block px-2 py-0.5 text-xs text-stone-500 bg-stone-200 dark:bg-stone-700 rounded">
+          ⌘K
+        </kbd>
+      </div>
+
+      {isOpen && (
+        <SearchDropdown
+          query={query}
+          onSelect={handleSelect}
+          onClose={handleClose}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/search.tsx
+++ b/frontend/src/components/ui/search.tsx
@@ -1,0 +1,122 @@
+import React from "react";
+
+interface HighlightedTextProps {
+  text: string;
+  keyword: string;
+  className?: string;
+}
+
+/**
+ * 高亮搜索关键词的文本组件
+ * 使用 <mark> 标签实现高亮效果
+ */
+export function HighlightedText({ text, keyword, className = "" }: HighlightedTextProps) {
+  if (!keyword.trim()) {
+    return <span className={className}>{text}</span>;
+  }
+
+  const parts = text.split(new RegExp(`(${keyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`, "gi"));
+
+  return (
+    <span className={className}>
+      {parts.map((part, i) =>
+        part.toLowerCase() === keyword.toLowerCase() ? (
+          <mark
+            key={i}
+            className="bg-amber-200 text-amber-900 px-0.5 rounded dark:bg-amber-900/50 dark:text-amber-300"
+          >
+            {part}
+          </mark>
+        ) : (
+          part
+        )
+      )}
+    </span>
+  );
+}
+
+/**
+ * 搜索结果项组件
+ */
+interface SearchResultItemProps {
+  id: string;
+  name: string;
+  coverImage?: string | null;
+  cityName?: string | null;
+  keyword: string;
+  onClick?: () => void;
+}
+
+export function SearchResultItem({
+  id,
+  name,
+  coverImage,
+  cityName,
+  keyword,
+  onClick,
+}: SearchResultItemProps) {
+  return (
+    <button
+      onClick={onClick}
+      className="w-full flex items-center gap-3 p-3 hover:bg-stone-50 dark:hover:bg-stone-800/50 transition-colors text-left"
+    >
+      {coverImage && (
+        <img
+          src={coverImage}
+          alt={name}
+          className="w-12 h-12 rounded-lg object-cover flex-shrink-0"
+        />
+      )}
+      <div className="flex-1 min-w-0">
+        <div className="font-medium text-stone-900 dark:text-stone-100 truncate">
+          <HighlightedText text={name} keyword={keyword} />
+        </div>
+        {cityName && (
+          <div className="text-sm text-stone-500 dark:text-stone-400">{cityName}</div>
+        )}
+      </div>
+    </button>
+  );
+}
+
+/**
+ * 搜索建议列表组件
+ */
+interface SearchSuggestionsProps {
+  suggestions: string[];
+  onSuggestionClick?: (suggestion: string) => void;
+}
+
+export function SearchSuggestions({ suggestions, onSuggestionClick }: SearchSuggestionsProps) {
+  if (suggestions.length === 0) return null;
+
+  return (
+    <div className="py-2">
+      <div className="px-3 py-1.5 text-xs font-medium text-stone-500 dark:text-stone-400">
+        热门搜索
+      </div>
+      {suggestions.map((suggestion, index) => (
+        <button
+          key={index}
+          onClick={() => onSuggestionClick?.(suggestion)}
+          className="w-full px-3 py-2 text-left text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-800/50 transition-colors flex items-center gap-2"
+        >
+          <svg
+            className="w-4 h-4 text-stone-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
+            />
+          </svg>
+          {suggestion}
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## 实现内容

### 后端
- 新增 /api/locations/search?q=keyword&limit=10 端点
- 前缀匹配：LIKE 'keyword%'（走索引）
- 搜索建议：热门地点返回

### 数据库
- 新增 locations_name_idx 索引优化搜索性能

### 前端
- SearchInput：带实时下拉搜索框
- HighlightedText：关键词高亮组件
- SearchResultItem：搜索结果项
- SearchSuggestions：热门搜索建议
- 集成到导航栏

### 技术亮点
- 防抖 300ms 减少请求
- 快捷键 ⌘K 聚焦搜索框
- 前缀匹配走数据库索引

Closes #39 Phase A