### PR TITLE
feat: Phase 2 队伍分享海报生成

### DIFF
--- a/frontend/public/locales/en/teams.json
+++ b/frontend/public/locales/en/teams.json
@@ -419,5 +419,10 @@
   "linkCopied": "Link copied",
   "posterComingSoon": "Poster feature coming soon",
   "shareHint": "Tip: Long press above to share with friends",
-  "close": "Close"
+  "close": "Close",
+  "generatingPoster": "Generating poster...",
+  "posterGenerateError": "Failed to generate poster",
+  "posterGenerateFallback": "Please use \"Copy Link\" to share",
+  "saveImageHint": "Tip: Click \"Save to Album\" to save, or long press image to save manually",
+  "saveToAlbum": "Save to Album"
 }

--- a/frontend/public/locales/en/teams.json
+++ b/frontend/public/locales/en/teams.json
@@ -424,5 +424,7 @@
   "posterGenerateError": "Failed to generate poster",
   "posterGenerateFallback": "Please use \"Copy Link\" to share",
   "saveImageHint": "Tip: Click \"Save to Album\" to save, or long press image to save manually",
-  "saveToAlbum": "Save to Album"
+  "saveToAlbum": "Save to Album",
+  "qrCodeHint": "Scan to join team",
+  "posterFooter": "gomate.live · Discover places, join teams"
 }

--- a/frontend/public/locales/ja/teams.json
+++ b/frontend/public/locales/ja/teams.json
@@ -424,5 +424,7 @@
   "posterGenerateError": "画像の生成に失敗しました",
   "posterGenerateFallback": "「リンクをコピー」をご利用ください",
   "saveImageHint": "ヒント：「保存」をタップするか、画像を長押しして保存してください",
-  "saveToAlbum": "保存"
+  "saveToAlbum": "保存",
+  "qrCodeHint": "スキャンしてチームに参加",
+  "posterFooter": "gomate.live · 場所を発見し、チームに参加しよう"
 }

--- a/frontend/public/locales/ja/teams.json
+++ b/frontend/public/locales/ja/teams.json
@@ -419,5 +419,10 @@
   "linkCopied": "リンクをコピーしました",
   "posterComingSoon": "画像機能は近日公開予定",
   "shareHint": "ヒント：上の内容を長押しして友達に共有できます",
-  "close": "閉じる"
+  "close": "閉じる",
+  "generatingPoster": "画像を生成中...",
+  "posterGenerateError": "画像の生成に失敗しました",
+  "posterGenerateFallback": "「リンクをコピー」をご利用ください",
+  "saveImageHint": "ヒント：「保存」をタップするか、画像を長押しして保存してください",
+  "saveToAlbum": "保存"
 }

--- a/frontend/public/locales/zh-CN/teams.json
+++ b/frontend/public/locales/zh-CN/teams.json
@@ -419,5 +419,10 @@
   "linkCopied": "链接已复制",
   "posterComingSoon": "海报功能即将上线",
   "shareHint": "提示：可以长按上方内容分享给好友",
-  "close": "关闭"
+  "close": "关闭",
+  "generatingPoster": "正在生成海报...",
+  "posterGenerateError": "生成海报失败",
+  "posterGenerateFallback": "请使用「复制链接」分享",
+  "saveImageHint": "提示：点击「保存到相册」按钮保存图片，或长按图片手动保存",
+  "saveToAlbum": "保存到相册"
 }

--- a/frontend/public/locales/zh-CN/teams.json
+++ b/frontend/public/locales/zh-CN/teams.json
@@ -424,5 +424,7 @@
   "posterGenerateError": "生成海报失败",
   "posterGenerateFallback": "请使用「复制链接」分享",
   "saveImageHint": "提示：点击「保存到相册」按钮保存图片，或长按图片手动保存",
-  "saveToAlbum": "保存到相册"
+  "saveToAlbum": "保存到相册",
+  "qrCodeHint": "扫码加入队伍",
+  "posterFooter": "gomate.live · 发现趣处，组队同行"
 }

