### PR TITLE
ui: 队伍分享海报重新设计

### DIFF
--- a/frontend/public/locales/en/teams.json
+++ b/frontend/public/locales/en/teams.json
@@ -433,5 +433,14 @@
   "saveImageHint": "Tip: Click \"Save to Album\" to save, or long press image to save manually",
   "saveToAlbum": "Save to Album",
   "qrCodeHint": "Scan to join team",
-  "posterFooter": "gomate.live · Discover places, join teams"
+  "posterFooter": "gomate.live · Discover places, join teams",
+  "posterSpotsLeft": "{count} spots left",
+  "posterAlmostFull": "Almost full",
+  "posterDateLabel": "Departure Date",
+  "posterLocationLabel": "Location",
+  "posterMembersLabel": "Team Size",
+  "posterMemberCount": "{current}/{max} people",
+  "posterLeaderLabel": "Leader",
+  "posterQrHint": "Scan to join team",
+  "posterGeneratingDesc": "Generating beautiful poster...",
 }

--- a/frontend/public/locales/ja/teams.json
+++ b/frontend/public/locales/ja/teams.json
@@ -433,5 +433,14 @@
   "saveImageHint": "ヒント：「保存」をタップするか、画像を長押しして保存してください",
   "saveToAlbum": "保存",
   "qrCodeHint": "スキャンしてチームに参加",
-  "posterFooter": "gomate.live · 場所を発見し、チームに参加しよう"
+  "posterFooter": "gomate.live · 場所を発見し、チームに参加しよう",
+  "posterSpotsLeft": "残り{count}名",
+  "posterAlmostFull": "満員間近",
+  "posterDateLabel": "出発日",
+  "posterLocationLabel": "開催地",
+  "posterMembersLabel": "チーム人数",
+  "posterMemberCount": "{current}/{max}名",
+  "posterLeaderLabel": "リーダー",
+  "posterQrHint": "スキャンしてチームに参加",
+  "posterGeneratingDesc": "素敵なシェア画像を生成中...",
 }

--- a/frontend/public/locales/zh-CN/teams.json
+++ b/frontend/public/locales/zh-CN/teams.json
@@ -433,5 +433,14 @@
   "saveImageHint": "提示：点击「保存到相册」按钮保存图片，或长按图片手动保存",
   "saveToAlbum": "保存到相册",
   "qrCodeHint": "扫码加入队伍",
-  "posterFooter": "gomate.live · 发现趣处，组队同行"
+  "posterFooter": "gomate.live · 发现趣处，组队同行",
+  "posterSpotsLeft": "还差 {count} 人",
+  "posterAlmostFull": "即将满员",
+  "posterDateLabel": "出发日期",
+  "posterLocationLabel": "活动地点",
+  "posterMembersLabel": "队伍人数",
+  "posterMemberCount": "{current}/{max} 人",
+  "posterLeaderLabel": "领队",
+  "posterQrHint": "扫码加入队伍",
+  "posterGeneratingDesc": "正在生成精美海报...",
 }

--- a/frontend/src/components/features/team-detail/share-poster-preview.tsx
+++ b/frontend/src/components/features/team-detail/share-poster-preview.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { toPng } from "html-to-image";
 import { useI18n } from "@/hooks/useI18n";
