### PR TITLE
fix(home): center align hero and section texts

### DIFF
--- a/frontend/src/components/features/home/home-hero.tsx
+++ b/frontend/src/components/features/home/home-hero.tsx
@@ -44,7 +44,7 @@ export function HomeHero({ data }: { data: HomeData }) {
           <span className="block text-gradient-brand">{t("content.hero.titleLine2")}</span>
         </h1>
 
-        <p className={`text-lg md:text-xl text-muted-foreground mb-10 max-w-xl mx-auto leading-relaxed ${animate.subtitle}`}>{t("content.hero.description")}</p>
+        <p className={`text-lg md:text-xl text-muted-foreground mb-10 max-w-xl mx-auto leading-relaxed text-center ${animate.subtitle}`}>{t("content.hero.description")}</p>
 
         <div className={`relative max-w-2xl mx-auto mb-8 group ${animate.search}`}>
           <Search className="absolute left-4 sm:left-5 top-1/2 -translate-y-1/2 h-4 w-4 sm:h-5 sm:w-5 pointer-events-none transition-colors duration-200 text-muted-foreground"

--- a/frontend/src/components/features/home/home-how-it-works.tsx
+++ b/frontend/src/components/features/home/home-how-it-works.tsx
@@ -30,8 +30,8 @@ export function HomeHowItWorksSection({ sectionRef, isInView }: { sectionRef: Re
                 <div className="w-14 h-14 rounded-2xl flex items-center justify-center flex-shrink-0 text-2xl" style={{ background: item.bg }}>{item.emoji}</div>
                 <span className="text-5xl font-black leading-none select-none" style={{ color: item.bg.replace("0.08", "0.18") }}>{item.step}</span>
               </div>
-              <h3 className="text-xl font-bold mb-3" style={{ color: item.color }}>{item.title}</h3>
-              <p className="text-sm text-muted-foreground leading-relaxed flex-1 mb-5">{item.desc}</p>
+              <h3 className="text-xl font-bold mb-3 text-center" style={{ color: item.color }}>{item.title}</h3>
+              <p className="text-sm text-muted-foreground leading-relaxed flex-1 mb-5 text-center">{item.desc}</p>
               <a href={item.href}>
                 <button className="w-full py-2.5 rounded-xl text-sm font-semibold transition-all duration-150"
                   style={{ background: item.bg, color: item.color }}

--- a/frontend/src/components/features/home/home-locations-section.tsx
+++ b/frontend/src/components/features/home/home-locations-section.tsx
@@ -16,7 +16,7 @@ export function HomeLocationsSection({ data }: { data: HomeData }) {
         <div className="text-center mb-12">
           <span className="inline-block mb-4 px-3 py-1 text-xs font-semibold rounded-full uppercase tracking-widest bg-amber-50/80 dark:bg-amber-950/30 text-amber-800 dark:text-amber-300">{t("home.featuredLocations")}</span>
           <h2 className="text-4xl md:text-5xl font-bold text-foreground mb-4">{t("locations.pageTitle")}</h2>
-          <p className="text-muted-foreground max-w-2xl mx-auto leading-relaxed text-lg">{t("locations.pageSubtitle")}</p>
+          <p className="text-center text-muted-foreground max-w-xl mx-auto leading-relaxed text-lg">{t("locations.pageSubtitle")}</p>
         </div>
 
         {isLoading ? (

--- a/frontend/src/components/features/locations/locations-hero.tsx
+++ b/frontend/src/components/features/locations/locations-hero.tsx
@@ -52,12 +52,14 @@ export function LocationsHero({
       </div>
 
       <div className="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div
-          className="inline-flex items-center gap-2 px-3 py-1 rounded-full mb-4 text-xs font-medium"
-          style={{ background: "rgba(217,119,6,0.08)", border: "1px solid rgba(217,119,6,0.2)", color: "#b45309", animation: "fade-up 0.4s cubic-bezier(0.16, 1, 0.3, 1) both" }}
-        >
-          <Sparkles className="h-3 w-3" />
-          {t("locations.ctaHeroBadge")}
+        <div className="flex justify-center">
+          <div
+            className="inline-flex items-center gap-2 px-3 py-1 rounded-full mb-4 text-xs font-medium"
+            style={{ background: "rgba(217,119,6,0.08)", border: "1px solid rgba(217,119,6,0.2)", color: "#b45309", animation: "fade-up 0.4s cubic-bezier(0.16, 1, 0.3, 1) both" }}
+          >
+            <Sparkles className="h-3 w-3" />
+            {t("locations.ctaHeroBadge")}
+          </div>
         </div>
 
         <h1 className="text-3xl sm:text-4xl font-bold text-foreground mb-2 leading-tight text-center" style={{ animation: "fade-up 0.4s cubic-bezier(0.16, 1, 0.3, 1) 80ms both" }}>


### PR DESCRIPTION
修复首页文案居中问题

## 改动

1. **home-hero.tsx**: description 显式添加 text-center
2. **home-how-it-works.tsx**: 步骤卡片内的 h3 和 p 添加 text-center
3. **home-locations-section.tsx**: 
   - 副标题添加 text-center
   - max-w-2xl 改为 max-w-xl（避免文字过长）
4. **locations-hero.tsx**: badge 用 flex justify-center 包裹

## 验证
- 375px / 1440px 各分辨率下文案视觉居中

## 涉及的4句文案
- 极简「地点组队」平台，找到同行的人，出发就不远
- 咖啡馆、公园、山野、海岸，找到适合你的下一个目的地
- 极简流程，从发现到出发，最快 5 分钟
- 已有 200+ 伙伴在这里找到了同行的人，你也可以