### PR TITLE
refactor: unify error handling to APIErrors (batch 2)

### DIFF
--- a/api/src/routes/activity-posts.ts
+++ b/api/src/routes/activity-posts.ts
@@ -1,3 +1,4 @@
+import { APIErrors } from "../lib/api-errors";
 import { Hono } from "hono";
 import { eq, desc, and } from "drizzle-orm";
 import { createAuth } from "../lib/auth";
@@ -23,7 +24,7 @@ activityPosts.get("/teams/:id/activity-posts", async (c) => {
     });
 
     if (!team) {
-      return c.json({ success: false, message: "队伍不存在" }, 404);
+      return c.json(APIErrors.notFound("队伍不存在"), 404);
     }
 
     // Get visible activity posts for this team
@@ -66,7 +67,7 @@ activityPosts.get("/teams/:id/activity-posts", async (c) => {
     });
   } catch (error) {
     console.error("Get activity posts error:", error);
-    return c.json({ success: false, message: "获取分享列表失败" }, 500);
+    return c.json(APIErrors.internalError("获取分享列表失败"), 500);
   }
 });
 
@@ -81,7 +82,7 @@ activityPosts.post("/teams/:id/activity-posts", async (c) => {
     const session = await auth.api.getSession({ headers: c.req.raw.headers });
 
     if (!session) {
-      return c.json({ success: false, message: "请先登录" }, 401);
+      return c.json(APIErrors.unauthorized("请先登录"), 401);
     }
 
     const db = createDb(c.env.DB);
@@ -94,13 +95,13 @@ activityPosts.post("/teams/:id/activity-posts", async (c) => {
     });
 
     if (!team) {
-      return c.json({ success: false, message: "队伍不存在" }, 404);
+      return c.json(APIErrors.notFound("队伍不存在"), 404);
     }
 
     // Check if team is completed
     if (team.status !== "completed") {
       return c.json(
-        { success: false, message: "只有已完成的队伍才能发布分享" },
+        APIErrors.forbidden("只有已完成的队伍才能发布分享"),
         403
       );
     }
@@ -116,7 +117,7 @@ activityPosts.post("/teams/:id/activity-posts", async (c) => {
 
     if (!membership) {
       return c.json(
-        { success: false, message: "只有队伍成员才能发布分享" },
+        APIErrors.forbidden("只有队伍成员才能发布分享"),
         403
       );
     }
@@ -125,15 +126,15 @@ activityPosts.post("/teams/:id/activity-posts", async (c) => {
     const { content, images = [] } = body;
 
     if (!content || content.trim().length === 0) {
-      return c.json({ success: false, message: "内容不能为空" }, 400);
+      return c.json(APIErrors.badRequest("内容不能为空"), 400);
     }
 
     if (content.length > 200) {
-      return c.json({ success: false, message: "内容不能超过200字" }, 400);
+      return c.json(APIErrors.badRequest("内容不能超过200字"), 400);
     }
 
     if (images.length > 3) {
-      return c.json({ success: false, message: "图片不能超过3张" }, 400);
+      return c.json(APIErrors.badRequest("图片不能超过3张"), 400);
     }
 
     const postId = crypto.randomUUID();
@@ -158,7 +159,7 @@ activityPosts.post("/teams/:id/activity-posts", async (c) => {
     });
   } catch (error) {
     console.error("Create activity post error:", error);
-    return c.json({ success: false, message: "发布失败" }, 500);
+    return c.json(APIErrors.internalError("发布失败"), 500);
   }
 });
 
@@ -173,7 +174,7 @@ activityPosts.delete("/activity-posts/:id", async (c) => {
     const session = await auth.api.getSession({ headers: c.req.raw.headers });
 
     if (!session) {
-      return c.json({ success: false, message: "请先登录" }, 401);
+      return c.json(APIErrors.unauthorized("请先登录"), 401);
     }
 
     const db = createDb(c.env.DB);
@@ -186,7 +187,7 @@ activityPosts.delete("/activity-posts/:id", async (c) => {
     });
 
     if (!post) {
-      return c.json({ success: false, message: "分享不存在" }, 404);
+      return c.json(APIErrors.notFound("分享不存在"), 404);
     }
 
     // Check permission: author or admin
@@ -194,7 +195,7 @@ activityPosts.delete("/activity-posts/:id", async (c) => {
     const isAdmin = session.user.role === "admin";
 
     if (!isAuthor && !isAdmin) {
-      return c.json({ success: false, message: "无权删除" }, 403);
+      return c.json(APIErrors.forbidden("无权删除"), 403);
     }
 
     // Soft delete by updating status
@@ -212,7 +213,7 @@ activityPosts.delete("/activity-posts/:id", async (c) => {
     });
   } catch (error) {
     console.error("Delete activity post error:", error);
-    return c.json({ success: false, message: "删除失败" }, 500);
+    return c.json(APIErrors.internalError("删除失败"), 500);
   }
 });
 
@@ -232,7 +233,7 @@ activityPosts.get("/locations/:id/activity-posts", async (c) => {
     });
 
     if (!location) {
-      return c.json({ success: false, message: "地点不存在" }, 404);
+      return c.json(APIErrors.notFound("地点不存在"), 404);
     }
 
     // Get visible activity posts for this location
@@ -286,7 +287,7 @@ activityPosts.get("/locations/:id/activity-posts", async (c) => {
     });
   } catch (error) {
     console.error("Get location activity posts error:", error);
-    return c.json({ success: false, message: "获取分享列表失败" }, 500);
+    return c.json(APIErrors.internalError("获取分享列表失败"), 500);
   }
 });
 

--- a/api/src/routes/locations.ts
+++ b/api/src/routes/locations.ts
@@ -270,7 +270,7 @@ locations.get("/", async (c) => {
     return c.json({ success: true, locations: formattedLocations, pagination: { page, pageSize, total, totalPages } });
   } catch (error) {
     console.error("Get locations error:", error);
-    return c.json({ success: false, error: "获取地点列表失败" }, 500);
+    return c.json(APIErrors.internalError("获取地点列表失败"), 500);
   }
 });
 
