### PR TITLE
fix: currentMembers 包含队长

### DIFF
--- a/api/src/routes/teams.ts
+++ b/api/src/routes/teams.ts
@@ -507,9 +507,13 @@ teams.get("/:id", async (c) => {
     } catch { /* 用户未登录 */ }
 
     // 计算已加入人数：approved + leave_pending 成员
-    const currentMembers = teamWithRelations.members?.filter(
+    // 如果队长不在 members 数组中，需要 +1
+    const leaderInMembers = teamWithRelations.members?.some(
+      (m: { userId: string }) => m.userId === teamWithRelations.leaderId
+    );
+    const currentMembers = (teamWithRelations.members?.filter(
       (m: { status: string }) => m.status === "approved" || m.status === "leave_pending"
-    ).length || 0;
+    ).length || 0) + (leaderInMembers ? 0 : 1);
 
     const isTeamMember = currentUserId
       ? !!teamWithRelations.members?.find(


### PR DESCRIPTION
## 问题描述
队伍参与人数不一致：
- API 返回 currentMembers = 2（只统计 members 数组）
- 成员列表显示 3 人（members + leader）

## 根本原因
队长作为单独字段返回，不在 members 数组中。

## 修复内容
| 位置 | 修改 |
|------|------|
| 队伍列表 SQL | `COUNT(*) + 1` |
| 队伍详情计算 | `.length + 1` |

## 测试
- [ ] currentMembers 正确包含队长
- [ ] 进度条与成员列表人数一致

@Martin 请 Code Review