### PR TITLE
perf(frontend): add lazy loading to activity-posts images

### DIFF
--- a/frontend/src/components/features/activity-posts/image-grid.tsx
+++ b/frontend/src/components/features/activity-posts/image-grid.tsx
@@ -54,6 +54,8 @@ export function ImageGrid({ images, maxImages = 3, className }: ImageGridProps) 
           <img
             src={displayImages[0]}
             alt="Activity photo"
+            loading="lazy"
+            decoding="async"
             className="w-full h-auto max-h-64 object-cover hover:scale-105 transition-transform duration-300"
           />
         </div>
@@ -67,6 +69,7 @@ export function ImageGrid({ images, maxImages = 3, className }: ImageGridProps) 
             <img
               src={currentImage}
               alt="Activity photo"
+              loading="eager"
               className="max-w-full max-h-[80vh] object-contain rounded-lg"
             />
           </div>
@@ -93,6 +96,8 @@ export function ImageGrid({ images, maxImages = 3, className }: ImageGridProps) 
             <img
               src={image}
               alt={`Activity photo ${index + 1}`}
+              loading="lazy"
+              decoding="async"
               className="w-full h-full object-cover hover:scale-105 transition-transform duration-300"
             />
             {hasMore && index === maxImages - 1 && (
@@ -113,6 +118,7 @@ export function ImageGrid({ images, maxImages = 3, className }: ImageGridProps) 
           <img
             src={currentImage}
             alt="Activity photo"
+            loading="eager"
             className="max-w-full max-h-[80vh] object-contain rounded-lg"
           />
         </div>


### PR DESCRIPTION
## Changes

- Add loading="lazy" and decoding="async" to all images in image-grid.tsx
- Use loading="eager" for lightbox modal images for immediate display
- Improves page load performance by deferring off-screen images

## Related Task

Task #7: 图片加载优化：添加 lazy loading

## Testing

- Verified images load correctly with lazy loading enabled
- Lightbox images still load immediately when opened