### PR TITLE
fix: 移动端底部布局优化

### DIFF
--- a/frontend/src/components/features/team-detail/team-detail-main.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-main.tsx
@@ -40,7 +40,7 @@ export function TeamDetailPartiful({ teamId }: TeamDetailPartifulProps) {
   return (
     <main className="min-h-screen bg-background flex flex-col">
       <Navbar />
-      <div className="flex-1 max-w-7xl mx-auto px-6 py-8 lg:py-12">
+      <div className="flex-1 max-w-7xl mx-auto px-6 py-8 lg:py-12 pb-24 lg:pb-12">
         <div className="grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-8 lg:gap-12">
           <TeamSidebar ctx={ctx} />
           <TeamMainContent ctx={ctx} />


### PR DESCRIPTION
## 问题
队伍详情页移动端底部固定导航栏遮挡页面内容

## 修复
- 添加 pb-24 (96px) 移动端底部 padding，为固定导航栏预留空间
- 保留 lg:pb-12 桌面端正常 padding

## 测试
- [ ] 移动端内容不被底部导航栏遮挡
- [ ] 桌面端布局正常

## 构建
✓ 通过