### PR TITLE
fix: generate scannable team poster QR codes

### DIFF
--- a/api/src/services/share-image/generate-share-image.ts
+++ b/api/src/services/share-image/generate-share-image.ts
@@ -451,10 +451,9 @@ function formatTeamDate(timestamp: number | Date): string {
  */
 export async function generateQRCode(text: string): Promise<string> {
   try {
-    // 使用 qrcode 生成 data URL
-    // 优化参数：增大尺寸、提高纠错级别、增加边距，确保扫码识别率
-    const dataUrl = await QRCode.toDataURL(text, {
-      width: 240,
+    // 使用纯 SVG 输出，避免 Cloudflare Workers 环境中 PNG DataURL 生成失败后落入不可扫描占位图。
+    const svg = await QRCode.toString(text, {
+      type: "svg",
       margin: 4,
       errorCorrectionLevel: "H",
       color: {
@@ -462,7 +461,7 @@ export async function generateQRCode(text: string): Promise<string> {
         light: "#ffffff",
       },
     });
-    return dataUrl;
+    return `data:image/svg+xml;base64,${btoa(svg)}`;
   } catch (e) {
     console.error("[QRCode] Failed to generate QR code:", e);
     // 降级：返回占位符 SVG


### PR DESCRIPTION
## Summary
- Switch share-image QR generation from PNG DataURL to pure SVG DataURL
- Avoid Cloudflare Worker PNG DataURL failures that triggered the old non-scannable fallback placeholder

## Validation
- pnpm --filter @gomate/api lint
- pnpm --filter @gomate/api build
- git diff --check
- Local Satori/resvg render with SVG QR generated a 750x936 PNG
- jsQR decoded the rendered poster QR as https://gomate.live/teams/team-1774192890239-as373tu69

## Context
PR #179 deployed successfully, but production validation showed the QR area rendered as the old fallback placeholder and could not scan. This hotfix makes the generated QR scannable in the Worker environment.