### PR TITLE
fix: harden location slug detail links

### DIFF
--- a/api/src/__tests__/integration/locations.test.ts
+++ b/api/src/__tests__/integration/locations.test.ts
@@ -109,6 +109,21 @@ describe("Locations API 集成测试", () => {
       expect(json.location.name).toBe("梧桐山");
     });
 
+    it("支持通过 slug 获取地点详情", async () => {
+      const location = await seedLocation(testDb, city.id, {
+        name: "梧桐山",
+        slug: "wutong-mountain",
+      });
+
+      const res = await req(app, "/locations/wutong-mountain");
+      expect(res.status).toBe(200);
+      const json = await res.json() as { success: boolean; location: { id: string; slug: string; name: string } };
+      expect(json.success).toBe(true);
+      expect(json.location.id).toBe(location.id);
+      expect(json.location.slug).toBe("wutong-mountain");
+      expect(json.location.name).toBe("梧桐山");
+    });
+
     it("获取不存在的地点返回 404", async () => {
       const res = await req(app, "/locations/nonexistent-id");
       expect(res.status).toBe(404);

--- a/api/src/services/share-image/generate-share-image.ts
+++ b/api/src/services/share-image/generate-share-image.ts
@@ -96,10 +96,16 @@ export async function generateLocationImage(
 ): Promise<{ png: Uint8Array; cacheKey: string }> {
   const db = createDb(env.DB);
 
-  // 1. 查询地点数据
-  const location = await db.query.locations.findFirst({
+  // 1. 查询地点数据，兼容 id 和 slug
+  let location = await db.query.locations.findFirst({
     where: eq(schema.locations.id, locationId),
   });
+
+  if (!location) {
+    location = await db.query.locations.findFirst({
+      where: eq(schema.locations.slug, locationId),
+    });
+  }
 
   if (!location) {
     throw new Error(`Location not found: ${locationId}`);
@@ -112,7 +118,7 @@ export async function generateLocationImage(
     .innerJoin(schema.tags, eq(schema.tags.id, schema.entityToTags.tagId))
     .where(
       and(
-        eq(schema.entityToTags.entityId, locationId),
+        eq(schema.entityToTags.entityId, location.id),
         eq(schema.entityToTags.entityType, "location")
       )
     );
@@ -130,7 +136,7 @@ export async function generateLocationImage(
   };
   const contentHash = (await generateMD5(JSON.stringify(contentData))).slice(0, 12);
 
-  const cacheKey = `share/location/${locationId}-${contentHash}.png`;
+  const cacheKey = `share/location/${location.id}-${contentHash}.png`;
 
   // 4. 检查 R2 缓存
   if (env.R2) {

--- a/frontend/src/components/features/discover/discover-main.tsx
+++ b/frontend/src/components/features/discover/discover-main.tsx
@@ -59,6 +59,12 @@ interface LocationsResponse {
   data?: Location[];
 }
 
+interface TagsResponse {
+  success: boolean;
+  tags?: Tag[];
+  data?: Tag[];
+}
+
 interface StoriesStatsResponse {
   success: boolean;
   data: {

--- a/frontend/src/components/features/location-detail-client.tsx
+++ b/frontend/src/components/features/location-detail-client.tsx
@@ -510,6 +510,7 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
   const [showArrows, setShowArrows] = React.useState(false);
   // Lightbox
   const [lightboxIndex, setLightboxIndex] = React.useState<number | null>(null);
+  const resolvedLocationId = location?.id;
 
   // 视差
   const [parallaxOffset, setParallaxOffset] = React.useState(0);
@@ -546,16 +547,16 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
 
   // 初始化收藏状态
   React.useEffect(() => {
-    if (!locationId || !userId) return;
+    if (!resolvedLocationId || !userId) return;
     fetchAPI(`/favorites?entityType=location`)
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
         if (!data) return;
         const favs: { entityId: string }[] = data.favorites || [];
-        setIsFavorited(favs.some((f) => f.entityId === locationId));
+        setIsFavorited(favs.some((f) => f.entityId === resolvedLocationId));
       })
       .catch(() => {});
-  }, [locationId, userId]);
+  }, [resolvedLocationId, userId]);
 
   const loadLocation = async () => {
     setIsLoading(true);
@@ -565,7 +566,7 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
       if (data.success && data.location) {
         setLocation(data.location);
         loadTeams(data.location.id);
-        loadRelatedLocations();
+        loadRelatedLocations(data.location.id);
         loadPois(data.location.id);
       } else {
         setError(t("errors.locationNotFound"));
@@ -587,13 +588,13 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
     }
   };
 
-  const loadRelatedLocations = async () => {
+  const loadRelatedLocations = async (currentLocationId: string) => {
     try {
       const res = await fetchAPI("/api/locations?pageSize=4");
       const data = await res.json();
       if (data.success) {
         setRelatedLocations(
-          (data.locations || []).filter((l: Location) => l.id !== locationId).slice(0, 3)
+          (data.locations || []).filter((l: Location) => l.id !== currentLocationId).slice(0, 3)
         );
       }
     } catch (err) {
@@ -633,13 +634,14 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
     const newFavorited = !isFavorited;
     setIsFavorited(newFavorited);
     try {
+      if (!location) return;
       if (newFavorited) {
         await fetchAPI("/favorites", {
           method: "POST",
-          body: JSON.stringify({ entityType: "location", entityId: locationId }),
+          body: JSON.stringify({ entityType: "location", entityId: location.id }),
         });
       } else {
-        await fetchAPI(`/favorites?entityType=location&entityId=${locationId}`, { method: "DELETE" });
+        await fetchAPI(`/favorites?entityType=location&entityId=${location.id}`, { method: "DELETE" });
       }
     } catch {
       setIsFavorited(!newFavorited);
@@ -883,7 +885,7 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
               actions={
                 <>
                   {isAdmin && (
-                    <a href={`/admin/locations/${locationId}/edit`}>
+                    <a href={`/admin/locations/${location.id}/edit`}>
                       <button className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-stone-100 dark:bg-stone-800 hover:bg-stone-200 dark:hover:bg-stone-700 text-stone-700 dark:text-stone-300 text-xs font-medium transition-all duration-150 active:scale-95 border border-stone-200 dark:border-stone-700">
                         <Pencil className="h-3.5 w-3.5" />
                         {t("admin.editLocation")}
@@ -921,7 +923,7 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
             {/* <RouteInfoCard location={location} /> */}
             <PoiSection locationId={location.id} />
             <TeamListSection teams={teams} locationId={location.id} />
-            <LocationActivityPosts locationId={locationId} />
+            <LocationActivityPosts locationId={location.id} />
           </div>
 
           {/* 右栏 sticky */}

--- a/frontend/src/pages/locations/[id].astro
+++ b/frontend/src/pages/locations/[id].astro
@@ -13,7 +13,7 @@ declareI18nNs(Astro.locals, ["locationDetail", "locations", "errors", "admin", "
 const { id } = Astro.params;
 
 // Phase 5: 服务端获取地点数据，用于 og:image
-let locationData: { name?: string; description?: string; coverImage?: string } | null = null;
+let locationData: { id?: string; name?: string; description?: string; coverImage?: string } | null = null;
 try {
   const response = await fetch(`${API_BASE}/locations/${id}`);
   if (response.ok) {
@@ -28,7 +28,7 @@ try {
 
 // 构建 og:image URL
 const ogImage = locationData
-  ? `${API_BASE}/share-image/location/${id}`
+  ? `${API_BASE}/share-image/location/${locationData.id || id}`
   : undefined;
 
 const title = locationData?.name


### PR DESCRIPTION
## Summary
- add regression coverage for fetching location detail by slug
- make location share image generation accept either id or slug, then use the canonical location id for tag lookup and cache keys
- make the location detail page use the loaded canonical location id for favorite, activity, related-location filtering, admin edit, and SSR og:image
- add the missing Discover tags response type so frontend type-check remains green

## Validation
- pnpm --filter @gomate/api test -- locations.test.ts
- pnpm --filter @gomate/api build
- pnpm --filter @gomate/frontend type-check
- pnpm --filter @gomate/frontend build

## Notes
Production main already deploys slug support for /locations/:id and /locations/:id/pois. This PR closes the remaining similar slug/id mismatch paths, especially /share-image/location/:id when called with a slug.