### PR TITLE
feat: Footer 版权栏文案优化

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -145,7 +145,7 @@
     "feedback": "Feedback - GoMate",
     "userDetail": "User Profile - GoMate"
   },
-  "madeWithLove": "by GoMate",
+  "madeWithLove": "Made with passion",
   "footer": {
     "expand": "Expand",
     "collapse": "Collapse"

--- a/frontend/public/locales/ja/common.json
+++ b/frontend/public/locales/ja/common.json
@@ -145,7 +145,7 @@
     "feedback": "フィードバック - GoMate",
     "userDetail": "ユーザープロフィール - GoMate"
   },
-  "madeWithLove": "GoMate より",
+  "madeWithLove": "時間を超える情熱を",
   "footer": {
     "expand": "展開",
     "collapse": "折りたたむ"

--- a/frontend/public/locales/zh-CN/common.json
+++ b/frontend/public/locales/zh-CN/common.json
@@ -145,7 +145,7 @@
     "feedback": "反馈建议 - GoMate",
     "userDetail": "用户资料 - GoMate"
   },
-  "madeWithLove": "用 ❤️ 制作",
+  "madeWithLove": "热爱可抵岁月漫长",
   "footer": {
     "expand": "展开",
     "collapse": "收起"

--- a/frontend/src/components/layout/footer.tsx
+++ b/frontend/src/components/layout/footer.tsx
@@ -499,7 +499,6 @@ export function Footer() {
             © {year} {t("common.copyright")}
           </p>
           <p className="text-xs flex items-center gap-1.5 text-muted-foreground">
-            Made with
             <Heart className="h-3 w-3 text-primary" style={{ fill: "currentColor" }} />
             {t("common.madeWithLove")}
           </p>


### PR DESCRIPTION
## 改动内容

优化 Footer 版权栏文案，更有温度。

### 文案变更

| 语言 | 原文 | 新文案 |
|------|------|--------|
| zh-CN | 用 ❤️ 制作 | 热爱可抵岁月漫长 |
| en | by GoMate | Made with passion |
| ja | GoMate より | 時間を超える情熱を |

### 结构调整
- 移除硬编码 "Made with"
- 改为：❤️ + 翻译文案

### 验证
- [x] i18n:build 通过
- [x] type-check 通过
- [x] 三语言显示正常

## 测试清单
- 桌面端/移动端版权栏显示
- 三语言切换验证