### PR TITLE
refactor: remove /user route alias, unify to /users

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -36,7 +36,6 @@ app.route("/auth", authRoute);
 app.route("/teams", teamsRoute);
 app.route("/locations", locationsRoute);
 app.route("/users", usersRoute);
-app.route("/user", usersRoute); // 兼容前端 /user/* 路径
 app.route("/upload", uploadRoute);
 app.route("/cities", citiesRoute);
 app.route("/tags", tagsRoute);

--- a/frontend/src/components/features/my-teams/use-my-teams.ts
+++ b/frontend/src/components/features/my-teams/use-my-teams.ts
@@ -84,7 +84,7 @@ export function useMyTeams() {
     if (!currentUser?.id) return;
     if (append) setCreatedLoadingMore(true); else setCreatedLoading(true);
     try {
-      const r = await fetchAPI(`/api/user/created-teams?page=${page}&pageSize=10`);
+      const r = await fetchAPI(`/api/users/created-teams?page=${page}&pageSize=10`);
       const data = await r.json();
       if (data.success) {
         if (append) setCreatedTeams((prev) => [...prev, ...data.teams]);
@@ -98,7 +98,7 @@ export function useMyTeams() {
     if (!currentUser?.id) return;
     if (append) setJoinedLoadingMore(true); else setJoinedLoading(true);
     try {
-      const r = await fetchAPI(`/api/user/teams/joined?page=${page}&pageSize=10`);
+      const r = await fetchAPI(`/api/users/teams/joined?page=${page}&pageSize=10`);
       const data = await r.json();
       if (data.success) {
         if (append) setJoinedTeams((prev) => [...prev, ...data.teams]);
@@ -112,7 +112,7 @@ export function useMyTeams() {
     if (!currentUser?.id) return;
     if (append) setApplicationsLoadingMore(true); else setApplicationsLoading(true);
     try {
-      const r = await fetchAPI(`/api/user/applications?page=${page}&pageSize=10`);
+      const r = await fetchAPI(`/api/users/applications?page=${page}&pageSize=10`);
       const data = await r.json();
       if (data.success) {
         if (append) setApplications((prev) => [...prev, ...data.applications]);
@@ -126,7 +126,7 @@ export function useMyTeams() {
     if (!currentUser?.id) return;
     if (append) setPendingLoadingMore(true); else setPendingLoading(true);
     try {
-      const r = await fetchAPI(`/api/user/pending-approvals?page=${page}&pageSize=10`);
+      const r = await fetchAPI(`/api/users/pending-approvals?page=${page}&pageSize=10`);
       const data = await r.json();
       if (data.success) {
         if (append) setPendingApprovals((prev) => [...prev, ...data.approvals]);

--- a/frontend/src/components/features/profile-client.tsx
+++ b/frontend/src/components/features/profile-client.tsx
@@ -89,8 +89,8 @@ export function ProfileClient() {
   const loadTeams = async (_userId: string) => {
     try {
       const [createdRes, joinedRes] = await Promise.all([
-        fetchAPI("/api/user/created-teams"),
-        fetchAPI("/api/user/teams/joined"),
+        fetchAPI("/api/users/created-teams"),
+        fetchAPI("/api/users/teams/joined"),
       ]);
       const createdData = await createdRes.json();
       const joinedData = await joinedRes.json();

--- a/frontend/src/components/features/profile-edit/use-profile-form.ts
+++ b/frontend/src/components/features/profile-edit/use-profile-form.ts
@@ -143,7 +143,7 @@ export function useProfileForm() {
       if (formData.experience) extra.experience = formData.experience;
       if (formData.equipment.length > 0) extra.equipment = formData.equipment;
 
-      const res = await fetchAPI("/api/user/update", {
+      const res = await fetchAPI("/api/users/update", {
         method: "PATCH",
         body: JSON.stringify({
           userId: user!.id, nickname: formData.nickname || null, image: avatarUrl,

--- a/frontend/src/components/features/team-detail/use-team-detail.ts
+++ b/frontend/src/components/features/team-detail/use-team-detail.ts
@@ -239,7 +239,7 @@ export function useTeamDetail(teamId: string): UseTeamDetailReturn {
       return;
     }
     try {
-      const res = await fetchAPI("/api/user/update", {
+      const res = await fetchAPI("/api/users/update", {
         method: "PATCH",
         body: JSON.stringify({ userId, wechat: wechat.trim() }),
       });

--- a/frontend/src/hooks/useTeamActions.ts
+++ b/frontend/src/hooks/useTeamActions.ts
@@ -261,7 +261,7 @@ export function useTeamActions({ teamId, onSuccess }: UseTeamActionsOptions) {
 
       setIsSavingWechat(true);
       try {
-        const res = await fetchAPI("/api/user/update", {
+        const res = await fetchAPI("/api/users/update", {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ userId, wechat: wechat.trim() }),


### PR DESCRIPTION
## Summary

Removes the duplicate `/user` route alias and unifies all API paths to use `/users` consistently.

## Changes

### API Changes
- **Removed** duplicate route alias `/user` from `api/src/index.ts`
- Only `/users` route remains (no breaking changes for `/users` endpoints)

### Frontend Updates
Updated all frontend API calls from `/api/user/` to `/api/users/`:
- `frontend/src/hooks/useTeamActions.ts`
- `frontend/src/components/features/profile-client.tsx`
- `frontend/src/components/features/team-detail/use-team-detail.ts`
- `frontend/src/components/features/my-teams/use-my-teams.ts`
- `frontend/src/components/features/profile-edit/use-profile-form.ts`

## Affected Endpoints
All user-related endpoints now use `/api/users/` consistently:
- `/api/users/created-teams`
- `/api/users/teams/joined`
- `/api/users/update`
- `/api/users/applications`
- `/api/users/pending-approvals`

## Testing
- ✅ No remaining `/api/user/` references in frontend
- ✅ Only `/users` route registered in API
- ✅ All paths unified and consistent

Closes #50