### PR TITLE
fix(frontend): remove invalid session: false config

### DIFF
--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -10,7 +10,6 @@ export default defineConfig({
   output: "server",
   adapter: cloudflare({
     imageService: "passthrough",
-    session: false, // Disable SESSION KV binding (not needed for this project)
   }),
   i18n: {
     defaultLocale: "zh-CN",


### PR DESCRIPTION
## Problem

PR #186 added `session: false` to disable SESSION KV binding, but this is not a valid option for @astrojs/cloudflare adapter.

The actual option is `sessionKVBindingName` for custom binding names.

## Root Cause

After reviewing the adapter's TypeScript definitions:
```typescript
// Valid options
sessionKVBindingName?: string;  // Custom binding name, default "SESSION"
```

The `session: false` was silently ignored, causing the adapter to still try to provision the SESSION KV namespace.

## Solution

1. Remove the invalid `session: false` config
2. Delete the existing `gomate-frontend-session` KV namespace (done manually by @jiahong-wu)
3. Re-deploy to let Cloudflare auto-provision the namespace cleanly

## Changes

- `frontend/astro.config.mjs`: Remove invalid `session: false` option