### PR TITLE
fix: 修复 team-detail 类型错误

### DIFF
--- a/frontend/src/components/features/team-detail/team-detail-bottom-bar.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-bottom-bar.tsx
@@ -240,6 +240,7 @@ function BottomBarLeader({ ctx, team, location }: { ctx: ReturnType<typeof useTe
 function BottomBarMember({ ctx, team }: { ctx: ReturnType<typeof useTeamDetail>; team: Team; }) {
   const { t } = useI18n(["teams", "common"]);
   const share = useTeamShare(team);
+  const { location } = ctx;
 
   return (
     <>
@@ -280,6 +281,7 @@ function BottomBarMember({ ctx, team }: { ctx: ReturnType<typeof useTeamDetail>;
 function BottomBarPending({ ctx, team }: { ctx: ReturnType<typeof useTeamDetail>; team: Team; }) {
   const { t } = useI18n(["teams", "common"]);
   const share = useTeamShare(team);
+  const { location } = ctx;
 
   return (
     <>
@@ -332,6 +334,7 @@ function BottomBarNotLoggedIn({ team }: { team: Team; }) {
 function BottomBarCanJoin({ ctx, team }: { ctx: ReturnType<typeof useTeamDetail>; team: Team; }) {
   const { t } = useI18n(["teams", "common"]);
   const share = useTeamShare(team);
+  const { location } = ctx;
 
   return (
     <>
@@ -366,6 +369,7 @@ function BottomBarCanJoin({ ctx, team }: { ctx: ReturnType<typeof useTeamDetail>
 function BottomBarCannotJoin({ ctx, team }: { ctx: ReturnType<typeof useTeamDetail>; team: Team; }) {
   const { t } = useI18n(["teams", "common"]);
   const share = useTeamShare(team);
+  const { location } = ctx;
 
   return (
     <>

--- a/frontend/src/components/features/team-detail/use-team-detail.ts
+++ b/frontend/src/components/features/team-detail/use-team-detail.ts
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { fetchAPI } from "@/lib/api";
-import type { Team, TeamMember, Application } from "@/lib/types";
+import type { Team, TeamMember, Application, Location } from "@/lib/types";
 import { useI18n } from "@/hooks/useI18n";
 
 interface ToastOptions {
@@ -60,7 +60,7 @@ interface UseTeamDetailReturn {
   canJoin: boolean;
   isFull: boolean;
   remaining: number;
-  location: any;
+  location: Location | null;
   handleJoin: () => Promise<void>;
   handleSaveWechat: (wechat: string) => Promise<void>;
   handleLeave: () => Promise<void>;
@@ -325,7 +325,7 @@ export function useTeamDetail(teamId: string): UseTeamDetailReturn {
   const isFull = team ? team.currentMembers >= team.maxMembers : false;
   const canJoin = !isLeader && !isMember && !isPending && team?.status === "recruiting" && !isFull;
   const remaining = team ? team.maxMembers - team.currentMembers : 0;
-  const location = (team as any)?.location;
+  const location = team?.location ?? null;
 
   return {
     toast, exiting,


### PR DESCRIPTION
## Summary
修复 CI/CD 流水线类型检查失败的 4 个错误。

## Changes
- `use-team-detail.ts`: 导入 `Location` 类型，将 `location` 从 `any` 改为 `Location | null`
- `team-detail-bottom-bar.tsx`: 在 `BottomBarMember`、`BottomBarPending`、`BottomBarCanJoin`、`BottomBarCannotJoin` 组件中从 `ctx` 解构 `location`

## 错误原因
移除 swr 后，`use-team-detail.ts` 中的 `location` 类型为 `any`，但实际使用时应为 `Location` 类型。

## Testing
- [x] pnpm type-check 通过（0 errors）
- [x] pnpm build 通过

## Related
修复 PR #128 合并后的 CI/CD 失败。