### PR TITLE
fix: correct spotsToForm calculation in team poster

### DIFF
--- a/api/src/services/share-image/generate-share-image.ts
+++ b/api/src/services/share-image/generate-share-image.ts
@@ -340,7 +340,8 @@ export async function generateTeamImage(
 
   const currentMembers = memberCount + 1; // +1 包含队长
   const maxMembers = team.maxMembers;
-  const spotsToForm = Math.max(0, team.durationMin - currentMembers); // durationMin 存储成行人数
+  // 计算还差多少人满员（方案2：使用 maxMembers - currentMembers）
+  const spotsToForm = Math.max(0, maxMembers - currentMembers);
 
   // 3. 生成内容哈希（用于缓存）
   const contentData = {


### PR DESCRIPTION
修复队伍分享海报中"还差 X 人"计算错误的问题。

## 问题
 使用了错误的 （活动时长）计算，导致显示数字不正确。

## 修复
改为使用  计算还差多少人满员。

## 改动
- api/src/services/share-image/generate-share-image.ts

## 测试
- [ ] 生成海报验证数字正确