### PR TITLE
fix(discover): fix React hydration warning in story cards

### DIFF
--- a/frontend/src/components/features/discover/featured-story-card.tsx
+++ b/frontend/src/components/features/discover/featured-story-card.tsx
@@ -48,7 +48,10 @@ export function FeaturedStoryCard({ story, onClick, className }: FeaturedStoryCa
 
   const formatDate = (timestamp: number) => {
     const date = new Date(timestamp);
-    return date.toLocaleDateString("zh-CN", { month: "short", day: "numeric" });
+    // 使用固定格式避免 hydration mismatch
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    return `${month}月${day}日`;
   };
 
   return (
@@ -126,7 +129,7 @@ export function FeaturedStoryCard({ story, onClick, className }: FeaturedStoryCa
             {story.author?.name || t("content.discover.anonymous")}
           </span>
           <span className="text-muted-foreground/40">·</span>
-          <span className="text-sm text-muted-foreground shrink-0">{formatDate(story.createdAt)}</span>
+          <span className="text-sm text-muted-foreground shrink-0" suppressHydrationWarning>{formatDate(story.createdAt)}</span>
           {story.location && (
             <span className="ml-auto text-xs text-primary/80 bg-primary/5 px-2 py-0.5 rounded truncate max-w-[40%]">
               {story.location.name}

--- a/frontend/src/components/features/discover/story-card.tsx
+++ b/frontend/src/components/features/discover/story-card.tsx
@@ -47,6 +47,12 @@ export function StoryCard({ story, onClick, className }: StoryCardProps) {
     onClick?.(story);
   };
 
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
   const formatDate = (timestamp: number) => {
     const date = new Date(timestamp);
     const now = new Date();
@@ -55,7 +61,10 @@ export function StoryCard({ story, onClick, className }: StoryCardProps) {
     if (diffDays === 0) return t("content.discover.today");
     if (diffDays === 1) return t("content.discover.yesterday");
     if (diffDays < 7) return t("content.discover.daysAgo", { days: diffDays });
-    return date.toLocaleDateString("zh-CN", { month: "short", day: "numeric" });
+    // 使用固定格式避免 hydration mismatch
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    return `${month}月${day}日`;
   };
 
   return (
@@ -135,7 +144,7 @@ export function StoryCard({ story, onClick, className }: StoryCardProps) {
           <span className="text-muted-foreground/40">·</span>
 
           {/* 日期 */}
-          <span className="shrink-0">{formatDate(story.createdAt)}</span>
+          <span className="shrink-0" suppressHydrationWarning>{formatDate(story.createdAt)}</span>
 
           {/* 地点标签（如果有） */}
           {story.location && (

--- a/frontend/src/components/features/discover/story-detail.tsx
+++ b/frontend/src/components/features/discover/story-detail.tsx
@@ -118,11 +118,11 @@ export function StoryDetail({ storyId }: StoryDetailProps) {
 
   const formatDate = (timestamp: number) => {
     const date = new Date(timestamp);
-    return date.toLocaleDateString("zh-CN", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    });
+    // 使用固定格式避免 hydration mismatch
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    return `${year}年${month}月${day}日`;
   };
 
   // Loading state
@@ -211,7 +211,7 @@ export function StoryDetail({ storyId }: StoryDetailProps) {
               <p className="font-medium text-foreground">
                 {story.author?.name || t("content.discover.anonymous")}
               </p>
-              <p className="text-sm text-muted-foreground">
+              <p className="text-sm text-muted-foreground" suppressHydrationWarning>
                 {formatDate(story.createdAt)}
               </p>
             </div>


### PR DESCRIPTION
## Summary
Fix React hydration warning in Discover page story cards.

## Changes
- story-detail.tsx: Replace toLocaleDateString with fixed format
- story-card.tsx: Same fix, add suppressHydrationWarning
- featured-story-card.tsx: Same fix

## Root Cause
toLocaleDateString() and new Date() produce different output in SSR vs CSR.

## Solution
Use fixed format date string and add suppressHydrationWarning.

## Verification
- /discover page: no hydration warning
- /discover/story_001 page: no hydration warning

Fixes task #36