### PR TITLE
feat: 海报添加地点封面图

### DIFF
--- a/frontend/src/components/features/team-detail/share-poster-preview.tsx
+++ b/frontend/src/components/features/team-detail/share-poster-preview.tsx
@@ -11,6 +11,7 @@ interface SharePosterPreviewProps {
   teamTitle: string;
   teamDate: string;
   teamLocation?: string;
+  teamCoverImage?: string;
   teamUrl: string;
   onClose: () => void;
 }
@@ -20,6 +21,7 @@ export function SharePosterPreview({
   teamTitle,
   teamDate,
   teamLocation,
+  teamCoverImage,
   teamUrl,
   onClose,
 }: SharePosterPreviewProps) {
@@ -44,6 +46,15 @@ export function SharePosterPreview({
         // Wait for fonts to load (Zpix font from CDN)
         if (document.fonts) {
           await document.fonts.ready;
+        }
+
+        // Wait for cover image to load
+        const coverImg = posterRef.current?.querySelector('img[data-cover]') as HTMLImageElement | null;
+        if (coverImg && !coverImg.complete) {
+          await new Promise((resolve) => {
+            coverImg.onload = resolve;
+            coverImg.onerror = resolve;
+          });
         }
 
         // Additional delay for iOS
@@ -166,6 +177,7 @@ export function SharePosterPreview({
                 title={teamTitle}
                 date={teamDate}
                 locationName={teamLocation}
+                coverImage={teamCoverImage}
                 url={teamUrl}
                 qrHint={t("teams.qrCodeHint")}
                 footerText={t("teams.posterFooter")}

--- a/frontend/src/components/features/team-detail/team-detail-bottom-bar.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-bottom-bar.tsx
@@ -230,6 +230,7 @@ function BottomBarLeader({ ctx, team, location }: { ctx: ReturnType<typeof useTe
         teamTitle={team.title}
         teamDate={team.date}
         teamLocation={location?.name}
+        teamCoverImage={location?.coverImage}
         teamUrl={window.location.href}
         onClose={share.closePreview}
       />
@@ -271,6 +272,7 @@ function BottomBarMember({ ctx, team }: { ctx: ReturnType<typeof useTeamDetail>;
         teamTitle={team.title}
         teamDate={team.date}
         teamLocation={location?.name}
+        teamCoverImage={location?.coverImage}
         teamUrl={window.location.href}
         onClose={share.closePreview}
       />
@@ -311,6 +313,7 @@ function BottomBarPending({ ctx, team }: { ctx: ReturnType<typeof useTeamDetail>
         teamTitle={team.title}
         teamDate={team.date}
         teamLocation={location?.name}
+        teamCoverImage={location?.coverImage}
         teamUrl={window.location.href}
         onClose={share.closePreview}
       />
@@ -359,6 +362,7 @@ function BottomBarCanJoin({ ctx, team }: { ctx: ReturnType<typeof useTeamDetail>
         teamTitle={team.title}
         teamDate={team.date}
         teamLocation={location?.name}
+        teamCoverImage={location?.coverImage}
         teamUrl={window.location.href}
         onClose={share.closePreview}
       />
@@ -393,6 +397,7 @@ function BottomBarCannotJoin({ ctx, team }: { ctx: ReturnType<typeof useTeamDeta
         teamTitle={team.title}
         teamDate={team.date}
         teamLocation={location?.name}
+        teamCoverImage={location?.coverImage}
         teamUrl={window.location.href}
         onClose={share.closePreview}
       />

--- a/frontend/src/components/features/team-detail/team-detail-sidebar.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-sidebar.tsx
@@ -97,6 +97,7 @@ export function TeamSidebar({ ctx }: { ctx: ReturnType<typeof useTeamDetail>; })
         teamTitle={team.title}
         teamDate={team.date}
         teamLocation={location?.name}
+        teamCoverImage={location?.coverImage}
         teamUrl={window.location.href}
         onClose={share.closePreview}
       />

--- a/frontend/src/components/features/team-detail/team-poster-content.tsx
+++ b/frontend/src/components/features/team-detail/team-poster-content.tsx
@@ -11,6 +11,7 @@ interface TeamPosterContentProps {
   title: string;
   date: string;
   locationName?: string;
+  coverImage?: string;
   url: string;
   qrHint: string;
   footerText: string;
@@ -20,6 +21,7 @@ export function TeamPosterContent({
   title,
   date,
   locationName,
+  coverImage,
   url,
   qrHint,
   footerText,
@@ -48,6 +50,19 @@ export function TeamPosterContent({
           font-display: swap;
         }
       `}</style>
+
+      {/* Cover Image */}
+      {coverImage && (
+        <div className="w-full h-[120px] overflow-hidden">
+          <img
+            src={coverImage}
+            alt={locationName || "Location"}
+            className="w-full h-full object-cover"
+            data-cover="true"
+            crossOrigin="anonymous"
+          />
+        </div>
+      )}
 
       {/* Header - GoMate Logo */}
       <div className="flex items-center justify-center py-4 bg-gradient-to-r from-amber-500 to-amber-600">


### PR DESCRIPTION
## Summary
海报添加地点封面图功能。

## Changes
- `TeamPosterContent`: 新增 `coverImage` prop
- `SharePosterPreview`: 新增 `teamCoverImage` prop
- 海报布局：封面图（120px 高）→ Header → Content
- 等待封面图加载完成后再生成海报
- 更新 `team-detail-bottom-bar.tsx` 和 `team-detail-sidebar.tsx`

## 技术细节
- 封面图使用 `object-fit: cover`
- 添加 `crossOrigin="anonymous"` 支持 CORS
- 等待封面图加载：`coverImg.onload/onerror`

## Testing
- [x] type-check 通过（0 errors）
- [x] build 通过

## Screenshots
等待 QA 验证后补充。