### PR TITLE
fix: i18n activityPosts 翻译 key 修复

### DIFF
--- a/frontend/src/components/features/activity-posts/activity-post-card.tsx
+++ b/frontend/src/components/features/activity-posts/activity-post-card.tsx
@@ -44,7 +44,7 @@ export function ActivityPostCard({
   const { t } = useI18n(["teams", "common"]);
 
   const handleDelete = () => {
-    if (onDelete && confirm(t("activityPosts.confirmDelete"))) {
+    if (onDelete && confirm(t("teams.activityPosts.confirmDelete"))) {
       onDelete(post.id);
     }
   };
@@ -81,7 +81,7 @@ export function ActivityPostCard({
           <button
             onClick={handleDelete}
             className="p-1.5 text-muted-foreground hover:text-red-500 hover:bg-red-50 rounded-full transition-colors"
-            aria-label={t("activityPosts.delete")}
+            aria-label={t("teams.activityPosts.delete")}
           >
             <Trash2 className="h-4 w-4" />
           </button>
@@ -109,7 +109,7 @@ export function ActivityPostCard({
             href={`/teams/${post.team.id}`}
             className="text-xs text-muted-foreground hover:text-amber-600 transition-colors"
           >
-            {t("activityPosts.fromTeam")}: {post.team.title}
+            {t("teams.activityPosts.fromTeam")}: {post.team.title}
           </a>
         </div>
       )}

--- a/frontend/src/components/features/activity-posts/activity-post-form.tsx
+++ b/frontend/src/components/features/activity-posts/activity-post-form.tsx
@@ -37,7 +37,7 @@ export function ActivityPostForm({ teamId, onSuccess, onCancel, className }: Act
 
     const remainingSlots = maxImages - images.length;
     if (remainingSlots <= 0) {
-      setError(t("activityPosts.maxImagesError"));
+      setError(t("teams.activityPosts.maxImagesError"));
       return;
     }
 
@@ -60,7 +60,7 @@ export function ActivityPostForm({ teamId, onSuccess, onCancel, className }: Act
         }
       }
     } catch (err) {
-      setError(t("activityPosts.uploadError"));
+      setError(t("teams.activityPosts.uploadError"));
     }
   };
 
@@ -70,7 +70,7 @@ export function ActivityPostForm({ teamId, onSuccess, onCancel, className }: Act
 
   const handleSubmit = async () => {
     if (!content.trim()) {
-      setError(t("activityPosts.contentRequired"));
+      setError(t("teams.activityPosts.contentRequired"));
       return;
     }
 
@@ -93,10 +93,10 @@ export function ActivityPostForm({ teamId, onSuccess, onCancel, className }: Act
         setImages([]);
         onSuccess?.();
       } else {
-        setError(data.message || t("activityPosts.submitError"));
+        setError(data.message || t("teams.activityPosts.submitError"));
       }
     } catch (err) {
-      setError(t("activityPosts.submitError"));
+      setError(t("teams.activityPosts.submitError"));
     } finally {
       setIsSubmitting(false);
     }
@@ -107,7 +107,7 @@ export function ActivityPostForm({ teamId, onSuccess, onCancel, className }: Act
       {/* Content textarea */}
       <div className="space-y-2">
         <textarea
-          placeholder={t("activityPosts.placeholder")}
+          placeholder={t("teams.activityPosts.placeholder")}
           value={content}
           onChange={handleContentChange}
           rows={4}
@@ -158,7 +158,7 @@ export function ActivityPostForm({ teamId, onSuccess, onCancel, className }: Act
             className="inline-flex items-center gap-2 px-4 py-2 border border-border rounded-lg text-sm font-medium hover:bg-muted transition-colors"
           >
             <ImagePlus className="h-4 w-4" />
-            {t("activityPosts.addImage")} ({images.length}/{maxImages})
+            {t("teams.activityPosts.addImage")} ({images.length}/{maxImages})
           </button>
         </div>
       )}
@@ -178,7 +178,7 @@ export function ActivityPostForm({ teamId, onSuccess, onCancel, className }: Act
           disabled={isSubmitting || !content.trim()}
           className="px-4 py-2 bg-amber-600 text-white rounded-lg text-sm font-medium hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
-          {isSubmitting ? t("common.submitting") : t("activityPosts.publish")}
+          {isSubmitting ? t("common.submitting") : t("teams.activityPosts.publish")}
         </button>
       </div>
     </div>

--- a/frontend/src/components/features/activity-posts/location-activity-posts.tsx
+++ b/frontend/src/components/features/activity-posts/location-activity-posts.tsx
@@ -51,7 +51,7 @@ export function LocationActivityPosts({ locationId, className }: LocationActivit
       <div className={cn("bg-card rounded-2xl border border-border", className)}>
         <div className="p-6 border-b border-border">
           <h3 className="text-lg font-semibold text-foreground">
-            {t("activityPosts.recentActivities")}
+            {t("teams.activityPosts.recentActivities")}
           </h3>
         </div>
         <div className="p-6">
@@ -60,7 +60,7 @@ export function LocationActivityPosts({ locationId, className }: LocationActivit
               <Mountain className="h-8 w-8 text-stone-400" />
             </div>
             <p className="text-muted-foreground text-sm">
-              {t("activityPosts.locationEmpty")}
+              {t("teams.activityPosts.locationEmpty")}
             </p>
           </div>
         </div>
@@ -72,7 +72,7 @@ export function LocationActivityPosts({ locationId, className }: LocationActivit
     <div className={cn("bg-card rounded-2xl border border-border", className)}>
       <div className="p-6 border-b border-border">
         <h3 className="text-lg font-semibold text-foreground">
-          {t("activityPosts.recentActivities")}
+          {t("teams.activityPosts.recentActivities")}
         </h3>
       </div>
       <div className="p-6">

--- a/frontend/src/components/features/activity-posts/team-activity-posts.tsx
+++ b/frontend/src/components/features/activity-posts/team-activity-posts.tsx
@@ -76,7 +76,7 @@ export function TeamActivityPosts({ teamId, teamStatus, isMember, className }: T
       {/* Header */}
       <div className="flex flex-row items-center justify-between p-6 border-b border-border">
         <h3 className="text-lg font-semibold text-foreground">
-          {t("activityPosts.title")}
+          {t("teams.activityPosts.title")}
         </h3>
         {canPost && (
           <button
@@ -84,7 +84,7 @@ export function TeamActivityPosts({ teamId, teamStatus, isMember, className }: T
             className="inline-flex items-center gap-2 px-4 py-2 bg-amber-600 text-white text-sm font-medium rounded-lg hover:bg-amber-700 transition-colors"
           >
             <Plus className="h-4 w-4" />
-            {t("activityPosts.add")}
+            {t("teams.activityPosts.add")}
           </button>
         )}
       </div>
@@ -94,7 +94,7 @@ export function TeamActivityPosts({ teamId, teamStatus, isMember, className }: T
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
           <div className="bg-card rounded-2xl border border-border w-full max-w-lg max-h-[90vh] overflow-y-auto">
             <div className="flex items-center justify-between p-4 border-b border-border">
-              <h4 className="text-lg font-semibold">{t("activityPosts.add")}</h4>
+              <h4 className="text-lg font-semibold">{t("teams.activityPosts.add")}</h4>
               <button
                 onClick={() => setShowForm(false)}
                 className="p-2 hover:bg-muted rounded-full transition-colors"
@@ -121,10 +121,10 @@ export function TeamActivityPosts({ teamId, teamStatus, isMember, className }: T
               <Mountain className="h-8 w-8 text-stone-400" />
             </div>
             <p className="text-muted-foreground text-sm mb-1">
-              {t("activityPosts.emptyTitle")}
+              {t("teams.activityPosts.emptyTitle")}
             </p>
             <p className="text-muted-foreground text-xs">
-              {canPost ? t("activityPosts.emptyDescription") : t("activityPosts.emptyNotMember")}
+              {canPost ? t("teams.activityPosts.emptyDescription") : t("teams.activityPosts.emptyNotMember")}
             </p>
           </div>
         ) : (


### PR DESCRIPTION
## 问题
activityPosts 相关翻译 key 显示为原始 key，未正确解析

## 修复
- `t("activityPosts.xxx")` → `t("teams.activityPosts.xxx")`

## 改动文件
- team-activity-posts.tsx
- location-activity-posts.tsx
- activity-post-form.tsx
- activity-post-card.tsx

## 验证
- [x] pnpm i18n:build 通过
- [x] pnpm type-check 通过
- [x] 翻译正确显示（如「活动回顾」）

## 原因
activityPosts 不是独立 namespace，翻译实际在 teams.json 中，需加 teams 前缀