@@ -388,7 +388,7 @@ locations.get("/:id", async (c) => {
       });
     }
 
-    if (!location) return c.json({ success: false, error: "地点不存在" }, 404);
+    if (!location) return c.json(APIErrors.notFound("地点不存在"), 404);
 
     // 查询地点关联的标签
     const tagRelations = await db
@@ -429,7 +429,7 @@ locations.get("/:id", async (c) => {
     });
   } catch (error) {
     console.error("Get location error:", error);
-    return c.json({ success: false, error: "获取地点详情失败" }, 500);
+    return c.json(APIErrors.internalError("获取地点详情失败"), 500);
   }
 });
 
@@ -455,7 +455,7 @@ locations.get("/:id/pois", async (c) => {
       });
     }
 
-    if (!location) return c.json({ success: false, error: "地点不存在" }, 404);
+    if (!location) return c.json(APIErrors.notFound("地点不存在"), 404);
 
     // 查询地点关联的 POI（entityType = "location"）
     const locationPois = await db
@@ -487,7 +487,7 @@ locations.get("/:id/pois", async (c) => {
     return c.json({ success: true, pois });
   } catch (error) {
     console.error("Get location pois error:", error);
-    return c.json({ success: false, error: "获取打卡点失败" }, 500);
+    return c.json(APIErrors.internalError("获取打卡点失败"), 500);
   }
 });
 
@@ -502,17 +502,17 @@ locations.delete("/:id", async (c) => {
     const db = createDb(c.env.DB);
 
     const existing = await db.query.locations.findFirst({ where: eq(schema.locations.id, id) });
-    if (!existing) return c.json({ success: false, error: "地点不存在" }, 404);
+    if (!existing) return c.json(APIErrors.notFound("地点不存在"), 404);
 
     await db.delete(schema.locations).where(eq(schema.locations.id, id));
 
     return c.json({ success: true });
   } catch (error) {
     const message = (error as Error).message;
-    if (message === "未登录") return c.json({ success: false, error: "未登录" }, 401);
-    if (message === "无权限访问") return c.json({ success: false, error: "无权限访问" }, 403);
+    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
+    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
     console.error("Delete location error:", error);
-    return c.json({ success: false, error: "删除地点失败" }, 500);
+    return c.json(APIErrors.internalError("删除地点失败"), 500);
   }
 });
 
@@ -539,7 +539,7 @@ locations.get("/:id/tags", async (c) => {
     return c.json({ success: true, tags: rows.map((r) => r.tag) });
   } catch (error) {
     console.error("Get location tags error:", error);
-    return c.json({ success: false, error: "获取标签失败" }, 500);
+    return c.json(APIErrors.internalError("获取标签失败"), 500);
   }
 });
 
@@ -580,10 +580,10 @@ locations.put("/:id/tags", async (c) => {
     return c.json({ success: true });
   } catch (error) {
     const message = (error as Error).message;
-    if (message === "未登录") return c.json({ success: false, error: "未登录" }, 401);
-    if (message === "无权限访问") return c.json({ success: false, error: "无权限访问" }, 403);
+    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
+    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
     console.error("Update location tags error:", error);
-    return c.json({ success: false, error: "更新标签失败" }, 500);
+    return c.json(APIErrors.internalError("更新标签失败"), 500);
   }
 });
 
@@ -628,10 +628,10 @@ locations.put("/:id/pois", async (c) => {
     return c.json({ success: true });
   } catch (error) {
     const message = (error as Error).message;
-    if (message === "未登录") return c.json({ success: false, error: "未登录" }, 401);
-    if (message === "无权限访问") return c.json({ success: false, error: "无权限访问" }, 403);
+    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
+    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
     console.error("Update location pois error:", error);
-    return c.json({ success: false, error: "更新打卡点失败" }, 500);
+    return c.json(APIErrors.internalError("更新打卡点失败"), 500);
   }
 });
 
@@ -679,7 +679,7 @@ locations.get("/search", async (c) => {
     });
   } catch (error) {
     console.error("Search locations error:", error);
-    return c.json({ success: false, error: "搜索失败" }, 500);
+    return c.json(APIErrors.internalError("搜索失败"), 500);
   }
 });
 


### PR DESCRIPTION
Unifies error handling in locations and activity-posts routes to use the centralized APIErrors helper.

## Changes

### Updated Files
1. **api/src/routes/locations.ts**
   - 17 error responses unified
   - Uses: unauthorized, forbidden, notFound, internalError

2. **api/src/routes/activity-posts.ts**
   - 16 error responses unified
   - Uses: unauthorized, forbidden, badRequest, notFound, internalError
   - Also updated from 'message' to 'error' format

### Total in Batch 2
- 33 error responses unified
- Combined with batch 1: 77 error responses total

### Error Response Format
All errors now follow this structure:
```json
{
  "success": false,
  "error": {
    "code": "ERROR_CODE",
    "message": "Error message",
    "details": {} // optional
  }
}
```

### Next Steps
Remaining files for batch 3:
- admin.ts, amap.ts, auth.ts, feedback.ts, hiking-routes.ts
- pois.ts, share-image.ts, tags.ts, upload.ts
- teams/*.ts (membership.ts, mutations.ts, status.ts)

Part of #55