### PR TITLE
feat: 未完成队伍隐藏活动回顾

### DIFF
--- a/frontend/src/components/features/activity-posts/team-activity-posts.tsx
+++ b/frontend/src/components/features/activity-posts/team-activity-posts.tsx
@@ -23,6 +23,9 @@ export function TeamActivityPosts({ teamId, teamStatus, isMember, className }: T
 
   const canPost = teamStatus === "completed" && isMember;
 
+  // 队伍未完成时隐藏活动回顾区块
+  if (teamStatus !== "completed") return null;
+
   const loadPosts = React.useCallback(async () => {
     setIsLoading(true);
     try {


### PR DESCRIPTION
## 需求
队伍未完成时隐藏「活动回顾」区块

## 改动
- `team-activity-posts.tsx` 添加状态判断
- 只有 `completed` 状态显示活动回顾
- 其他状态返回 null（隐藏整个区块）

## 状态映射
| 状态 | 显示活动回顾 |
|------|--------------|
| recruiting | ❌ |
| full | ❌ |
| formed | ❌ |
| completed | ✅ |
| cancelled | ❌ |

## 验证
- [x] type-check 通过