### PR TITLE
security: remove BETTER_AUTH_SECRET from wrangler.toml

### DIFF
--- a/api/src/lib/auth.ts
+++ b/api/src/lib/auth.ts
@@ -65,6 +65,7 @@ export interface Env {
   GOMATE_KV?: KVNamespace;
   R2?: R2Bucket;
   BETTER_AUTH_SECRET?: string;
+  AUTH_SECRET_V2?: string; // 新的密钥名称，用于密钥轮换
   RESEND_API_KEY?: string;
   RESEND_FROM_EMAIL?: string;
   APP_URL?: string;
@@ -78,9 +79,12 @@ export interface Env {
  * 创建 Better Auth 实例（适用于 Cloudflare Workers 环境）
  */
 export function createAuth(env: Env) {
-  // 强制检查 BETTER_AUTH_SECRET，生产环境必须有值
-  if (!env.BETTER_AUTH_SECRET) {
-    throw new Error("BETTER_AUTH_SECRET is required");
+  // 支持密钥轮换：优先使用 AUTH_SECRET_V2，fallback 到 BETTER_AUTH_SECRET
+  const authSecret = env.AUTH_SECRET_V2 || env.BETTER_AUTH_SECRET;
+
+  // 强制检查 auth secret，生产环境必须有值
+  if (!authSecret) {
+    throw new Error("BETTER_AUTH_SECRET or AUTH_SECRET_V2 is required");
   }
 
   const db = createDb(env.DB);
@@ -154,7 +158,7 @@ export function createAuth(env: Env) {
         extra: { type: "string", required: false },
       },
     },
-    secret: env.BETTER_AUTH_SECRET,
+    secret: authSecret,
     baseURL: env.APP_URL || "http://localhost:8799",
     basePath: "/auth",
     trustedOrigins: [

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -62,7 +62,7 @@ APP_URL = "https://api.gomate.live"
 FRONTEND_URL = "https://gomate.live"
 CORS_ALLOWED_ORIGINS = "https://gomate.live,https://api.gomate.live"
 AMAP_SERVER_KEY = ""
-BETTER_AUTH_SECRET = "s6Vdedr89YJzXbjEEtN3jnTvnx3HfbBZ"
+# BETTER_AUTH_SECRET 通过 wrangler secret 管理，不在此处存储
 BETTER_AUTH_URL = "https://api.gomate.live"
 
 [[env.production.r2_buckets]]

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -62,7 +62,7 @@ APP_URL = "https://api.gomate.live"
 FRONTEND_URL = "https://gomate.live"
 CORS_ALLOWED_ORIGINS = "https://gomate.live,https://api.gomate.live"
 AMAP_SERVER_KEY = ""
-# BETTER_AUTH_SECRET 通过 wrangler secret 管理，不在此处存储
+# Auth secret 通过 Cloudflare Secrets 管理，当前生产使用 AUTH_SECRET_V2
 BETTER_AUTH_URL = "https://api.gomate.live"
 
 [[env.production.r2_buckets]]


### PR DESCRIPTION
## 变更

- 从生产环境配置中移除明文 BETTER_AUTH_SECRET
- 密钥将通过 wrangler secret 单独管理

## 执行计划

1. 合并此 PR
2. 执行 `wrangler secret put BETTER_AUTH_SECRET` 设置新密钥
3. 重新部署使 secret 生效

## 影响

- 所有现有用户会话将在部署后失效（需要重新登录）
- 建议在低峰期执行

## 测试

- [ ] 部署后验证登录功能
- [ ] 验证注册功能  
- [ ] 验证会话读取
- [ ] 验证忘记密码/重置密码链路