### PR TITLE
fix: 修复海报生成失败问题

### DIFF
--- a/frontend/src/components/features/team-detail/share-poster-preview.tsx
+++ b/frontend/src/components/features/team-detail/share-poster-preview.tsx
@@ -48,18 +48,14 @@ export function SharePosterPreview({
           await document.fonts.ready;
         }
 
-        // Wait for cover image to load
-        const coverImg = posterRef.current?.querySelector('img[data-cover]') as HTMLImageElement | null;
-        if (coverImg && !coverImg.complete) {
-          await new Promise((resolve) => {
-            coverImg.onload = resolve;
-            coverImg.onerror = resolve;
-          });
-        }
+        // Wait for images to load (cover + QR code)
+        await new Promise(resolve => setTimeout(resolve, 800));
 
         // Additional delay for iOS
         const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
-        await new Promise(resolve => setTimeout(resolve, isIOS ? 500 : 300));
+        if (isIOS) {
+          await new Promise(resolve => setTimeout(resolve, 500));
+        }
 
         // Ensure element is visible for capture
         const originalStyle = posterRef.current.style.cssText;

--- a/frontend/src/components/features/team-detail/team-poster-content.tsx
+++ b/frontend/src/components/features/team-detail/team-poster-content.tsx
@@ -27,6 +27,7 @@ export function TeamPosterContent({
   footerText,
 }: TeamPosterContentProps) {
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+  const [coverError, setCoverError] = useState(false);
 
   useEffect(() => {
     QRCode.toDataURL(url, {
@@ -51,15 +52,15 @@ export function TeamPosterContent({
         }
       `}</style>
 
-      {/* Cover Image */}
-      {coverImage && (
+      {/* Cover Image - only render if loaded successfully */}
+      {coverImage && !coverError && (
         <div className="w-full h-[120px] overflow-hidden">
           <img
             src={coverImage}
             alt={locationName || "Location"}
             className="w-full h-full object-cover"
             data-cover="true"
-            crossOrigin="anonymous"
+            onError={() => setCoverError(true)}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary
修复海报生成失败问题。

## 问题原因
封面图使用 `crossOrigin=\"anonymous\"` 可能导致跨域加载失败，进而导致 html-to-image 转换失败。

## 修复方案
1. 移除 `crossOrigin=\"anonymous\"` 属性
2. 添加封面图加载错误处理（加载失败则不显示封面图）
3. 简化图片等待逻辑，统一使用 setTimeout（800ms + iOS 额外 500ms）

## 改动文件
- `team-poster-content.tsx`: 移除 crossOrigin，添加 onError 处理
- `share-poster-preview.tsx`: 简化等待逻辑

## Testing
- [x] type-check 通过（0 errors）
- [x] build 通过

## Related
修复海报生成失败问题。