### PR TITLE
fix(frontend): disable SESSION KV binding to fix deployment

### DIFF
--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -10,6 +10,7 @@ export default defineConfig({
   output: "server",
   adapter: cloudflare({
     imageService: "passthrough",
+    session: false, // Disable SESSION KV binding (not needed for this project)
   }),
   i18n: {
     defaultLocale: "zh-CN",


### PR DESCRIPTION
## Problem

PR #185 merge caused deployment failure:

```
Provisioning SESSION (KV Namespace)...
🌀 Creating new KV Namespace "gomate-frontend-session"...
✘ [ERROR] A request to the Cloudflare API failed.
  a namespace with this account ID and title already exists [code: 10014]
```

## Cause

Astro 6 Cloudflare adapter v13 defaults to creating a SESSION KV namespace.
A namespace with the same name already exists in the Cloudflare account,
causing wrangler to fail when trying to create it again.

## Solution

Disable session functionality in `astro.config.mjs`:

```ts
adapter: cloudflare({
  imageService: "passthrough",
  session: false,  // Disable SESSION KV binding
}),
```

This project doesn't use session functionality, so disabling it is safe.

## Verification

- ✅ type-check passes
- ✅ build passes
- ✅ i18n:validate passes

## Impact

- No breaking changes
- Removes unused SESSION KV binding from deployment