### PR TITLE
fix: 修复首页移动端 UI 覆盖问题

### DIFF
--- a/frontend/src/components/features/home/home-hero.tsx
+++ b/frontend/src/components/features/home/home-hero.tsx
@@ -53,15 +53,15 @@ export function HomeHero({ data }: { data: HomeData }) {
             onChange={(e) => search.setValue(e.target.value)}
             onKeyDown={(e) => { if (e.key === "Enter") handleSearch(search.value); }}
             onFocus={() => search.setFocused(true)} onBlur={() => search.setFocused(false)}
-            className="w-full pl-10 sm:pl-14 pr-24 sm:pr-32 py-3 sm:py-4 bg-card/95 border border-border rounded-2xl text-foreground placeholder:text-muted-foreground text-sm sm:text-base transition-all duration-250 focus:outline-none"
+            className="w-full pl-11 sm:pl-14 pr-28 sm:pr-32 py-3 sm:py-4 bg-card/95 border border-border rounded-2xl text-foreground placeholder:text-muted-foreground text-sm sm:text-base transition-all duration-250 focus:outline-none"
             style={{ boxShadow: search.isFocused ? "0 6px 28px rgba(217,119,6,0.20), 0 0 0 3px rgba(217,119,6,0.12)" : "0 4px 20px rgba(30,24,18,0.08)", backdropFilter: "blur(8px)" }} />
           {search.value && (
-            <button onClick={search.clear} className="absolute right-[4.5rem] sm:right-[5.5rem] top-1/2 -translate-y-1/2 w-5 h-5 sm:w-6 sm:h-6 rounded-full flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition-all duration-150 animate-spin-in">
-              <X className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
+            <button onClick={search.clear} className="absolute right-20 sm:right-28 top-1/2 -translate-y-1/2 w-6 h-6 rounded-full flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition-all duration-150 animate-spin-in">
+              <X className="h-3.5 w-3.5" />
             </button>
           )}
           <button onClick={() => handleSearch(search.value)}
-            className={`absolute right-2 sm:right-3 top-1/2 -translate-y-1/2 px-3 sm:px-5 py-1.5 sm:py-2 text-xs sm:text-sm font-semibold rounded-xl text-white transition-colors duration-150 ${search.isButtonBouncing ? "animate-bounce-in" : ""}`}
+            className={`absolute right-3 top-1/2 -translate-y-1/2 px-4 sm:px-5 py-1.5 sm:py-2 text-xs sm:text-sm font-semibold rounded-xl text-white transition-colors duration-150 ${search.isButtonBouncing ? "animate-bounce-in" : ""}`}
             style={{ background: "linear-gradient(135deg, #D97706 0%, #F59E0B 100%)", boxShadow: "0 2px 10px rgba(217,119,6,0.30)" }}>
             {t("common.search")}
           </button>

--- a/frontend/src/components/features/home/home-location-card.tsx
+++ b/frontend/src/components/features/home/home-location-card.tsx
@@ -61,7 +61,7 @@ export const LocationCard = memo(function LocationCard({ location, index = 0 }: 
 
           <div className="absolute inset-0" style={{ background: "linear-gradient(to top, rgba(15,15,12,0.72) 0%, rgba(15,15,12,0.18) 45%, transparent 70%)" }} />
 
-          <div className="absolute inset-0 flex flex-col justify-end p-4 opacity-100 sm:opacity-0 sm:group-hover:opacity-100"
+          <div className="absolute inset-0 flex flex-col justify-end p-4 pb-16 sm:pb-4 opacity-100 sm:opacity-0 sm:group-hover:opacity-100"
             style={{ background: "linear-gradient(to top, rgba(146,64,14,0.90) 0%, rgba(146,64,14,0.55) 55%, transparent 100%)", transition: "opacity 0.3s ease" }}>
             <p className="text-white/90 text-xs sm:text-sm line-clamp-1 sm:line-clamp-2 leading-relaxed mb-2">{location.description}</p>
             {routeInfo && (

--- a/frontend/src/components/features/home/home-team-card.tsx
+++ b/frontend/src/components/features/home/home-team-card.tsx
@@ -118,7 +118,7 @@ export function TeamCard({ team }: { team: Team }) {
           />
         )}
 
-        <div className="p-4">
+        <div className="p-4 pb-10 sm:pb-4">
           {!hasCover && team.location && (
             <div className="flex items-center gap-1.5 mb-2.5">
               <MapPin className="h-3 w-3 flex-shrink-0" style={{ color: "#D97706" }} />
@@ -164,7 +164,7 @@ export function TeamCard({ team }: { team: Team }) {
           </div>
         </div>
 
-        <div className="absolute bottom-0 left-0 right-0 flex items-center justify-center gap-1.5 py-2 text-xs font-semibold text-white translate-y-0 sm:translate-y-full sm:group-hover:translate-y-0 transition-transform duration-300 ease-out"
+        <div className="sm:absolute bottom-0 left-0 right-0 flex items-center justify-center gap-1.5 py-2.5 text-xs font-semibold text-white sm:translate-y-full sm:group-hover:translate-y-0 transition-all duration-300 ease-out rounded-b-lg sm:rounded-none opacity-100 sm:opacity-0 sm:group-hover:opacity-100 mt-2 sm:mt-0 static sm:static"
           style={{ background: "linear-gradient(135deg, #D97706 0%, #F59E0B 100%)", transitionTimingFunction: "cubic-bezier(0.34,1.56,0.64,1)" }}>
           <span>{t("home.teamCard.viewDetails")}</span><ArrowRight className="h-3.5 w-3.5" />
         </div>

--- a/frontend/src/components/features/home/home-team-card.tsx
+++ b/frontend/src/components/features/home/home-team-card.tsx
@@ -164,8 +164,8 @@ export function TeamCard({ team }: { team: Team }) {
           </div>
         </div>
 
-        <div className="absolute bottom-0 left-0 right-0 flex items-center justify-center gap-1.5 py-2 text-xs font-semibold text-white"
-          style={{ background: "linear-gradient(135deg, #D97706 0%, #F59E0B 100%)", transform: hovered ? "translateY(0)" : "translateY(0)", transition: "transform 0.28s cubic-bezier(0.34,1.56,0.64,1)", opacity: hovered ? 1 : 0.9 }}>
+        <div className="absolute bottom-0 left-0 right-0 flex items-center justify-center gap-1.5 py-2 text-xs font-semibold text-white translate-y-0 sm:translate-y-full sm:group-hover:translate-y-0 transition-transform duration-300 ease-out"
+          style={{ background: "linear-gradient(135deg, #D97706 0%, #F59E0B 100%)", transitionTimingFunction: "cubic-bezier(0.34,1.56,0.64,1)" }}>
           <span>{t("home.teamCard.viewDetails")}</span><ArrowRight className="h-3.5 w-3.5" />
         </div>
       </article>

--- a/frontend/src/components/features/home/home-team-card.tsx
+++ b/frontend/src/components/features/home/home-team-card.tsx
@@ -164,8 +164,8 @@ export function TeamCard({ team }: { team: Team }) {
           </div>
         </div>
 
-        <div className="absolute bottom-0 left-0 right-0 flex items-center justify-center gap-1.5 py-2 text-xs font-semibold text-white translate-y-0 sm:translate-y-full sm:group-hover:translate-y-0 transition-transform duration-300 ease-out"
-          style={{ background: "linear-gradient(135deg, #D97706 0%, #F59E0B 100%)", transitionTimingFunction: "cubic-bezier(0.34,1.56,0.64,1)" }}>
+        <div className="absolute bottom-0 left-0 right-0 flex items-center justify-center gap-1.5 py-2 text-xs font-semibold text-white"
+          style={{ background: "linear-gradient(135deg, #D97706 0%, #F59E0B 100%)", transform: hovered ? "translateY(0)" : "translateY(0)", transition: "transform 0.28s cubic-bezier(0.34,1.56,0.64,1)", opacity: hovered ? 1 : 0.9 }}>
           <span>{t("home.teamCard.viewDetails")}</span><ArrowRight className="h-3.5 w-3.5" />
         </div>
       </article>


### PR DESCRIPTION
修复 PR #112 部署后发现的移动端 UI 问题：

- 队伍卡片 CTA 按钮与内容重叠
- 地点卡片描述与标签重叠  
- Hero 搜索框按钮位置偏移

修复内容：
- home-team-card.tsx: 增加 pb-10 sm:pb-4 预留空间
- home-location-card.tsx: 增加 pb-16 sm:pb-4 避免重叠
- home-hero.tsx: 调整搜索框内边距和按钮位置