### PR TITLE
fix(#37): 修复两天按钮映射逻辑

### DIFF
--- a/frontend/src/components/features/create-team-client.tsx
+++ b/frontend/src/components/features/create-team-client.tsx
@@ -411,9 +411,9 @@ export function CreateTeamClient() {
                   />
                   <QuickDurationButton
                     label={t("teams.durationTwoDays")}
-                    minutes={2880}
+                    minutes={1200}
                     currentValue={formData.durationMin}
-                    onClick={() => handleDurationQuickSelect(2880)}
+                    onClick={() => handleDurationQuickSelect(1200)}
                   />
                   <button
                     type="button"


### PR DESCRIPTION
## Bug 修复

**问题：**「两天」按钮点击后时长字段显示「1 小时」

**原因：** 两天按钮设置 2880 分钟（48 小时），但 dropdown 最大值为 1200 分钟（20+ 小时），导致 select 元素无法匹配到对应 option。

**修复：** 将「两天」按钮映射到 1200 分钟（20+ 小时），与 dropdown 最大值一致。

## 改动
- frontend/src/components/features/create-team-client.tsx: 两天按钮从 2880 改为 1200

## 测试
- 两天按钮点击后正确显示「20+ 小时」
- 按钮选中状态正常

Fixes #37