### PR TITLE
feat: CTA 区域优化

### DIFF
--- a/frontend/public/locales/en/home.json
+++ b/frontend/public/locales/en/home.json
@@ -5,8 +5,8 @@
     "title": "Ready to Go?",
     "subtitle": "Find your travel companions, the journey is not far",
     "description": "Over {count}+ companions have already found their travel partners here, and you can too",
-    "joinBtn": "Join GoMate for Free",
-    "browseTeamsBtn": "Browse Available Teams"
+    "createTeamBtn": "Create a Team",
+    "viewAllTeamsLink": "View all teams"
   },
   "howItWorks": {
     "badge": "How It Works",

--- a/frontend/public/locales/ja/home.json
+++ b/frontend/public/locales/ja/home.json
@@ -5,8 +5,8 @@
     "title": "準備はできましたか",
     "subtitle": "同行者を見つければ、旅は遠くない",
     "description": "{count}人以上のパートナーがここで同行者を見つけました。あなたもできます。",
-    "joinBtn": "無料でGoMateに参加",
-    "browseTeamsBtn": "どんなチームがあるか見てみる"
+    "createTeamBtn": "チームを作成",
+    "viewAllTeamsLink": "すべてのチームを見る"
   },
   "howItWorks": {
     "badge": "利用の流れ",

--- a/frontend/public/locales/zh-CN/home.json
+++ b/frontend/public/locales/zh-CN/home.json
@@ -5,8 +5,8 @@
     "title": "准备好了吗",
     "subtitle": "找到同行的人，出发就不远",
     "description": "已有 {count}+ 伙伴在这里找到了同行的人，你也可以",
-    "joinBtn": "免费加入 GoMate",
-    "browseTeamsBtn": "先看看有哪些队伍"
+    "createTeamBtn": "创建队伍",
+    "viewAllTeamsLink": "查看所有队伍"
   },
   "howItWorks": {
     "badge": "使用流程",

--- a/frontend/src/components/features/home/home-cta-section.tsx
+++ b/frontend/src/components/features/home/home-cta-section.tsx
@@ -29,22 +29,17 @@ export function HomeCtaSection({ data }: { data: HomeData }) {
           {t("home.cta.description", { count: 200 })}
         </p>
 
-        <div className="flex flex-col sm:flex-row gap-4 justify-center">
-          {!isLoggedIn && (
-            <a href="/register"
-              className="inline-block px-8 py-3.5 font-semibold rounded-full text-white text-base transition-all duration-150"
-              style={{ background: "linear-gradient(135deg, #D97706 0%, #F59E0B 100%)", boxShadow: "0 4px 18px rgba(217,119,6,0.38)" }}
-              onMouseEnter={(e) => { const el = e.currentTarget as HTMLAnchorElement; el.style.transform = "translateY(-2px)"; el.style.boxShadow = "0 8px 26px rgba(217,119,6,0.50)"; }}
-              onMouseLeave={(e) => { const el = e.currentTarget as HTMLAnchorElement; el.style.transform = "translateY(0)"; el.style.boxShadow = "0 4px 18px rgba(217,119,6,0.38)"; }}>
-              {t("home.cta.joinBtn")}
-            </a>
-          )}
+        <div className="flex flex-col gap-4 justify-center items-center">
+          <a href="/teams/create"
+            className="inline-block px-8 py-3.5 font-semibold rounded-full text-white text-base transition-all duration-150"
+            style={{ background: "linear-gradient(135deg, #D97706 0%, #F59E0B 100%)", boxShadow: "0 4px 18px rgba(217,119,6,0.38)" }}
+            onMouseEnter={(e) => { const el = e.currentTarget as HTMLAnchorElement; el.style.transform = "translateY(-2px)"; el.style.boxShadow = "0 8px 26px rgba(217,119,6,0.50)"; }}
+            onMouseLeave={(e) => { const el = e.currentTarget as HTMLAnchorElement; el.style.transform = "translateY(0)"; el.style.boxShadow = "0 4px 18px rgba(217,119,6,0.38)"; }}>
+            {t("home.cta.createTeamBtn")}
+          </a>
           <a href="/teams"
-            className="inline-block px-8 py-3.5 font-semibold rounded-full text-base text-foreground transition-all duration-150 border-2"
-            style={{ borderColor: "rgba(217,119,6,0.35)" }}
-            onMouseEnter={(e) => { (e.currentTarget as HTMLAnchorElement).style.background = "rgba(217,119,6,0.06)"; }}
-            onMouseLeave={(e) => { (e.currentTarget as HTMLAnchorElement).style.background = "transparent"; }}>
-            {t("home.cta.browseTeamsBtn")}
+            className="text-[#D97706] hover:underline text-base font-medium transition-all duration-150">
+            {t("home.cta.viewAllTeamsLink")}
           </a>
         </div>
       </div>

--- a/frontend/src/components/features/home/home-hero.tsx
+++ b/frontend/src/components/features/home/home-hero.tsx
@@ -99,7 +99,7 @@ export function HomeHero({ data }: { data: HomeData }) {
         </div>
       </div>
 
-      <div className="absolute left-4 sm:left-8 top-1/3 flex flex-col gap-2 sm:gap-3" aria-hidden="true">
+      <div className="absolute left-4 sm:left-8 top-1/3 hidden sm:flex flex-col gap-2 sm:gap-3" aria-hidden="true">
         {[{ icon: "🏔️", label: t("home.floatingLabels.mountain1"), delay: "0s" }].map((item) => (
           <div key={item.label} className="flex items-center gap-1.5 sm:gap-2 px-2 sm:px-3 py-1.5 sm:py-2 rounded-xl sm:rounded-2xl bg-gradient-to-br from-card/95 to-amber-50/80 dark:to-amber-950/60 border border-amber-200/50 dark:border-amber-900/50 animate-float-up"
             style={{ boxShadow: "0 4px 16px rgba(217,119,6,0.12), 0 2px 8px rgba(0,0,0,0.06)", backdropFilter: "blur(12px)", animationDelay: item.delay }}>
@@ -109,7 +109,7 @@ export function HomeHero({ data }: { data: HomeData }) {
         ))}
       </div>
 
-      <div className="absolute right-4 sm:right-8 top-1/3 flex flex-col gap-2 sm:gap-3" aria-hidden="true">
+      <div className="absolute right-4 sm:right-8 top-1/3 hidden sm:flex flex-col gap-2 sm:gap-3" aria-hidden="true">
         {[{ icon: "👥", label: t("home.floatingLabels.teamJoined").replace("{count}", "3"), delay: "-1s" }].map((item) => (
           <div key={item.label} className="flex items-center gap-1.5 sm:gap-2 px-2 sm:px-3 py-1.5 sm:py-2 rounded-xl sm:rounded-2xl bg-gradient-to-br from-card/95 to-amber-50/80 dark:to-amber-950/60 border border-amber-200/50 dark:border-amber-900/50 animate-float-down"
             style={{ boxShadow: "0 4px 16px rgba(217,119,6,0.12), 0 2px 8px rgba(0,0,0,0.06)", backdropFilter: "blur(12px)", animationDelay: item.delay }}>


### PR DESCRIPTION
## 摘要
CTA 区域按钮优化，引导创建行为。

## 改动

### 1. home-cta-section.tsx
- 主按钮：「创建队伍」→ /teams/create（橙色渐变）
- 次按钮：「查看所有队伍」→ /teams（文字链接）
- 布局：垂直居中，移除登录状态判断

### 2. 翻译文件（en/zh-CN/ja）
**新增 key：**
- `home.cta.createTeamBtn`
- `home.cta.viewAllTeamsLink`

**删除 key：**
- `home.cta.joinBtn`
- `home.cta.browseTeamsBtn`

## 验证
- ✅ i18n 构建通过
- ✅ 前端构建通过
- ✅ TypeScript 检查通过

## 待验收
- @Steven 产品/文案验收
- @Martin Code Review
- @Wen QA 回归