### PR TITLE
fix: replace mx-auto with flex justify-center for text centering

### DIFF
--- a/frontend/src/components/features/home/home-cta-section.tsx
+++ b/frontend/src/components/features/home/home-cta-section.tsx
@@ -25,9 +25,11 @@ export function HomeCtaSection({ data }: { data: HomeData }) {
           {t("home.cta.subtitle")}
         </h2>
 
-        <p className="text-muted-foreground text-lg mb-10 max-w-xl mx-auto leading-relaxed">
-          {t("home.cta.description", { count: 200 })}
-        </p>
+        <div className="flex justify-center">
+          <p className="text-muted-foreground text-lg mb-10 w-full max-w-xl text-center leading-relaxed">
+            {t("home.cta.description", { count: 200 })}
+          </p>
+        </div>
 
         <div className="flex flex-col gap-4 justify-center items-center">
           <a href="/teams/create"

--- a/frontend/src/components/features/home/home-hero.tsx
+++ b/frontend/src/components/features/home/home-hero.tsx
@@ -44,7 +44,9 @@ export function HomeHero({ data }: { data: HomeData }) {
           <span className="block text-gradient-brand">{t("content.hero.titleLine2")}</span>
         </h1>
 
-        <p className={`text-lg md:text-xl text-muted-foreground mb-10 max-w-xl mx-auto leading-relaxed text-center ${animate.subtitle}`}>{t("content.hero.description")}</p>
+        <div className="flex justify-center">
+          <p className={`text-lg md:text-xl text-muted-foreground mb-10 w-full max-w-xl leading-relaxed text-center ${animate.subtitle}`}>{t("content.hero.description")}</p>
+        </div>
 
         <div className={`relative max-w-2xl mx-auto mb-8 group ${animate.search}`}>
           <Search className="absolute left-4 sm:left-5 top-1/2 -translate-y-1/2 h-4 w-4 sm:h-5 sm:w-5 pointer-events-none transition-colors duration-200 text-muted-foreground"

--- a/frontend/src/components/features/home/home-how-it-works.tsx
+++ b/frontend/src/components/features/home/home-how-it-works.tsx
@@ -17,7 +17,9 @@ export function HomeHowItWorksSection({ sectionRef, isInView }: { sectionRef: Re
         <div className="text-center mb-14">
           <span className="inline-block mb-4 px-3 py-1 text-xs font-semibold rounded-full uppercase tracking-widest bg-amber-50/80 dark:bg-amber-950/30 text-amber-800 dark:text-amber-300">{t("home.howItWorks.badge")}</span>
           <h2 className="text-4xl md:text-5xl font-bold text-foreground mb-4">{t("home.howItWorks.title")}</h2>
-          <p className="text-muted-foreground text-lg max-w-xl mx-auto leading-relaxed">{t("home.howItWorks.subtitle")}</p>
+          <div className="flex justify-center">
+            <p className="text-muted-foreground text-lg w-full max-w-xl leading-relaxed text-center">{t("home.howItWorks.subtitle")}</p>
+          </div>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">

--- a/frontend/src/components/features/home/home-locations-section.tsx
+++ b/frontend/src/components/features/home/home-locations-section.tsx
@@ -16,7 +16,9 @@ export function HomeLocationsSection({ data }: { data: HomeData }) {
         <div className="text-center mb-12">
           <span className="inline-block mb-4 px-3 py-1 text-xs font-semibold rounded-full uppercase tracking-widest bg-amber-50/80 dark:bg-amber-950/30 text-amber-800 dark:text-amber-300">{t("home.featuredLocations")}</span>
           <h2 className="text-4xl md:text-5xl font-bold text-foreground mb-4">{t("locations.pageTitle")}</h2>
-          <p className="text-center text-muted-foreground max-w-xl mx-auto leading-relaxed text-lg">{t("locations.pageSubtitle")}</p>
+          <div className="flex justify-center">
+            <p className="text-center text-muted-foreground w-full max-w-xl leading-relaxed text-lg">{t("locations.pageSubtitle")}</p>
+          </div>
         </div>
 
         {isLoading ? (

--- a/frontend/src/components/features/locations/locations-hero.tsx
+++ b/frontend/src/components/features/locations/locations-hero.tsx
@@ -65,9 +65,11 @@ export function LocationsHero({
         <h1 className="text-3xl sm:text-4xl font-bold text-foreground mb-2 leading-tight text-center" style={{ animation: "fade-up 0.4s cubic-bezier(0.16, 1, 0.3, 1) 80ms both" }}>
           {t("locations.pageTitle")}
         </h1>
-        <p className="text-stone-400 dark:text-stone-500 text-sm sm:text-base mb-7 leading-relaxed max-w-xl text-center mx-auto" style={{ animation: "fade-up 0.4s cubic-bezier(0.16, 1, 0.3, 1) 150ms both" }}>
-          {t("locations.pageSubtitle")}
-        </p>
+        <div className="flex justify-center">
+          <p className="text-stone-400 dark:text-stone-500 text-sm sm:text-base mb-7 leading-relaxed w-full max-w-xl text-center" style={{ animation: "fade-up 0.4s cubic-bezier(0.16, 1, 0.3, 1) 150ms both" }}>
+            {t("locations.pageSubtitle")}
+          </p>
+        </div>
 
         {/* 场景角色入口 */}
         <div className="mb-6" style={{ animation: "fade-up 0.4s cubic-bezier(0.16, 1, 0.3, 1) 190ms both" }}>


### PR DESCRIPTION
## Summary

修复首页和地点页文字居中问题。

## Problem
`mx-auto` 在特定 flex 布局下 computed style 为 0px（margin-left/right = 0），导致文字盒子偏左。

## Solution
改为外层 `flex justify-center` 包裹 + 内层 `w-full max-w-xl text-center` 模式。

## Changes
- `home-hero.tsx:47` - 主标题描述文字居中
- `home-how-it-works.tsx:20` - 副标题居中
- `home-locations-section.tsx:19` - 地点区块副标题居中
- `home-cta-section.tsx:28` - CTA 描述文字居中
- `locations-hero.tsx:68` - 地点页副标题居中

## Verification
DOM 实测副标题盒子 center 应等于 viewport 中轴（1440px 下 center=720）。