### PR TITLE
feat: 分享图生成迁移到服务端 (Satori + resvg-wasm)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,9 +123,6 @@ importers:
       framer-motion:
         specifier: ^11.0.0
         version: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      html-to-image:
-        specifier: ^1.11.13
-        version: 1.11.13
       lucide-react:
         specifier: ^0.460.0
         version: 0.460.0(react@18.3.1)
@@ -3429,9 +3426,6 @@ packages:
 
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
-
-  html-to-image@1.11.13:
-    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
@@ -8085,8 +8079,6 @@ snapshots:
   html-escaper@2.0.2: {}
 
   html-escaper@3.0.3: {}
-
-  html-to-image@1.11.13: {}
 
   html-to-text@9.0.5:
     dependencies:


### PR DESCRIPTION
## 变更摘要

完整实现分享图生成的服务端迁移，替代原有的 html-to-image 客户端方案。

## 主要变更

### Phase 1: 基础能力验证
- 新增  端点用于测试 Satori + resvg-wasm

### Phase 2: 地点分享图
- 新增  端点
- 地点海报 Satori 模板 (location-poster.tsx)
- D1 查询 + 标签渲染
- R2 缓存 (content-hash based)

### Phase 3: 队伍分享图
- 新增  端点
- 队伍海报 Satori 模板 (team-poster.tsx)
- 动态进度条 + 队长头像
- R2 缓存

### Phase 4: 前端改造
- 删除 html-to-image 依赖
- 新建 useShareImage() Hook
- 重写 SharePosterModal / SharePosterPreview

### Phase 5: SEO 支持
- Layout.astro 添加 og:image meta 标签
- 地点/队伍详情页 SSR + og:image

## 技术栈
- Satori: JSX-to-SVG 渲染
- resvg-wasm: SVG-to-PNG 转换
- Cloudflare Workers + R2 缓存

## 测试
- [ ] API 端点测试
- [ ] 前端弹窗测试
- [ ] iOS Safari 下载测试
- [ ] og:image 验证