--- a/frontend/src/components/features/team-detail/share-poster-preview.tsx
+++ b/frontend/src/components/features/team-detail/share-poster-preview.tsx
@@ -1,37 +1,110 @@
 "use client";
 
 import * as React from "react";
+import { toPng } from "html-to-image";
 import { useI18n } from "@/hooks/useI18n";
-import { Link2, X, CheckCircle } from "lucide-react";
+import { Link2, X, CheckCircle, Download, Loader2 } from "lucide-react";
+import { TeamPosterContent } from "./team-poster-content";
 
 interface SharePosterPreviewProps {
   open: boolean;
-  teamTitle?: string;
-  teamUrl?: string;
+  teamTitle: string;
+  teamDate: string;
+  teamLocation?: string;
+  teamUrl: string;
   onClose: () => void;
 }
 
 export function SharePosterPreview({
   open,
   teamTitle,
+  teamDate,
+  teamLocation,
   teamUrl,
   onClose,
 }: SharePosterPreviewProps) {
   const { t } = useI18n(["teams", "common"]);
   const [copied, setCopied] = React.useState(false);
+  const [isGenerating, setIsGenerating] = React.useState(false);
+  const [posterDataUrl, setPosterDataUrl] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const posterRef = React.useRef<HTMLDivElement>(null);
 
-  if (!open) return null;
+  // Generate poster image when opened
+  React.useEffect(() => {
+    if (!open || posterDataUrl) return;
+
+    const generatePoster = async () => {
+      if (!posterRef.current) return;
+
+      setIsGenerating(true);
+      setError(null);
+
+      try {
+        // Wait for fonts and images to load
+        await new Promise(resolve => setTimeout(resolve, 500));
+
+        const dataUrl = await toPng(posterRef.current, {
+          pixelRatio: 2,
+          cacheBust: true,
+          backgroundColor: '#ffffff',
+        });
+
+        setPosterDataUrl(dataUrl);
+      } catch (err) {
+        console.error("Failed to generate poster:", err);
+        setError(t("teams.posterGenerateError"));
+      } finally {
+        setIsGenerating(false);
+      }
+    };
+
+    generatePoster();
+  }, [open, posterDataUrl, t]);
 
   const handleCopyLink = async () => {
-    if (!teamUrl) return;
     try {
       await navigator.clipboard.writeText(teamUrl);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
-      // Ignore error
+      // Ignore
     }
   };
+
+  const handleSaveImage = async () => {
+    if (!posterDataUrl) return;
+
+    try {
+      // iOS Safari special handling
+      const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+
+      if (isIOS) {
+        // Open image in new tab for iOS (user can long press to save)
+        const newWindow = window.open();
+        if (newWindow) {
+          newWindow.document.write(`
+            <html>
+              <head><title>长按保存图片</title></head>
+              <body style="margin:0;display:flex;justify-content:center;align-items:center;background:#000;">
+                <img src="${posterDataUrl}" style="max-width:100%;max-height:100vh;" />
+              </body>
+            </html>
+          `);
+        }
+      } else {
+        // Standard download for Android/PC
+        const link = document.createElement("a");
+        link.href = posterDataUrl;
+        link.download = `gomate-team-${Date.now()}.png`;
+        link.click();
+      }
+    } catch (err) {
+      console.error("Failed to save image:", err);
+    }
+  };
+
+  if (!open) return null;
 
   return (
     <>
@@ -42,44 +115,86 @@ export function SharePosterPreview({
       >
         {/* Modal */}
         <div
-          className="bg-card rounded-2xl max-w-sm w-full p-6 shadow-xl"
+          className="bg-card rounded-2xl max-w-sm w-full max-h-[90vh] overflow-y-auto shadow-xl"
           onClick={(e) => e.stopPropagation()}
         >
           {/* Header */}
-          <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center justify-between p-4 border-b border-border">
             <h3 className="text-lg font-semibold text-foreground">
               {t("teams.shareTeam")}
             </h3>
             <button
               onClick={onClose}
-              className="p-1 hover:bg-muted rounded-full transition-colors"
+              className="p-2 hover:bg-muted rounded-full transition-colors"
             >
               <X className="w-5 h-5 text-muted-foreground" />
             </button>
           </div>
 
-          {/* Placeholder for Poster (Phase 2) */}
-          <div className="bg-muted rounded-xl p-8 mb-6 text-center">
-            <div className="w-16 h-16 mx-auto mb-3 rounded-full bg-amber-100 flex items-center justify-center">
-              <span className="text-2xl">📋</span>
+          {/* Poster Preview */}
+          <div className="p-4 flex flex-col items-center">
+            {/* Hidden poster for generation */}
+            <div
+              ref={posterRef}
+              className="absolute -left-[9999px] top-0"
+              style={{ position: 'fixed', left: '-9999px' }}
+            >
+              <TeamPosterContent
+                title={teamTitle}
+                date={teamDate}
+                locationName={teamLocation}
+                url={teamUrl}
+              />
             </div>
-            <p className="text-sm text-muted-foreground mb-1">
-              {teamTitle || t("teams.teamInfo")}
-            </p>
-            <p className="text-xs text-muted-foreground">
-              {t("teams.posterComingSoon")}
+
+            {/* Display generated poster */}
+            {isGenerating ? (
+              <div className="w-[340px] h-[480px] bg-muted rounded-xl flex flex-col items-center justify-center">
+                <Loader2 className="w-8 h-8 animate-spin text-amber-600 mb-3" />
+                <p className="text-sm text-muted-foreground">
+                  {t("teams.generatingPoster")}
+                </p>
+              </div>
+            ) : posterDataUrl ? (
+              <img
+                src={posterDataUrl}
+                alt="Team Poster"
+                className="w-[340px] rounded-xl shadow-lg"
+              />
+            ) : error ? (
+              <div className="w-[340px] h-[480px] bg-muted rounded-xl flex flex-col items-center justify-center p-6">
+                <p className="text-sm text-red-500 mb-2">{error}</p>
+                <p className="text-xs text-muted-foreground">
+                  {t("teams.posterGenerateFallback")}
+                </p>
+              </div>
+            ) : null}
+
+            {/* Hint */}
+            <p className="mt-3 text-xs text-center text-muted-foreground">
+              {t("teams.saveImageHint")}
             </p>
           </div>
 
           {/* Actions */}
-          <div className="space-y-3">
-            {/* Copy Link */}
+          <div className="p-4 space-y-3 border-t border-border">
+            {/* Save Image - Primary */}
+            <button
+              onClick={handleSaveImage}
+              disabled={!posterDataUrl}
+              className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-amber-600 text-white rounded-xl font-medium hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              <Download className="w-4 h-4" />
+              {t("teams.saveToAlbum")}
+            </button>
+
+            {/* Copy Link - Secondary */}
             <button
               onClick={handleCopyLink}
               className={`w-full flex items-center justify-center gap-2 px-4 py-3 rounded-xl font-medium transition-colors ${
                 copied
                   ? "bg-green-100 text-green-700"
-                  : "bg-amber-600 text-white hover:bg-amber-700"
+                  : "border border-border text-foreground hover:bg-muted"
               }`}
             >
               {copied ? (
@@ -103,11 +218,6 @@ export function SharePosterPreview({
               {t("teams.close")}
             </button>
           </div>
-
-          {/* Hint */}
-          <p className="mt-4 text-xs text-center text-muted-foreground">
-            {t("teams.shareHint")}
-          </p>
         </div>
       </div>
     </>

--- a/frontend/src/components/features/team-detail/share-poster-preview.tsx
+++ b/frontend/src/components/features/team-detail/share-poster-preview.tsx
@@ -144,6 +144,8 @@ export function SharePosterPreview({
                 date={teamDate}
                 locationName={teamLocation}
                 url={teamUrl}
+                qrHint={t("teams.qrCodeHint")}
+                footerText={t("teams.posterFooter")}
               />
             </div>
 

--- a/frontend/src/components/features/team-detail/team-detail-bottom-bar.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-bottom-bar.tsx
@@ -228,6 +228,8 @@ function BottomBarLeader({ ctx, team, location }: { ctx: ReturnType<typeof useTe
       <SharePosterPreview
         open={share.showPreview}
         teamTitle={team.title}
+        teamDate={team.date}
+        teamLocation={location?.name}
         teamUrl={window.location.href}
         onClose={share.closePreview}
       />
@@ -266,6 +268,8 @@ function BottomBarMember({ ctx, team }: { ctx: ReturnType<typeof useTeamDetail>;
       <SharePosterPreview
         open={share.showPreview}
         teamTitle={team.title}
+        teamDate={team.date}
+        teamLocation={location?.name}
         teamUrl={window.location.href}
         onClose={share.closePreview}
       />
@@ -303,6 +307,8 @@ function BottomBarPending({ ctx, team }: { ctx: ReturnType<typeof useTeamDetail>
       <SharePosterPreview
         open={share.showPreview}
         teamTitle={team.title}
+        teamDate={team.date}
+        teamLocation={location?.name}
         teamUrl={window.location.href}
         onClose={share.closePreview}
       />
@@ -348,6 +354,8 @@ function BottomBarCanJoin({ ctx, team }: { ctx: ReturnType<typeof useTeamDetail>
       <SharePosterPreview
         open={share.showPreview}
         teamTitle={team.title}
+        teamDate={team.date}
+        teamLocation={location?.name}
         teamUrl={window.location.href}
         onClose={share.closePreview}
       />
@@ -379,6 +387,8 @@ function BottomBarCannotJoin({ ctx, team }: { ctx: ReturnType<typeof useTeamDeta
       <SharePosterPreview
         open={share.showPreview}
         teamTitle={team.title}
+        teamDate={team.date}
+        teamLocation={location?.name}
         teamUrl={window.location.href}
         onClose={share.closePreview}
       />

--- a/frontend/src/components/features/team-detail/team-detail-sidebar.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-sidebar.tsx
@@ -95,6 +95,8 @@ export function TeamSidebar({ ctx }: { ctx: ReturnType<typeof useTeamDetail>; })
       <SharePosterPreview
         open={share.showPreview}
         teamTitle={team.title}
+        teamDate={team.date}
+        teamLocation={location?.name}
         teamUrl={window.location.href}
         onClose={share.closePreview}
       />

--- a/frontend/src/components/features/team-detail/team-poster-content.tsx
+++ b/frontend/src/components/features/team-detail/team-poster-content.tsx
@@ -12,6 +12,8 @@ interface TeamPosterContentProps {
   date: string;
   locationName?: string;
   url: string;
+  qrHint: string;
+  footerText: string;
 }
 
 export function TeamPosterContent({
@@ -19,6 +21,8 @@ export function TeamPosterContent({
   date,
   locationName,
   url,
+  qrHint,
+  footerText,
 }: TeamPosterContentProps) {
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
 
@@ -92,7 +96,7 @@ export function TeamPosterContent({
             </div>
           )}
           <p className="mt-3 text-xs text-stone-500">
-            扫码加入队伍
+            {qrHint}
           </p>
         </div>
       </div>
@@ -100,7 +104,7 @@ export function TeamPosterContent({
       {/* Footer */}
       <div className="py-3 bg-stone-50 border-t border-stone-100">
         <p className="text-center text-xs text-stone-400">
-          gomate.live · 发现趣处，组队同行
+          {footerText}
         </p>
       </div>
     </div>

--- a/frontend/src/components/features/team-detail/team-poster-content.tsx
+++ b/frontend/src/components/features/team-detail/team-poster-content.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import QRCode from "qrcode";
+import { Mountain } from "lucide-react";
+
+const ZPIX_FONT_URL =
+  "https://cdn.jsdelivr.net/gh/SolidZORO/zpix-pixel-font@master/website/zpix.woff2";
+
+interface TeamPosterContentProps {
+  title: string;
+  date: string;
+  locationName?: string;
+  url: string;
+}
+
+export function TeamPosterContent({
+  title,
+  date,
+  locationName,
+  url,
+}: TeamPosterContentProps) {
+  const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    QRCode.toDataURL(url, {
+      width: 180,
+      margin: 2,
+      color: { dark: "#1c1917", light: "#ffffff" },
+    }).then(setQrDataUrl);
+  }, [url]);
+
+  return (
+    <div
+      className="flex w-[340px] flex-col bg-white rounded-2xl overflow-hidden shadow-lg"
+      style={{ fontFamily: "'Zpix', system-ui, sans-serif" }}
+    >
+      <style>{`
+        @font-face {
+          font-family: 'Zpix';
+          src: url('${ZPIX_FONT_URL}') format('woff2');
+          font-weight: normal;
+          font-style: normal;
+          font-display: swap;
+        }
+      `}</style>
+
+      {/* Header - GoMate Logo */}
+      <div className="flex items-center justify-center py-4 bg-gradient-to-r from-amber-500 to-amber-600">
+        <div className="flex items-center gap-2 text-white">
+          <Mountain className="w-5 h-5" />
+          <span className="text-sm font-semibold tracking-wide">GoMate</span>
+        </div>
+      </div>
+
+      {/* Content Area */}
+      <div className="flex flex-col px-6 py-5">
+        {/* Title */}
+        <h2
+          className="text-lg leading-tight text-stone-900 mb-4"
+          style={{ fontFamily: "'Zpix', monospace" }}
+        >
+          {title}
+        </h2>
+
+        {/* Date */}
+        <div className="flex items-center gap-2 text-sm text-stone-600 mb-2">
+          <span className="text-amber-600">📅</span>
+          <span>{date}</span>
+        </div>
+
+        {/* Location */}
+        {locationName && (
+          <div className="flex items-center gap-2 text-sm text-stone-600 mb-4">
+            <span className="text-amber-600">📍</span>
+            <span>{locationName}</span>
+          </div>
+        )}
+
+        {/* Divider */}
+        <div className="w-full h-px bg-stone-200 my-4" />
+
+        {/* QR Code */}
+        <div className="flex flex-col items-center">
+          {qrDataUrl && (
+            <div className="rounded-xl bg-white p-3 shadow-md border border-stone-100">
+              <img
+                src={qrDataUrl}
+                alt="QR Code"
+                className="w-32 h-32"
+              />
+            </div>
+          )}
+          <p className="mt-3 text-xs text-stone-500">
+            扫码加入队伍
+          </p>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="py-3 bg-stone-50 border-t border-stone-100">
+        <p className="text-center text-xs text-stone-400">
+          gomate.live · 发现趣处，组队同行
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Phase 2 功能概述
实现队伍分享海报的生成和保存功能

## 改动内容

### 新增组件
- `team-poster-content.tsx` - 海报渲染组件（340px 宽，Logo+标题+时间+地点+二维码）

### 更新组件
- `share-poster-preview.tsx` - 集成 html-to-image 生成海报，支持保存到相册
- `team-detail-bottom-bar.tsx` - 传递 teamDate/teamLocation 参数
- `team-detail-sidebar.tsx` - 传递 teamDate/teamLocation 参数

### 翻译更新
- zh-CN/en/ja: 添加生成状态、错误提示、保存按钮等翻译

## 技术实现
- **海报生成**: html-to-image toPng with pixelRatio: 2
- **iOS Safari**: 打开新标签页保存（Blob 兼容性处理）
- **Android/PC**: 标准 a[download] 下载
- **QR Code**: qrcode 库生成，180x180px

## 用户流程
```
点击分享按钮
  ↓
底部选项弹窗
  ↓
点击「生成分享海报」
  ↓
显示海报预览 + 保存按钮
  ↓
点击「保存到相册」
  ↓
iOS: 新标签页打开图片（长按保存）
Android/PC: 直接下载图片
```

## 测试
- [x] Type-check 通过
- [ ] 真机测试（iOS Safari 保存）
- [ ] 真机测试（Android Chrome）
- [ ] 二维码扫描验证
- [ ] 三语言翻译验证

## 相关 PR
- Phase 1: #125（底部弹窗 + 复制链接）
- Hotfix: #126（翻译修复）