### PR TITLE
fix: 修复海报生成失败 - 预加载封面图避免 CORS 问题

### DIFF
--- a/frontend/src/components/features/team-detail/share-poster-preview.tsx
+++ b/frontend/src/components/features/team-detail/share-poster-preview.tsx
@@ -30,7 +30,46 @@ export function SharePosterPreview({
   const [isGenerating, setIsGenerating] = React.useState(false);
   const [posterDataUrl, setPosterDataUrl] = React.useState<string | null>(null);
   const [error, setError] = React.useState<string | null>(null);
+  const [processedCoverImage, setProcessedCoverImage] = React.useState<string | undefined>(undefined);
   const posterRef = React.useRef<HTMLDivElement>(null);
+
+  // Pre-load and process cover image to avoid CORS issues
+  React.useEffect(() => {
+    if (!open || !teamCoverImage) {
+      setProcessedCoverImage(undefined);
+      return;
+    }
+
+    const loadImage = async () => {
+      try {
+        // Try to load image and convert to data URL to avoid CORS
+        const response = await fetch(teamCoverImage);
+        if (!response.ok) throw new Error('Image fetch failed');
+        const blob = await response.blob();
+        const dataUrl = await new Promise<string>((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onloadend = () => resolve(reader.result as string);
+          reader.onerror = reject;
+          reader.readAsDataURL(blob);
+        });
+        setProcessedCoverImage(dataUrl);
+      } catch (err) {
+        console.warn('[Poster] Failed to preload cover image:', err);
+        // Fallback: don't show cover image
+        setProcessedCoverImage(undefined);
+      }
+    };
+
+    loadImage();
+  }, [open, teamCoverImage]);
+
+  // Reset state when modal opens
+  React.useEffect(() => {
+    if (open) {
+      setPosterDataUrl(null);
+      setError(null);
+    }
+  }, [open, teamTitle, teamDate, teamLocation, teamCoverImage, teamUrl]);
 
   // Generate poster image when opened
   React.useEffect(() => {
@@ -49,7 +88,8 @@ export function SharePosterPreview({
         }
 
         // Wait for images to load (cover + QR code)
-        await new Promise(resolve => setTimeout(resolve, 800));
+        // Use a longer timeout to ensure everything is ready
+        await new Promise(resolve => setTimeout(resolve, 1000));
 
         // Additional delay for iOS
         const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
@@ -173,7 +213,7 @@ export function SharePosterPreview({
                 title={teamTitle}
                 date={teamDate}
                 locationName={teamLocation}
-                coverImage={teamCoverImage}
+                coverImage={processedCoverImage}
                 url={teamUrl}
                 qrHint={t("teams.qrCodeHint")}
                 footerText={t("teams.posterFooter")}


### PR DESCRIPTION
## 问题

海报生成仍然失败，QA 测试显示错误信息「画像の生成に失敗しました」。

## 根因分析

1. **CORS 问题**：封面图跨域导致 html-to-image 使用的 Canvas 被污染
2. **超时不可靠**：800ms 固定超时不能保证图片已加载完成
3. **状态未重置**：多次打开弹窗时，posterDataUrl 状态未正确重置

## 修复方案

### 1. 预加载封面图
- 使用 `fetch` + `FileReader` 将封面图转为 data URL
- data URL 无跨域问题，Canvas 不会被污染
- 加载失败时降级为无封面图模式

### 2. 增加等待时间
- 图片加载等待从 800ms 增加到 1000ms
- 确保图片和字体都准备就绪

### 3. 状态管理修复
- 新增 `processedCoverImage` state 存储处理后的图片
- 弹窗打开时重置 `posterDataUrl` 和 `error` 状态

## 测试验证

- [ ] iOS Safari 生成带封面图的海报
- [ ] 封面图加载失败时降级（不显示封面但生成成功）
- [ ] 多次打开分享弹窗无异常
- [ ] 无封面图的队伍正常生成

Fixes #12