### PR TITLE
fix: remove swr dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,6 @@
     "qrcode": "^1.5.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "swr": "^2.4.1",
     "tailwind-merge": "^2.5.0",
     "tailwindcss": "^4.0.0",
     "zod": "^3.23.0"

--- a/frontend/src/hooks/use-locations.ts
+++ b/frontend/src/hooks/use-locations.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import useSWR from "swr";
+import { useState, useEffect, useCallback } from "react";
 import { fetchAPI } from "@/lib/api";
 import type { Location } from "@/lib/types";
 
@@ -15,30 +15,38 @@ interface LocationsResponse {
   };
 }
 
-const fetcher = async (url: string): Promise<LocationsResponse> => {
-  const res = await fetchAPI(url);
-  const data = await res.json();
-  if (!data.success) {
-    throw new Error(data.error || "获取地点列表失败");
-  }
-  return data;
-};
-
 /**
- * 使用 SWR 获取地点列表，支持缓存和自动重验证
- * 缓存时间：5分钟
+ * 获取地点列表，支持分页
  */
 export function useLocations(page = 1, pageSize = 6) {
-  const { data, error, isLoading, mutate } = useSWR<LocationsResponse>(
-    `/api/locations?page=${page}&pageSize=${pageSize}&view=card`,
-    fetcher,
-    {
-      revalidateOnFocus: false,
-      dedupingInterval: 300000, // 5分钟去重
-      keepPreviousData: true, // 切换分页时保持旧数据
-      refreshInterval: 0, // 不自动刷新
+  const [data, setData] = useState<LocationsResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchData = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await fetchAPI(`/api/locations?page=${page}&pageSize=${pageSize}&view=card`);
+      const json = await res.json();
+      if (!json.success) {
+        throw new Error(json.error || "获取地点列表失败");
+      }
+      setData(json);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error("获取地点列表失败"));
+    } finally {
+      setIsLoading(false);
     }
-  );
+  }, [page, pageSize]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const mutate = useCallback(async () => {
+    await fetchData();
+  }, [fetchData]);
 
   return {
     locations: data?.locations ?? [],
@@ -49,35 +57,49 @@ export function useLocations(page = 1, pageSize = 6) {
   };
 }
 
-interface TagsResponse {
-  success: boolean;
-  tags: { id: string; name: string; type: string }[];
-}
-
-const tagsFetcher = async (url: string): Promise<TagsResponse> => {
-  const res = await fetchAPI(url);
-  const data = await res.json();
-  if (!data.success) {
-    throw new Error(data.error || "获取标签失败");
-  }
-  return data;
-};
-
 /**
- * 使用 SWR 获取热门标签
+ * 获取热门标签
  */
 export function useLocationTags() {
-  const { data, error, isLoading } = useSWR<TagsResponse>(
-    "/api/locations?tags=true",
-    tagsFetcher,
-    {
-      revalidateOnFocus: false,
-      dedupingInterval: 600000, // 10分钟，标签变化较少
-    }
-  );
+  const [tags, setTags] = useState<{ id: string; name: string; type: string }[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const fetchTags = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const res = await fetchAPI("/api/locations?tags=true");
+        const json = await res.json();
+        if (!json.success) {
+          throw new Error(json.error || "获取标签失败");
+        }
+        if (mounted) {
+          setTags(json.tags);
+        }
+      } catch (err) {
+        if (mounted) {
+          setError(err instanceof Error ? err : new Error("获取标签失败"));
+        }
+      } finally {
+        if (mounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchTags();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   return {
-    tags: data?.tags ?? [],
+    tags,
     isLoading,
     error,
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,9 +126,6 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
-      swr:
-        specifier: ^2.4.1
-        version: 2.4.1(react@18.3.1)
       tailwind-merge:
         specifier: ^2.5.0
         version: 2.6.1
@@ -4460,11 +4457,6 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
-  swr@2.4.1:
-    resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
-    peerDependencies:
-      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -4682,11 +4674,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  use-sync-external-store@1.6.0:
-    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -9322,12 +9309,6 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  swr@2.4.1(react@18.3.1):
-    dependencies:
-      dequal: 2.0.3
-      react: 18.3.1
-      use-sync-external-store: 1.6.0(react@18.3.1)
-
   symbol-tree@3.2.4: {}
 
   tailwind-merge@2.6.1: {}
@@ -9553,10 +9534,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  use-sync-external-store@1.6.0(react@18.3.1):
-    dependencies:
-      react: 18.3.1
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## Summary
移除 `swr` 依赖，修复 CI/CD 构建失败问题。

## Changes
- 重写 `use-locations.ts`：用 `useState`/`useEffect` 替代 `swr`
- 从 `package.json` 移除 `swr` 依赖
- 更新 `pnpm-lock.yaml`

## Why
- CI 环境缓存导致 `pnpm-lock.yaml` 未同步，`swr` 依赖未正确安装
- 减少依赖，简化项目维护

## Testing
- [x] 本地构建通过
- [x] 类型检查通过

## Related
修复 CI/CD 失败导致的部署阻塞。