-import { Link2, X, CheckCircle, Download, Loader2 } from "lucide-react";
+import { Link2, X, CheckCircle, Download, Loader2, Share2 } from "lucide-react";
 import { TeamPosterContent } from "./team-poster-content";
 
 interface SharePosterPreviewProps {
@@ -13,6 +13,10 @@ interface SharePosterPreviewProps {
   teamLocation?: string;
   teamCoverImage?: string;
   teamUrl: string;
+  teamCurrentMembers?: number;
+  teamMaxMembers?: number;
+  teamLeaderName?: string;
+  teamLeaderAvatar?: string | null;
   onClose: () => void;
 }
 
@@ -23,6 +27,10 @@ export function SharePosterPreview({
   teamLocation,
   teamCoverImage,
   teamUrl,
+  teamCurrentMembers = 1,
+  teamMaxMembers = 5,
+  teamLeaderName,
+  teamLeaderAvatar,
   onClose,
 }: SharePosterPreviewProps) {
   const { t } = useI18n(["teams", "common"]);
@@ -82,13 +90,12 @@ export function SharePosterPreview({
       setError(null);
 
       try {
-        // Wait for fonts to load (Zpix font from CDN)
+        // Wait for fonts to load
         if (document.fonts) {
           await document.fonts.ready;
         }
 
-        // Wait for images to load (cover + QR code)
-        // Use a longer timeout to ensure everything is ready
+        // Wait for images to load
         await new Promise(resolve => setTimeout(resolve, 1000));
 
         // Additional delay for iOS
@@ -180,14 +187,17 @@ export function SharePosterPreview({
       >
         {/* Modal */}
         <div
-          className="bg-card rounded-2xl max-w-sm w-full max-h-[90vh] overflow-y-auto shadow-xl"
+          className="bg-card rounded-2xl max-w-[420px] w-full max-h-[90vh] overflow-y-auto shadow-xl"
           onClick={(e) => e.stopPropagation()}
         >
           {/* Header */}
           <div className="flex items-center justify-between p-4 border-b border-border">
-            <h3 className="text-lg font-semibold text-foreground">
-              {t("teams.shareTeam")}
-            </h3>
+            <div className="flex items-center gap-2">
+              <Share2 className="w-5 h-5 text-amber-600" />
+              <h3 className="text-lg font-semibold text-foreground">
+                {t("teams.shareTeam")}
+              </h3>
+            </div>
             <button
               onClick={onClose}
               className="p-2 hover:bg-muted rounded-full transition-colors"
@@ -197,15 +207,14 @@ export function SharePosterPreview({
           </div>
 
           {/* Poster Preview */}
-          <div className="p-4 flex flex-col items-center">
-            {/* Hidden poster for generation - use opacity:0 instead of off-screen for iOS compatibility */}
+          <div className="p-4 flex flex-col items-center bg-gradient-to-b from-amber-50/50 to-background">
+            {/* Hidden poster for generation */}
             <div
               ref={posterRef}
               className="fixed top-0 left-0 pointer-events-none"
               style={{
                 opacity: 0,
                 zIndex: -1,
-                width: '340px',
               }}
               aria-hidden="true"
             >
@@ -215,27 +224,41 @@ export function SharePosterPreview({
                 locationName={teamLocation}
                 coverImage={processedCoverImage}
                 url={teamUrl}
-                qrHint={t("teams.qrCodeHint")}
-                footerText={t("teams.posterFooter")}
+                currentMembers={teamCurrentMembers}
+                maxMembers={teamMaxMembers}
+                leaderName={teamLeaderName}
+                leaderAvatar={teamLeaderAvatar}
               />
             </div>
 
             {/* Display generated poster */}
             {isGenerating ? (
-              <div className="w-[340px] h-[480px] bg-muted rounded-xl flex flex-col items-center justify-center">
-                <Loader2 className="w-8 h-8 animate-spin text-amber-600 mb-3" />
+              <div className="w-[280px] h-[498px] bg-muted rounded-2xl flex flex-col items-center justify-center shadow-lg">
+                <Loader2 className="w-10 h-10 animate-spin text-amber-600 mb-4" />
                 <p className="text-sm text-muted-foreground">
                   {t("teams.generatingPoster")}
                 </p>
+                <p className="text-xs text-muted-foreground/70 mt-2">
+                  正在生成精美海报...
+                </p>
               </div>
             ) : posterDataUrl ? (
-              <img
-                src={posterDataUrl}
-                alt="Team Poster"
-                className="w-[340px] rounded-xl shadow-lg"
-              />
+              <div className="relative">
+                <img
+                  src={posterDataUrl}
+                  alt="Team Poster"
+                  className="w-[280px] rounded-2xl shadow-2xl"
+                />
+                {/* Decorative corner */}
+                <div className="absolute -bottom-3 -right-3 w-8 h-8 bg-amber-500 rounded-full flex items-center justify-center shadow-lg">
+                  <CheckCircle className="w-4 h-4 text-white" />
+                </div>
+              </div>
             ) : error ? (
-              <div className="w-[340px] h-[480px] bg-muted rounded-xl flex flex-col items-center justify-center p-6">
+              <div className="w-[280px] h-[498px] bg-muted rounded-2xl flex flex-col items-center justify-center p-6">
+                <div className="w-12 h-12 rounded-full bg-red-100 flex items-center justify-center mb-3">
+                  <X className="w-6 h-6 text-red-500" />
+                </div>
                 <p className="text-sm text-red-500 mb-2">{error}</p>
                 <p className="text-xs text-muted-foreground">
                   {t("teams.posterGenerateFallback")}
@@ -244,9 +267,11 @@ export function SharePosterPreview({
             ) : null}
 
             {/* Hint */}
-            <p className="mt-3 text-xs text-center text-muted-foreground">
-              {t("teams.saveImageHint")}
-            </p>
+            <div className="mt-4 text-center">
+              <p className="text-xs text-muted-foreground">
+                {t("teams.saveImageHint")}
+              </p>
+            </div>
           </div>
 
           {/* Actions */}
@@ -255,9 +280,9 @@ export function SharePosterPreview({
             <button
               onClick={handleSaveImage}
               disabled={!posterDataUrl}
-              className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-amber-600 text-white rounded-xl font-medium hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="w-full flex items-center justify-center gap-2 px-4 py-3.5 bg-amber-600 text-white rounded-xl font-medium hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors shadow-lg shadow-amber-200/50"
             >
-              <Download className="w-4 h-4" />
+              <Download className="w-5 h-5" />
               {t("teams.saveToAlbum")}
             </button>
 

--- a/frontend/src/components/features/team-detail/share-poster-preview.tsx
+++ b/frontend/src/components/features/team-detail/share-poster-preview.tsx
@@ -239,7 +239,7 @@ export function SharePosterPreview({
                   {t("teams.generatingPoster")}
                 </p>
                 <p className="text-xs text-muted-foreground/70 mt-2">
-                  正在生成精美海报...
+                  {t("teams.posterGeneratingDesc")}
                 </p>
               </div>
             ) : posterDataUrl ? (

--- a/frontend/src/components/features/team-detail/team-detail-bottom-bar.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-bottom-bar.tsx
@@ -232,6 +232,10 @@ function BottomBarLeader({ ctx, team, location }: { ctx: ReturnType<typeof useTe
         teamLocation={location?.name}
         teamCoverImage={location?.coverImage}
         teamUrl={window.location.href}
+        teamCurrentMembers={team.currentMembers}
+        teamMaxMembers={team.maxMembers}
+        teamLeaderName={team.leader?.nickname || team.leader?.name}
+        teamLeaderAvatar={team.leader?.avatar}
         onClose={share.closePreview}
       />
     </>
@@ -274,6 +278,10 @@ function BottomBarMember({ ctx, team }: { ctx: ReturnType<typeof useTeamDetail>;
         teamLocation={location?.name}
         teamCoverImage={location?.coverImage}
         teamUrl={window.location.href}
+        teamCurrentMembers={team.currentMembers}
+        teamMaxMembers={team.maxMembers}
+        teamLeaderName={team.leader?.nickname || team.leader?.name}
+        teamLeaderAvatar={team.leader?.avatar}
         onClose={share.closePreview}
       />
     </>
@@ -315,6 +323,10 @@ function BottomBarPending({ ctx, team }: { ctx: ReturnType<typeof useTeamDetail>
         teamLocation={location?.name}
         teamCoverImage={location?.coverImage}
         teamUrl={window.location.href}
+        teamCurrentMembers={team.currentMembers}
+        teamMaxMembers={team.maxMembers}
+        teamLeaderName={team.leader?.nickname || team.leader?.name}
+        teamLeaderAvatar={team.leader?.avatar}
         onClose={share.closePreview}
       />
     </>
@@ -364,6 +376,10 @@ function BottomBarCanJoin({ ctx, team }: { ctx: ReturnType<typeof useTeamDetail>
         teamLocation={location?.name}
         teamCoverImage={location?.coverImage}
         teamUrl={window.location.href}
+        teamCurrentMembers={team.currentMembers}
+        teamMaxMembers={team.maxMembers}
+        teamLeaderName={team.leader?.nickname || team.leader?.name}
+        teamLeaderAvatar={team.leader?.avatar}
         onClose={share.closePreview}
       />
     </>
@@ -399,6 +415,10 @@ function BottomBarCannotJoin({ ctx, team }: { ctx: ReturnType<typeof useTeamDeta
         teamLocation={location?.name}
         teamCoverImage={location?.coverImage}
         teamUrl={window.location.href}
+        teamCurrentMembers={team.currentMembers}
+        teamMaxMembers={team.maxMembers}
+        teamLeaderName={team.leader?.nickname || team.leader?.name}
+        teamLeaderAvatar={team.leader?.avatar}
         onClose={share.closePreview}
       />
     </>

--- a/frontend/src/components/features/team-detail/team-detail-sidebar.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-sidebar.tsx
@@ -104,6 +104,10 @@ export function TeamSidebar({ ctx }: { ctx: ReturnType<typeof useTeamDetail>; })
           teamLocation={location?.name}
           teamCoverImage={location?.coverImage}
           teamUrl={window.location.href}
+          teamCurrentMembers={team.currentMembers}
+          teamMaxMembers={team.maxMembers}
+          teamLeaderName={team.leader?.nickname || team.leader?.name}
+          teamLeaderAvatar={team.leader?.avatar}
           onClose={share.closePreview}
         />
       </React.Suspense>

--- a/frontend/src/components/features/team-detail/team-poster-content.tsx
+++ b/frontend/src/components/features/team-detail/team-poster-content.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import QRCode from "qrcode";
 import { MapPin, Calendar, Users, Mountain } from "lucide-react";
+import { useI18n } from "@/hooks/useI18n";
 
 interface TeamPosterContentProps {
   title: string;
@@ -27,6 +28,7 @@ export function TeamPosterContent({
   leaderName,
   leaderAvatar,
 }: TeamPosterContentProps) {
+  const { t } = useI18n(["teams"]);
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
   const [coverError, setCoverError] = useState(false);
 
@@ -74,7 +76,9 @@ export function TeamPosterContent({
               background: "rgba(217, 119, 6, 0.85)",
             }}
           >
-            {remaining > 0 ? `还差 ${remaining} 人` : "即将满员"}
+            {remaining > 0
+              ? t("teams.posterSpotsLeft", { count: remaining })
+              : t("teams.posterAlmostFull")}
           </div>
         </div>
 
@@ -119,7 +123,7 @@ export function TeamPosterContent({
               <Calendar className="w-4 h-4 text-amber-600" />
             </div>
             <div>
-              <p className="text-xs text-stone-500">出发日期</p>
+              <p className="text-xs text-stone-500">{t("teams.posterDateLabel")}</p>
               <p className="text-sm font-semibold text-stone-800">{date}</p>
             </div>
           </div>
@@ -134,7 +138,7 @@ export function TeamPosterContent({
                 <MapPin className="w-4 h-4 text-stone-600" />
               </div>
               <div>
-                <p className="text-xs text-stone-500">活动地点</p>
+                <p className="text-xs text-stone-500">{t("teams.posterLocationLabel")}</p>
                 <p className="text-sm font-semibold text-stone-800">{locationName}</p>
               </div>
             </div>
@@ -149,9 +153,9 @@ export function TeamPosterContent({
               <Users className="w-4 h-4 text-emerald-600" />
             </div>
             <div className="flex-1">
-              <p className="text-xs text-stone-500">队伍人数</p>
+              <p className="text-xs text-stone-500">{t("teams.posterMembersLabel")}</p>
               <p className="text-sm font-semibold text-stone-800">
-                {currentMembers}/{maxMembers} 人
+                {t("teams.posterMemberCount", { current: currentMembers, max: maxMembers })}
               </p>
             </div>
             {/* Progress bar */}
@@ -184,7 +188,7 @@ export function TeamPosterContent({
               </div>
             )}
             <div>
-              <p className="text-xs text-stone-500">领队</p>
+              <p className="text-xs text-stone-500">{t("teams.posterLeaderLabel")}</p>
               <p className="text-sm font-semibold text-stone-800">{leaderName}</p>
             </div>
           </div>
@@ -222,10 +226,10 @@ export function TeamPosterContent({
           {/* QR Hint */}
           <div className="mt-4 text-center">
             <p className="text-base font-semibold text-amber-700 mb-1">
-              扫码加入队伍
+              {t("teams.posterQrHint")}
             </p>
             <p className="text-xs text-stone-400">
-              gomate.live · 发现趣处，组队同行
+              {t("teams.posterFooter")}
             </p>
           </div>
         </div>

--- a/frontend/src/components/features/team-detail/team-poster-content.tsx
+++ b/frontend/src/components/features/team-detail/team-poster-content.tsx
@@ -2,10 +2,7 @@
 
 import { useEffect, useState } from "react";
 import QRCode from "qrcode";
-import { Mountain } from "lucide-react";
-
-const ZPIX_FONT_URL =
-  "https://cdn.jsdelivr.net/gh/SolidZORO/zpix-pixel-font@master/website/zpix.woff2";
+import { MapPin, Calendar, Users, Mountain } from "lucide-react";
 
 interface TeamPosterContentProps {
   title: string;
@@ -13,8 +10,10 @@ interface TeamPosterContentProps {
   locationName?: string;
   coverImage?: string;
   url: string;
-  qrHint: string;
-  footerText: string;
+  currentMembers?: number;
+  maxMembers?: number;
+  leaderName?: string;
+  leaderAvatar?: string | null;
 }
 
 export function TeamPosterContent({
@@ -23,105 +22,233 @@ export function TeamPosterContent({
   locationName,
   coverImage,
   url,
-  qrHint,
-  footerText,
+  currentMembers = 1,
+  maxMembers = 5,
+  leaderName,
+  leaderAvatar,
 }: TeamPosterContentProps) {
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
   const [coverError, setCoverError] = useState(false);
 
   useEffect(() => {
     QRCode.toDataURL(url, {
-      width: 180,
+      width: 200,
       margin: 2,
-      color: { dark: "#1c1917", light: "#ffffff" },
+      color: { dark: "#92400E", light: "#ffffff" },
     }).then(setQrDataUrl);
   }, [url]);
 
+  // Calculate progress
+  const progress = Math.min((currentMembers / maxMembers) * 100, 100);
+  const remaining = maxMembers - currentMembers;
+
   return (
     <div
-      className="flex w-[340px] flex-col bg-white rounded-2xl overflow-hidden shadow-lg"
-      style={{ fontFamily: "'Zpix', system-ui, sans-serif" }}
+      className="flex w-[375px] flex-col bg-white overflow-hidden"
+      style={{
+        fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+      }}
     >
-      <style>{`
-        @font-face {
-          font-family: 'Zpix';
-          src: url('${ZPIX_FONT_URL}') format('woff2');
-          font-weight: normal;
-          font-style: normal;
-          font-display: swap;
-        }
-      `}</style>
-
-      {/* Cover Image - only render if loaded successfully */}
-      {coverImage && !coverError && (
-        <div className="w-full h-[120px] overflow-hidden">
+      {/* Cover Image Section */}
+      <div className="relative w-full h-[220px] overflow-hidden">
+        {coverImage && !coverError ? (
           <img
             src={coverImage}
             alt={locationName || "Location"}
             className="w-full h-full object-cover"
-            data-cover="true"
             onError={() => setCoverError(true)}
           />
-        </div>
-      )}
+        ) : (
+          <div className="w-full h-full bg-gradient-to-br from-amber-400 to-orange-500 flex items-center justify-center">
+            <Mountain className="w-16 h-16 text-white/60" />
+          </div>
+        )}
+        {/* Gradient overlay */}
+        <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent" />
 
-      {/* Header - GoMate Logo */}
-      <div className="flex items-center justify-center py-4 bg-gradient-to-r from-amber-500 to-amber-600">
-        <div className="flex items-center gap-2 text-white">
-          <Mountain className="w-5 h-5" />
-          <span className="text-sm font-semibold tracking-wide">GoMate</span>
+        {/* Status badge */}
+        <div className="absolute top-4 left-4">
+          <div
+            className="px-3 py-1.5 rounded-full text-xs font-semibold text-white backdrop-blur-md"
+            style={{
+              background: "rgba(217, 119, 6, 0.85)",
+            }}
+          >
+            {remaining > 0 ? `还差 ${remaining} 人` : "即将满员"}
+          </div>
+        </div>
+
+        {/* GoMate Logo */}
+        <div className="absolute top-4 right-4 flex items-center gap-1.5 text-white">
+          <div
+            className="w-7 h-7 rounded-lg flex items-center justify-center"
+            style={{ background: "rgba(255, 255, 255, 0.2)" }}
+          >
+            <Mountain className="w-4 h-4" />
+          </div>
+          <span className="text-xs font-semibold">GoMate</span>
         </div>
       </div>
 
-      {/* Content Area */}
-      <div className="flex flex-col px-6 py-5">
+      {/* Content Section */}
+      <div className="relative flex flex-col px-6 pt-6 pb-8">
+        {/* Decorative background */}
+        <div
+          className="absolute top-0 left-0 right-0 h-32 -z-10"
+          style={{
+            background: "linear-gradient(180deg, #FEF3C7 0%, #ffffff 100%)",
+          }}
+        />
+
         {/* Title */}
-        <h2
-          className="text-lg leading-tight text-stone-900 mb-4"
-          style={{ fontFamily: "'Zpix', monospace" }}
+        <h1
+          className="text-xl font-bold text-stone-900 mb-4 leading-snug"
+          style={{ lineHeight: "1.4" }}
         >
           {title}
-        </h2>
+        </h1>
 
-        {/* Date */}
-        <div className="flex items-center gap-2 text-sm text-stone-600 mb-2">
-          <span className="text-amber-600">📅</span>
-          <span>{date}</span>
+        {/* Info Cards */}
+        <div className="space-y-3 mb-5">
+          {/* Date */}
+          <div className="flex items-center gap-3 p-3 rounded-xl bg-amber-50/80">
+            <div
+              className="w-9 h-9 rounded-lg flex items-center justify-center"
+              style={{ background: "rgba(217, 119, 6, 0.15)" }}
+            >
+              <Calendar className="w-4 h-4 text-amber-600" />
+            </div>
+            <div>
+              <p className="text-xs text-stone-500">出发日期</p>
+              <p className="text-sm font-semibold text-stone-800">{date}</p>
+            </div>
+          </div>
+
+          {/* Location */}
+          {locationName && (
+            <div className="flex items-center gap-3 p-3 rounded-xl bg-stone-50/80">
+              <div
+                className="w-9 h-9 rounded-lg flex items-center justify-center"
+                style={{ background: "rgba(120, 113, 108, 0.1)" }}
+              >
+                <MapPin className="w-4 h-4 text-stone-600" />
+              </div>
+              <div>
+                <p className="text-xs text-stone-500">活动地点</p>
+                <p className="text-sm font-semibold text-stone-800">{locationName}</p>
+              </div>
+            </div>
+          )}
+
+          {/* Members */}
+          <div className="flex items-center gap-3 p-3 rounded-xl bg-emerald-50/80">
+            <div
+              className="w-9 h-9 rounded-lg flex items-center justify-center"
+              style={{ background: "rgba(16, 185, 129, 0.15)" }}
+            >
+              <Users className="w-4 h-4 text-emerald-600" />
+            </div>
+            <div className="flex-1">
+              <p className="text-xs text-stone-500">队伍人数</p>
+              <p className="text-sm font-semibold text-stone-800">
+                {currentMembers}/{maxMembers} 人
+              </p>
+            </div>
+            {/* Progress bar */}
+            <div className="w-16 h-2 bg-stone-200 rounded-full overflow-hidden">
+              <div
+                className="h-full rounded-full bg-emerald-500"
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+          </div>
         </div>
 
-        {/* Location */}
-        {locationName && (
-          <div className="flex items-center gap-2 text-sm text-stone-600 mb-4">
-            <span className="text-amber-600">📍</span>
-            <span>{locationName}</span>
+        {/* Leader */}
+        {leaderName && (
+          <div className="flex items-center gap-3 mb-5 p-3 rounded-xl border border-stone-100">
+            {leaderAvatar ? (
+              <img
+                src={leaderAvatar}
+                alt={leaderName}
+                className="w-10 h-10 rounded-full object-cover"
+              />
+            ) : (
+              <div
+                className="w-10 h-10 rounded-full flex items-center justify-center text-white text-sm font-bold"
+                style={{
+                  background: "linear-gradient(135deg, #D97706 0%, #FCD34D 100%)",
+                }}
+              >
+                {leaderName.charAt(0).toUpperCase()}
+              </div>
+            )}
+            <div>
+              <p className="text-xs text-stone-500">领队</p>
+              <p className="text-sm font-semibold text-stone-800">{leaderName}</p>
+            </div>
           </div>
         )}
 
-        {/* Divider */}
-        <div className="w-full h-px bg-stone-200 my-4" />
+        {/* Divider with decorative dots */}
+        <div className="flex items-center gap-2 mb-5">
+          <div className="flex-1 h-px bg-stone-200" />
+          <div className="flex gap-1">
+            <div className="w-1.5 h-1.5 rounded-full bg-amber-400" />
+            <div className="w-1.5 h-1.5 rounded-full bg-amber-500" />
+            <div className="w-1.5 h-1.5 rounded-full bg-amber-600" />
+          </div>
+          <div className="flex-1 h-px bg-stone-200" />
+        </div>
 
-        {/* QR Code */}
+        {/* QR Code Section */}
         <div className="flex flex-col items-center">
-          {qrDataUrl && (
-            <div className="rounded-xl bg-white p-3 shadow-md border border-stone-100">
+          {/* QR Container with shadow */}
+          <div
+            className="rounded-2xl bg-white p-4 shadow-lg border border-stone-100"
+            style={{
+              boxShadow: "0 10px 40px -10px rgba(217, 119, 6, 0.2)",
+            }}
+          >
+            {qrDataUrl && (
               <img
                 src={qrDataUrl}
                 alt="QR Code"
-                className="w-32 h-32"
+                className="w-36 h-36"
               />
-            </div>
-          )}
-          <p className="mt-3 text-xs text-stone-500">
-            {qrHint}
-          </p>
+            )}
+          </div>
+
+          {/* QR Hint */}
+          <div className="mt-4 text-center">
+            <p className="text-base font-semibold text-amber-700 mb-1">
+              扫码加入队伍
+            </p>
+            <p className="text-xs text-stone-400">
+              gomate.live · 发现趣处，组队同行
+            </p>
+          </div>
         </div>
       </div>
 
-      {/* Footer */}
-      <div className="py-3 bg-stone-50 border-t border-stone-100">
-        <p className="text-center text-xs text-stone-400">
-          {footerText}
-        </p>
+      {/* Bottom decorative pattern */}
+      <div className="relative h-16 overflow-hidden">
+        <svg
+          className="absolute bottom-0 w-full"
+          viewBox="0 0 375 60"
+          preserveAspectRatio="none"
+        >
+          <path
+            d="M0,60 L0,40 Q93.75,20 187.5,40 Q281.25,60 375,40 L375,60 Z"
+            fill="#FEF3C7"
+            opacity="0.5"
+          />
+          <path
+            d="M0,60 L0,50 Q93.75,30 187.5,50 Q281.25,70 375,50 L375,60 Z"
+            fill="#FDE68A"
+            opacity="0.3"
+          />
+        </svg>
       </div>
     </div>
   );


### PR DESCRIPTION
## 重新设计内容

参考小红书/朋友圈分享最佳实践，重新设计队伍分享海报。

### 改进点

1. **尺寸优化** → 375x667（9:16 竖版），更适合手机分享
2. **视觉层次** → 地点封面大图 + 毛玻璃信息卡片 + QR Code
3. **信息丰富** → 新增队伍人数进度条、领队信息展示
4. **装饰元素** → 琥珀色渐变、底部波浪图案、状态徽章
5. **品牌露出** → GoMate Logo + "扫码加入队伍"更醒目
6. **UX 优化** → 弹窗预览带装饰角标、生成 loading 状态更友好

### 改动文件

- `team-poster-content.tsx` — 海报内容组件重写
- `share-poster-preview.tsx` — 预览弹窗优化
- `team-detail-sidebar.tsx` — 传递新 props（队伍人数、领队信息）
- `team-detail-bottom-bar.tsx` — 传递新 props

### 截图对比

| 旧版 | 新版 |
|------|------|
| 340x480 小尺寸 | 375x667 9:16 竖版 |
| 简单布局 | 封面大图 + 毛玻璃卡片 |
| 信息较少 | 人数进度 + 领队信息 |

## 验证

- TypeScript 检查通过
- 海报生成正常
- 多语言支持