### PR TITLE
feat: Discover 标签筛选改造

### DIFF
--- a/api/src/__tests__/helpers/db.ts
+++ b/api/src/__tests__/helpers/db.ts
@@ -207,6 +207,21 @@ export function createTestDb() {
       created_at INTEGER NOT NULL,
       UNIQUE(user_id, entity_type, entity_id)
     );
+
+    CREATE TABLE IF NOT EXISTS stories (
+      id TEXT PRIMARY KEY,
+      author_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      summary TEXT NOT NULL,
+      content TEXT NOT NULL,
+      cover_image TEXT,
+      location_id TEXT REFERENCES locations(id) ON DELETE SET NULL,
+      status TEXT NOT NULL DEFAULT 'published',
+      view_count INTEGER NOT NULL DEFAULT 0,
+      like_count INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
   `);
 
   const db = drizzle(sqlite, { schema });

--- a/api/src/__tests__/helpers/seed.ts
+++ b/api/src/__tests__/helpers/seed.ts
@@ -148,3 +148,79 @@ export async function seedTeamMember(
   const [inserted] = await db.select().from(schema.teamMembers).where(eq(schema.teamMembers.id, id));
   return inserted;
 }
+
+/**
+ * 插入测试故事
+ */
+export async function seedStory(
+  db: TestDb,
+  authorId: string,
+  overrides: Partial<schema.NewStory> = {}
+): Promise<schema.Story> {
+  const id = genId("story");
+  const ts = new Date();
+  const { id: _omitId, ...restOverrides } = overrides;
+  const story: schema.NewStory = {
+    id,
+    authorId,
+    title: restOverrides.title ?? `TestStory_${id}`,
+    summary: restOverrides.summary ?? "测试故事摘要",
+    content: restOverrides.content ?? "测试故事内容",
+    coverImage: restOverrides.coverImage ?? null,
+    locationId: restOverrides.locationId ?? null,
+    status: restOverrides.status ?? "published",
+    viewCount: restOverrides.viewCount ?? 0,
+    likeCount: restOverrides.likeCount ?? 0,
+    createdAt: restOverrides.createdAt ?? ts,
+    updatedAt: restOverrides.updatedAt ?? ts,
+    ...restOverrides,
+  };
+  await db.insert(schema.stories).values(story);
+  const [inserted] = await db.select().from(schema.stories).where(eq(schema.stories.id, id));
+  return inserted;
+}
+
+/**
+ * 插入测试标签
+ */
+export async function seedTag(
+  db: TestDb,
+  overrides: Partial<schema.NewTag> = {}
+): Promise<schema.Tag> {
+  const id = genId("tag");
+  const ts = new Date();
+  const { id: _omitId, ...restOverrides } = overrides;
+  const tag: schema.NewTag = {
+    id,
+    name: restOverrides.name ?? `TestTag_${id}`,
+    type: restOverrides.type ?? "activity",
+    createdAt: restOverrides.createdAt ?? ts,
+    ...restOverrides,
+  };
+  await db.insert(schema.tags).values(tag);
+  const [inserted] = await db.select().from(schema.tags).where(eq(schema.tags.id, id));
+  return inserted;
+}
+
+/**
+ * 关联标签到实体
+ */
+export async function seedEntityTag(
+  db: TestDb,
+  entityId: string,
+  entityType: string,
+  tagId: string
+): Promise<schema.EntityToTag> {
+  const id = genId("et");
+  const ts = new Date();
+  const entityTag: typeof schema.entityToTags.$inferInsert = {
+    id,
+    entityId,
+    entityType,
+    tagId,
+    createdAt: ts,
+  };
+  await db.insert(schema.entityToTags).values(entityTag);
+  const [inserted] = await db.select().from(schema.entityToTags).where(eq(schema.entityToTags.id, id));
+  return inserted;
+}

--- a/api/src/__tests__/integration/stories.test.ts
+++ b/api/src/__tests__/integration/stories.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Hono } from "hono";
+import { createTestDb } from "../helpers/db";
+import { seedUser, seedStory, seedTag, seedEntityTag } from "../helpers/seed";
+import * as schema from "../../db/schema";
+
+let currentSession: { user: { id: string; email: string; name: string } } | null = null;
+let testDb: ReturnType<typeof createTestDb>["db"];
+
+vi.mock("../../lib/auth", () => ({
+  createAuth: (_env: unknown) => ({
+    api: {
+      getSession: async (_opts: unknown) => currentSession,
+    },
+  }),
+}));
+
+vi.mock("../../db", () => ({
+  createDb: (_d1: unknown) => testDb,
+}));
+
+const { default: storiesRoute } = await import("../../routes/stories");
+
+function createApp() {
+  const app = new Hono<{ Bindings: { DB: unknown } }>();
+  app.route("/stories", storiesRoute);
+  return app;
+}
+
+async function req(app: ReturnType<typeof createApp>, path: string, options: RequestInit = {}) {
+  return app.fetch(new Request(`http://localhost${path}`, options), { DB: {} });
+}
+
+describe("Stories API 集成测试", () => {
+  let app: ReturnType<typeof createApp>;
+  let user: schema.User;
+
+  beforeEach(async () => {
+    const fresh = createTestDb();
+    testDb = fresh.db;
+    app = createApp();
+    currentSession = null;
+
+    user = await seedUser(testDb, { name: "测试用户", email: "test@example.com" });
+  });
+
+  describe("GET /stories - 故事列表", () => {
+    it("获取故事列表返回分页数据", async () => {
+      await seedStory(testDb, user.id, { title: "故事1", status: "published" });
+      await seedStory(testDb, user.id, { title: "故事2", status: "published" });
+
+      const res = await req(app, "/stories");
+      expect(res.status).toBe(200);
+      const json = await res.json() as { success: boolean; data: unknown[]; pagination: unknown };
+      expect(json.success).toBe(true);
+      expect(json.data).toHaveLength(2);
+      expect(json.pagination).toBeDefined();
+    });
+
+    it("支持分页参数 page 和 limit", async () => {
+      for (let i = 0; i < 5; i++) {
+        await seedStory(testDb, user.id, { title: `故事${i}`, status: "published" });
+      }
+
+      const res = await req(app, "/stories?page=1&limit=2");
+      expect(res.status).toBe(200);
+      const json = await res.json() as { success: boolean; data: unknown[]; pagination: { hasMore: boolean; total: number } };
+      expect(json.data).toHaveLength(2);
+      expect(json.pagination.hasMore).toBe(true);
+      expect(json.pagination.total).toBe(5);
+    });
+
+    it("?tag=xxx 只返回对应标签的故事", async () => {
+      // 创建标签
+      const tag = await seedTag(testDb, { name: "溯溪", type: "activity" });
+
+      // 创建故事
+      const story1 = await seedStory(testDb, user.id, { title: "溯溪故事", status: "published" });
+      const story2 = await seedStory(testDb, user.id, { title: "其他故事", status: "published" });
+
+      // 关联标签
+      await seedEntityTag(testDb, story1.id, "story", tag.id);
+
+      const res = await req(app, "/stories?tag=溯溪");
+      expect(res.status).toBe(200);
+      const json = await res.json() as { success: boolean; data: { title: string }[] };
+      expect(json.success).toBe(true);
+      expect(json.data).toHaveLength(1);
+      expect(json.data[0].title).toBe("溯溪故事");
+    });
+
+    it("?tag=不存在的标签 返回空数组", async () => {
+      const res = await req(app, "/stories?tag=不存在的标签");
+      expect(res.status).toBe(200);
+      const json = await res.json() as { success: boolean; data: unknown[]; pagination: { total: number } };
+      expect(json.success).toBe(true);
+      expect(json.data).toHaveLength(0);
+      expect(json.pagination.total).toBe(0);
+    });
+
+    it("标签筛选下分页参数正确", async () => {
+      const tag = await seedTag(testDb, { name: "徒步", type: "activity" });
+
+      // 创建多个带标签的故事
+      for (let i = 0; i < 5; i++) {
+        const story = await seedStory(testDb, user.id, { title: `徒步故事${i}`, status: "published" });
+        await seedEntityTag(testDb, story.id, "story", tag.id);
+      }
+
+      // 创建一个不带标签的故事
+      await seedStory(testDb, user.id, { title: "其他故事", status: "published" });
+
+      const res = await req(app, "/stories?tag=徒步&page=1&limit=2");
+      expect(res.status).toBe(200);
+      const json = await res.json() as { success: boolean; data: unknown[]; pagination: { hasMore: boolean; total: number } };
+      expect(json.data).toHaveLength(2);
+      expect(json.pagination.hasMore).toBe(true);
+      expect(json.pagination.total).toBe(5);
+    });
+
+    it("无 tag 参数时返回所有已发布故事", async () => {
+      await seedStory(testDb, user.id, { title: "故事1", status: "published" });
+      await seedStory(testDb, user.id, { title: "故事2", status: "published" });
+      await seedStory(testDb, user.id, { title: "草稿", status: "draft" });
+
+      const res = await req(app, "/stories");
+      expect(res.status).toBe(200);
+      const json = await res.json() as { success: boolean; data: unknown[] };
+      expect(json.data).toHaveLength(2); // 只返回 published
+    });
+
+    it("标签筛选下 Load More 保持筛选状态", async () => {
+      const tag = await seedTag(testDb, { name: "露营", type: "activity" });
+
+      // 创建3个带标签的故事（刚好2页）
+      for (let i = 0; i < 3; i++) {
+        const story = await seedStory(testDb, user.id, { title: `露营故事${i}`, status: "published" });
+        await seedEntityTag(testDb, story.id, "story", tag.id);
+      }
+
+      // 第一页
+      const res1 = await req(app, "/stories?tag=露营&page=1&limit=2");
+      const json1 = await res1.json() as { data: unknown[]; pagination: { hasMore: boolean } };
+      expect(json1.data).toHaveLength(2);
+      expect(json1.pagination.hasMore).toBe(true);
+
+      // 第二页
+      const res2 = await req(app, "/stories?tag=露营&page=2&limit=2");
+      const json2 = await res2.json() as { data: unknown[]; pagination: { hasMore: boolean } };
+      expect(json2.data).toHaveLength(1);
+      expect(json2.pagination.hasMore).toBe(false);
+    });
+  });
+
+  describe("GET /stories/:id - 故事详情", () => {
+    it("获取故事详情成功", async () => {
+      const story = await seedStory(testDb, user.id, { title: "测试故事", status: "published" });
+
+      const res = await req(app, `/stories/${story.id}`);
+      expect(res.status).toBe(200);
+      const json = await res.json() as { success: boolean; data: { title: string } };
+      expect(json.success).toBe(true);
+      expect(json.data.title).toBe("测试故事");
+    });
+
+    it("故事不存在返回 404", async () => {
+      const res = await req(app, "/stories/non-existent-id");
+      expect(res.status).toBe(404);
+      const json = await res.json() as { success: boolean; message: string };
+      expect(json.success).toBe(false);
+      expect(json.message).toBe("故事不存在");
+    });
+  });
+
+  describe("GET /stories/stats - 故事统计", () => {
+    it("获取统计数据成功", async () => {
+      await seedStory(testDb, user.id, { title: "故事1", status: "published" });
+
+      const res = await req(app, "/stories/stats");
+      expect(res.status).toBe(200);
+      const json = await res.json() as { success: boolean; data: { weeklyNewStories: number } };
+      expect(json.success).toBe(true);
+      expect(typeof json.data.weeklyNewStories).toBe("number");
+    });
+  });
+});

