### PR TITLE
fix: 修复海报生成时的屏幕闪烁问题

### DIFF
--- a/frontend/public/locales/en/teams.json
+++ b/frontend/public/locales/en/teams.json
@@ -442,5 +442,5 @@
   "posterMemberCount": "{current}/{max} people",
   "posterLeaderLabel": "Leader",
   "posterQrHint": "Scan to join team",
-  "posterGeneratingDesc": "Generating beautiful poster...",
+  "posterGeneratingDesc": "Generating beautiful poster..."
 }

--- a/frontend/public/locales/ja/teams.json
+++ b/frontend/public/locales/ja/teams.json
@@ -442,5 +442,5 @@
   "posterMemberCount": "{current}/{max}名",
   "posterLeaderLabel": "リーダー",
   "posterQrHint": "スキャンしてチームに参加",
-  "posterGeneratingDesc": "素敵なシェア画像を生成中...",
+  "posterGeneratingDesc": "素敵なシェア画像を生成中..."
 }

--- a/frontend/public/locales/zh-CN/teams.json
+++ b/frontend/public/locales/zh-CN/teams.json
@@ -442,5 +442,5 @@
   "posterMemberCount": "{current}/{max} 人",
   "posterLeaderLabel": "领队",
   "posterQrHint": "扫码加入队伍",
-  "posterGeneratingDesc": "正在生成精美海报...",
+  "posterGeneratingDesc": "正在生成精美海报..."
 }

--- a/frontend/src/components/features/team-detail/share-poster-preview.tsx
+++ b/frontend/src/components/features/team-detail/share-poster-preview.tsx
@@ -104,18 +104,15 @@ export function SharePosterPreview({
           await new Promise(resolve => setTimeout(resolve, 500));
         }
 
-        // Ensure element is visible for capture
-        const originalStyle = posterRef.current.style.cssText;
-        posterRef.current.style.cssText = originalStyle + '; visibility: visible !important; opacity: 1 !important;';
+        // Ensure element is visible for capture - element is already off-screen
+        // No need to toggle visibility, preventing screen flash
+        await new Promise(resolve => requestAnimationFrame(resolve));
 
         const dataUrl = await toPng(posterRef.current, {
           pixelRatio: 2,
           cacheBust: true,
           backgroundColor: '#ffffff',
         });
-
-        // Restore original style
-        posterRef.current.style.cssText = originalStyle;
 
         // Validate generated image
         if (!dataUrl || dataUrl.length < 1000) {
@@ -208,13 +205,16 @@ export function SharePosterPreview({
 
           {/* Poster Preview */}
           <div className="p-4 flex flex-col items-center bg-gradient-to-b from-amber-50/50 to-background">
-            {/* Hidden poster for generation */}
+            {/* Hidden poster for generation - off-screen to avoid flash */}
             <div
               ref={posterRef}
-              className="fixed top-0 left-0 pointer-events-none"
+              className="absolute pointer-events-none"
               style={{
-                opacity: 0,
-                zIndex: -1,
+                position: 'absolute',
+                left: '-9999px',
+                top: '-9999px',
+                opacity: 1,
+                visibility: 'visible',
               }}
               aria-hidden="true"
             >


### PR DESCRIPTION
## 问题描述

点击分享海报生成时，等待过程中屏幕会闪烁出隐藏元素。

## 根因分析

- 隐藏元素使用 `opacity: 0` + `zIndex: -1` 仍可能短暂显示
- 生成时临时修改 `visibility: visible !important; opacity: 1 !important;` 导致样式切换闪烁

## 修复方案

1. **将隐藏元素移至视口外**：`left: -9999px, top: -9999px`
2. **使用 absolute 定位**：替代 fixed 定位
3. **移除样式切换逻辑**：不再需要临时修改 visibility/opacity
4. **使用 requestAnimationFrame**：确保帧同步

## 改动

```diff
- className="fixed top-0 left-0 pointer-events-none"
- style={{ opacity: 0, zIndex: -1 }}

+ className="absolute pointer-events-none"
+ style={{ position: 'absolute', left: '-9999px', top: '-9999px' }}
```

## 验证

- 海报生成正常
- 无屏幕闪烁
- 保存图片功能正常