### PR TITLE
fix: use flex centering for home teams section subtitle

### DIFF
--- a/frontend/src/components/features/home/home-teams-section.tsx
+++ b/frontend/src/components/features/home/home-teams-section.tsx
@@ -13,12 +13,10 @@ export function HomeTeamsSection({ data }: { data: HomeData }) {
     <section id="teams" ref={teamsRef}
       className={`py-12 sm:py-16 lg:py-20 bg-background section-hidden ${teamsInView ? "section-visible" : ""}`}>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-12">
+        <div className="flex flex-col items-center text-center mb-12">
           <span className="inline-block mb-4 px-3 py-1 text-xs font-semibold rounded-full uppercase tracking-widest bg-amber-50/80 dark:bg-amber-950/30 text-amber-800 dark:text-amber-300">{t("home.recentTeams")}</span>
           <h2 className="text-4xl md:text-5xl font-bold text-foreground mb-4">{t("teams.pageTitle")}</h2>
-          <div className="flex justify-center">
-          <p className="text-muted-foreground w-full max-w-2xl text-center leading-relaxed text-lg">{t("teams.pageSubtitle")}</p>
-        </div>
+          <p className="text-muted-foreground max-w-2xl leading-relaxed text-lg">{t("teams.pageSubtitle")}</p>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-5">


### PR DESCRIPTION
## Changes

Fixed the home teams section subtitle centering by using proper flex layout.

### What changed
- Replaced redundant flex wrapper div with parent flex container
- Changed parent div from `text-center` to `flex flex-col items-center text-center`
- Removed unnecessary `<div className="flex justify-center">` wrapper around subtitle
- Removed redundant `w-full` and `text-center` from subtitle paragraph

### Why
The previous implementation had a redundant flex wrapper div around the subtitle paragraph. The parent container already had `text-center`, but using flex provides more reliable centering for all child elements (badge, title, and subtitle).

Fixes #39