### PR TITLE
fix: 分享弹窗关闭按钮翻译

### DIFF
--- a/frontend/src/components/features/team-detail/share-poster-preview.tsx
+++ b/frontend/src/components/features/team-detail/share-poster-preview.tsx
@@ -100,7 +100,7 @@ export function SharePosterPreview({
               onClick={onClose}
               className="w-full py-3 text-muted-foreground hover:bg-muted rounded-xl transition-colors"
             >
-              {t("common.close")}
+              {t("teams.close")}
             </button>
           </div>
 


### PR DESCRIPTION
## 问题
分享弹窗关闭按钮显示 `common.close` 而非「关闭」

## 原因
- `common.close` 实际路径为 `common.wechat.close`，不是全局的
- 应使用 `teams.close`

## 修复
share-poster-preview.tsx: 将 `t("common.close")` 改为 `t("teams.close")`

## 改动
- 1 行修改