### PR TITLE
fix: 修复海报生成空白和闪烁问题

### DIFF
--- a/frontend/src/components/features/team-detail/share-poster-preview.tsx
+++ b/frontend/src/components/features/team-detail/share-poster-preview.tsx
@@ -104,10 +104,7 @@ export function SharePosterPreview({
           await new Promise(resolve => setTimeout(resolve, 500));
         }
 
-        // Ensure element is visible for capture - element is already off-screen
-        // No need to toggle visibility, preventing screen flash
-        await new Promise(resolve => requestAnimationFrame(resolve));
-
+        // Generate poster - element is already rendered off-screen
         const dataUrl = await toPng(posterRef.current, {
           pixelRatio: 2,
           cacheBust: true,
@@ -205,16 +202,15 @@ export function SharePosterPreview({
 
           {/* Poster Preview */}
           <div className="p-4 flex flex-col items-center bg-gradient-to-b from-amber-50/50 to-background">
-            {/* Hidden poster for generation - off-screen to avoid flash */}
+            {/* Hidden poster for generation - positioned off-screen to avoid flash */}
             <div
               ref={posterRef}
-              className="absolute pointer-events-none"
+              className="pointer-events-none"
               style={{
-                position: 'absolute',
+                position: 'fixed',
                 left: '-9999px',
                 top: '-9999px',
-                opacity: 1,
-                visibility: 'visible',
+                width: '375px',
               }}
               aria-hidden="true"
             >


### PR DESCRIPTION
## 问题
PR #140 修复闪烁问题时引入新问题：海报生成空白。

## 根因分析
- `left: -9999px` 将元素移出视口，html-to-image 无法捕获视口外元素
- `opacity: 0` 导致 Canvas 渲染为透明像素

## 修复方案（基于 @Steven 建议）
```tsx
// Hidden poster for generation
style={{
  position: 'fixed',
  left: '-9999px',
  top: '-9999px',
  width: '375px',  // 固定宽度确保渲染
}}
```

**关键点**：
- 不使用 `opacity: 0`，html-to-image 可正常捕获
- 元素移出视口，无闪烁
- 简化生成逻辑，无需临时样式切换

## 改动
- `share-poster-preview.tsx`: 调整隐藏样式和生成逻辑

## 测试验证
- [ ] 海报正常生成（无空白）
- [ ] 无闪烁问题
- [ ] iOS Safari 保存流程
- [ ] Android 下载保存

## Related
- Fixes PR #140 引入的问题
- Co-authored with @Steven