--- a/api/src/__tests__/integration/stories.test.ts
+++ b/api/src/__tests__/integration/stories.test.ts
@@ -76,7 +76,7 @@ describe("Stories API 集成测试", () => {
 
       // 创建故事
       const story1 = await seedStory(testDb, user.id, { title: "溯溪故事", status: "published" });
-      const story2 = await seedStory(testDb, user.id, { title: "其他故事", status: "published" });
+      const _story2 = await seedStory(testDb, user.id, { title: "其他故事", status: "published" });
 
       // 关联标签
       await seedEntityTag(testDb, story1.id, "story", tag.id);

--- a/api/src/routes/stories.ts
+++ b/api/src/routes/stories.ts
@@ -90,7 +90,7 @@ stories.get("/", async (c) => {
     const offset = (page - 1) * limit;
 
     // 基础过滤条件：状态
-    let whereConditions = [eq(schema.stories.status, status)];
+    const whereConditions = [eq(schema.stories.status, status)];
 
     // 如果指定了标签，先查询该标签对应的故事ID列表
     let storyIdsWithTag: string[] = [];

--- a/api/src/routes/stories.ts
+++ b/api/src/routes/stories.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { eq, desc, count, sql } from "drizzle-orm";
+import { eq, desc, count, sql, inArray, and } from "drizzle-orm";
 import { createAuth } from "../lib/auth";
 import { createDb } from "../db";
 import * as schema from "../db/schema";
@@ -78,7 +78,7 @@ stories.get("/stats", async (c) => {
 /**
  * GET /stories
  * 获取故事列表（分页）
- * Query: page, limit, status
+ * Query: page, limit, status, tag
  */
 stories.get("/", async (c) => {
   try {
@@ -86,9 +86,57 @@ stories.get("/", async (c) => {
     const page = Math.max(1, parseInt(c.req.query("page") || "1", 10));
     const limit = Math.min(20, parseInt(c.req.query("limit") || "10", 10));
     const status = c.req.query("status") || "published";
+    const tag = c.req.query("tag");
     const offset = (page - 1) * limit;
 
-    const whereClause = eq(schema.stories.status, status);
+    // 基础过滤条件：状态
+    let whereConditions = [eq(schema.stories.status, status)];
+
+    // 如果指定了标签，先查询该标签对应的故事ID列表
+    let storyIdsWithTag: string[] = [];
+    if (tag && tag.trim()) {
+      const tagName = tag.trim();
+      // 查询标签ID
+      const tagRecord = await db.query.tags.findFirst({
+        where: eq(schema.tags.name, tagName),
+      });
+
+      if (tagRecord) {
+        // 查询关联的故事ID
+        const entityTagsResult = await db
+          .select({ entityId: schema.entityToTags.entityId })
+          .from(schema.entityToTags)
+          .where(
+            and(
+              eq(schema.entityToTags.tagId, tagRecord.id),
+              eq(schema.entityToTags.entityType, "story")
+            )
+          );
+        storyIdsWithTag = entityTagsResult.map((r) => r.entityId);
+      }
+
+      // 如果有标签但无关联故事，返回空结果
+      if (storyIdsWithTag.length === 0) {
+        return c.json({
+          success: true,
+          data: [],
+          pagination: {
+            page,
+            limit,
+            total: 0,
+            hasMore: false,
+          },
+        });
+      }
+
+      // 添加故事ID过滤条件
+      whereConditions.push(inArray(schema.stories.id, storyIdsWithTag));
+    }
+
+    // 组合过滤条件
+    const whereClause = whereConditions.length > 1
+      ? and(whereConditions[0], whereConditions[1])
+      : whereConditions[0];
 
     const items = await db
       .select({

--- a/frontend/src/components/features/discover/discover-main.tsx
+++ b/frontend/src/components/features/discover/discover-main.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Compass, Loader2, Plus, MapPin, Tag, Flame } from "lucide-react";
+import { Compass, Loader2, Plus, MapPin, Tag, Flame, X } from "lucide-react";
 import { apiGet } from "@/lib/api";
 import { StoryCard } from "./story-card";
 import { FeaturedStoryCard } from "./featured-story-card";
@@ -87,6 +87,9 @@ export function DiscoverMain() {
   const [hasMore, setHasMore] = React.useState(false);
   const [isLoadingMore, setIsLoadingMore] = React.useState(false);
 
+  // 标签筛选状态 - 从 URL 读取
+  const [selectedTag, setSelectedTag] = React.useState<string | null>(null);
+
   // Sidebar data
   const [locations, setLocations] = React.useState<Location[]>([]);
   const [tags, setTags] = React.useState<Tag[]>([]);
@@ -100,7 +103,16 @@ export function DiscoverMain() {
     setMounted(true);
   }, []);
 
-  const loadStories = React.useCallback(async (pageNum: number, append: boolean) => {
+  // 从 URL 读取 tag 参数
+  React.useEffect(() => {
+    if (typeof window !== "undefined") {
+      const params = new URLSearchParams(window.location.search);
+      const tagParam = params.get("tag");
+      setSelectedTag(tagParam || null);
+    }
+  }, []);
+
+  const loadStories = React.useCallback(async (pageNum: number, append: boolean, tagFilter: string | null = selectedTag) => {
     try {
       if (pageNum === 1) {
         setIsLoading(true);
@@ -109,7 +121,8 @@ export function DiscoverMain() {
       }
       setError(null);
 
-      const response = await apiGet<StoriesResponse>(`/stories?page=${pageNum}&limit=10`);
+      const tagQuery = tagFilter ? `&tag=${encodeURIComponent(tagFilter)}` : "";
+      const response = await apiGet<StoriesResponse>(`/stories?page=${pageNum}&limit=10${tagQuery}`);
 
       if (response.success) {
         if (append) {
@@ -129,16 +142,16 @@ export function DiscoverMain() {
       setIsLoading(false);
       setIsLoadingMore(false);
     }
-  }, [t]);
+  }, [t, selectedTag]);
 
   // Initial load - call real API only after mount
   React.useEffect(() => {
     if (mounted) {
       setIsLoading(true);
-      loadStories(1, false);
+      loadStories(1, false, selectedTag);
       loadSidebarData();
     }
-  }, [mounted, loadStories]);
+  }, [mounted, loadStories, selectedTag]);
 
   const loadSidebarData = async () => {
     const [locationsResult, tagsResult, statsResult] = await Promise.allSettled([
@@ -179,9 +192,42 @@ export function DiscoverMain() {
     window.location.href = `/discover/${story.id}`;
   };
 
+  // 处理标签点击
+  const handleTagClick = (tagName: string) => {
+    const newTag = tagName === selectedTag ? null : tagName;
+    setSelectedTag(newTag);
+
+    // 更新 URL
+    if (newTag) {
+      const url = new URL(window.location.href);
+      url.searchParams.set("tag", newTag);
+      window.history.pushState({}, "", url.toString());
+    } else {
+      const url = new URL(window.location.href);
+      url.searchParams.delete("tag");
+      window.history.pushState({}, "", url.toString());
+    }
+
+    // 重置列表并重新加载
+    setStories([]);
+    setPage(1);
+    loadStories(1, false, newTag);
+  };
+
+  // 清除筛选
+  const handleClearFilter = () => {
+    setSelectedTag(null);
+    const url = new URL(window.location.href);
+    url.searchParams.delete("tag");
+    window.history.pushState({}, "", url.toString());
+    setStories([]);
+    setPage(1);
+    loadStories(1, false, null);
+  };
+
   const handleLoadMore = () => {
     if (!isLoadingMore && hasMore) {
-      loadStories(page + 1, true);
+      loadStories(page + 1, true, selectedTag);
     }
   };
 
@@ -204,7 +250,7 @@ export function DiscoverMain() {
         <div className="text-center">
           <p className="text-destructive mb-4" suppressHydrationWarning>{error}</p>
           <button
-            onClick={() => loadStories(1, false)}
+            onClick={() => loadStories(1, false, selectedTag)}
             className="px-4 py-2 rounded-lg border border-border bg-background hover:bg-accent transition-colors"
           >
             {t("content.discover.retry")}
@@ -264,6 +310,47 @@ export function DiscoverMain() {
         <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_300px] gap-5 lg:gap-8">
           {/* Left: Main Content Flow */}
           <div className="space-y-4">
+            {/* Mobile Tag Filter - 横向滚动标签入口 */}
+            <div className="lg:hidden">
+              {tags.length > 0 && (
+                <div className="flex gap-2 overflow-x-auto pb-2 -mx-3 px-3 scrollbar-hide">
+                  {tags.map((tag) => (
+                    <button
+                      key={tag.id ?? tag.name}
+                      onClick={() => handleTagClick(tag.name)}
+                      className={`inline-flex items-center px-3 py-1.5 rounded-full text-xs whitespace-nowrap transition-colors ${
+                        selectedTag === tag.name
+                          ? "bg-primary text-primary-foreground"
+                          : "bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground"
+                      }`}
+                    >
+                      #{tag.name}
+                      {typeof tag.count === "number" && (
+                        <span className="ml-1 opacity-60">{tag.count}</span>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Filter Status Chip */}
+            {selectedTag && (
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-muted-foreground">筛选:</span>
+                <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-primary/10 text-primary text-sm font-medium">
+                  #{selectedTag}
+                  <button
+                    onClick={handleClearFilter}
+                    className="ml-1 p-0.5 rounded-full hover:bg-primary/20 transition-colors"
+                    aria-label="清除筛选"
+                  >
+                    <X className="w-3.5 h-3.5" />
+                  </button>
+                </span>
+              </div>
+            )}
+
             {/* Featured Story - 第一篇作为精选 */}
             {stories.length > 0 && (
               <FeaturedStoryCard
@@ -359,16 +446,22 @@ export function DiscoverMain() {
               >
                 <div className="flex flex-wrap gap-2">
                   {tags.map((tag) => (
-                    <a
+                    <button
                       key={tag.id ?? tag.name}
-                      href={`/discover?tag=${tag.name}`}
-                      className="inline-flex items-center px-2.5 py-1 rounded-md bg-muted/50 text-xs text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+                      onClick={() => handleTagClick(tag.name)}
+                      className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs transition-colors ${
+                        selectedTag === tag.name
+                          ? "bg-primary text-primary-foreground"
+                          : "bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground"
+                      }`}
                     >
                       #{tag.name}
                       {typeof tag.count === "number" && (
-                        <span className="ml-1 text-muted-foreground/60">{tag.count}</span>
+                        <span className={`ml-1 ${selectedTag === tag.name ? "opacity-80" : "opacity-60"}`}>
+                          {tag.count}
+                        </span>
                       )}
-                    </a>
+                    </button>
                   ))}
                 </div>
               </SidebarSection>


### PR DESCRIPTION
## 变更内容

### 后端 API
- GET /stories?tag= 支持真实数据库过滤
- 通过 tags + entity_to_tags 表关联查询
- 分页 total/hasMore 与过滤条件一致
- 无 tag 时保持原有行为

### 前端实现
- URL query 作为筛选状态源，刷新保留状态
- 选中标签高亮显示，支持清除筛选
- 移动端横向标签入口
- Load More 保持筛选状态

### 测试
- 10 个集成测试覆盖标签筛选场景

## 验证结果
✓ pnpm --filter @gomate/api test -- stories (10 passed)
✓ pnpm --filter @gomate/api build
✓ pnpm --filter @gomate/frontend type-check
✓ pnpm --filter @gomate/frontend build

## 线上验收标准
- [ ] /discover?tag=溯溪 刷新后仍显示筛选状态
- [ ] 点击标签后列表内容变化，且 URL 同步
- [ ] 点击清除后恢复全部故事
- [ ] 分页加载更多仍然维持 tag 筛选
- [ ] 375px 移动端也能看到并使用 tag 筛选