### PR TITLE
refactor: unify error handling to APIErrors (batch 3)

### DIFF
--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -1,3 +1,4 @@
+import { APIErrors } from "../lib/api-errors";
 import { Hono } from "hono";
 import { eq } from "drizzle-orm";
 import { createDb } from "../db";
@@ -33,7 +34,7 @@ admin.post("/clear-rate-limit", async (c) => {
     const body = await c.req.json<{ identifier?: string }>();
 
     if (!body.identifier || typeof body.identifier !== "string") {
-      return c.json({ success: false, error: "请提供要清除的标识符（邮箱）" }, 400);
+      return c.json(APIErrors.badRequest("请提供要清除的标识符（邮箱）"), 400);
     }
 
     // Worker 环境下速率限制不跨请求持久化，直接返回成功
@@ -43,10 +44,10 @@ admin.post("/clear-rate-limit", async (c) => {
     });
   } catch (error) {
     const message = (error as Error).message;
-    if (message === "未登录") return c.json({ success: false, error: "未登录" }, 401);
-    if (message === "无权限访问") return c.json({ success: false, error: "无权限访问" }, 403);
+    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
+    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
     console.error("Clear rate limit error:", error);
-    return c.json({ success: false, error: "清除失败" }, 500);
+    return c.json(APIErrors.internalError("清除失败"), 500);
   }
 });
 
@@ -69,10 +70,10 @@ admin.post("/cron/update-expired-teams", async (c) => {
     });
   } catch (error) {
     const message = (error as Error).message;
-    if (message === "未登录") return c.json({ success: false, error: "未登录" }, 401);
-    if (message === "无权限访问") return c.json({ success: false, error: "无权限访问" }, 403);
+    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
+    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
     console.error("Manual cron trigger error:", error);
-    return c.json({ success: false, error: "执行失败" }, 500);
+    return c.json(APIErrors.internalError("执行失败"), 500);
   }
 });
 

--- a/api/src/routes/amap.ts
+++ b/api/src/routes/amap.ts
@@ -1,3 +1,4 @@
+import { APIErrors } from "../lib/api-errors";
 import { Hono } from "hono";
 import type { Env } from "../lib/auth";
 import { fetchWithTimeout } from "../lib/timeout";
@@ -7,7 +8,7 @@ export const amapRoute = new Hono<{ Bindings: Env }>();
 /** 输入提示（地图搜索候选） */
 amapRoute.get("/inputtips", async (c) => {
   const AMAP_KEY = c.env.AMAP_SERVER_KEY;
-  if (!AMAP_KEY) return c.json({ success: false, error: "AMAP_SERVER_KEY not configured" }, 500);
+  if (!AMAP_KEY) return c.json(APIErrors.internalError("AMAP_SERVER_KEY not configured"), 500);
 
   const keywords = c.req.query("keywords") ?? "";
   const city = c.req.query("city") ?? "全国";
@@ -20,14 +21,14 @@ amapRoute.get("/inputtips", async (c) => {
     return c.json(data);
   } catch (error) {
     console.error("[Amap] inputtips timeout:", error);
-    return c.json({ success: false, error: "Request timeout", status: "0", tips: [] }, 504);
+    return c.json(APIErrors.internalError("Request timeout", { status: "0", tips: [] }), 504);
   }
 });
 
 /** 正地理编码（地址 → 坐标） */
 amapRoute.get("/geocode", async (c) => {
   const AMAP_KEY = c.env.AMAP_SERVER_KEY;
-  if (!AMAP_KEY) return c.json({ success: false, error: "AMAP_SERVER_KEY not configured" }, 500);
+  if (!AMAP_KEY) return c.json(APIErrors.internalError("AMAP_SERVER_KEY not configured"), 500);
 
   const address = c.req.query("address") ?? "";
   if (!address.trim()) return c.json({ status: "0", geocodes: [] });
@@ -39,14 +40,14 @@ amapRoute.get("/geocode", async (c) => {
     return c.json(data);
   } catch (error) {
     console.error("[Amap] geocode timeout:", error);
-    return c.json({ success: false, error: "Request timeout", status: "0", geocodes: [] }, 504);
+    return c.json(APIErrors.internalError("Request timeout", { status: "0", geocodes: [] }), 504);
   }
 });
 
 /** 逆地理编码（坐标 → 地址） */
 amapRoute.get("/regeo", async (c) => {
   const AMAP_KEY = c.env.AMAP_SERVER_KEY;
-  if (!AMAP_KEY) return c.json({ success: false, error: "AMAP_SERVER_KEY not configured" }, 500);
+  if (!AMAP_KEY) return c.json(APIErrors.internalError("AMAP_SERVER_KEY not configured"), 500);
 
   const location = c.req.query("location") ?? "";
   if (!location) return c.json({ status: "0" });
@@ -58,6 +59,6 @@ amapRoute.get("/regeo", async (c) => {
     return c.json(data);
   } catch (error) {
     console.error("[Amap] regeo timeout:", error);
-    return c.json({ success: false, error: "Request timeout", status: "0" }, 504);
+    return c.json(APIErrors.internalError("Request timeout", { status: "0" }), 504);
   }
 });

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -1,3 +1,4 @@
+import { APIErrors } from "../lib/api-errors";
 import { Hono } from "hono";
 import { z } from "zod";
 import { eq } from "drizzle-orm";
@@ -23,13 +24,13 @@ auth.post("/forgot-password", async (c) => {
     const ip = getClientIP(c.req.raw);
     const rateResult = await checkRateLimit(c.env.GOMATE_KV, `rate:auth:forgot:${ip}`, 5, 60);
     if (!rateResult.allowed) {
-      return c.json({ success: false, error: "请求过于频繁，请稍后再试", retryAfter: rateResult.retryAfter }, 429);
+      return c.json(APIErrors.badRequest("请求过于频繁，请稍后再试", { retryAfter: rateResult.retryAfter }), 429);
     }
 
     const body = await c.req.json();
     const parsed = forgotPasswordSchema.safeParse(body);
     if (!parsed.success) {
-      return c.json({ success: false, error: parsed.error.errors[0]?.message || "请提供有效的邮箱地址" }, 400);
+      return c.json(APIErrors.validationError(parsed.error.errors[0]?.message || "请提供有效的邮箱地址"), 400);
     }
     const { email } = parsed.data;
 
@@ -57,7 +58,7 @@ auth.post("/forgot-password", async (c) => {
     return c.json({ success: true, message: "如果该邮箱已注册，重置密码邮件已发送" });
   } catch (error) {
     console.error("Forgot password error:", error);
-    return c.json({ success: false, error: "发送重置邮件失败，请稍后重试" }, 500);
+    return c.json(APIErrors.internalError("发送重置邮件失败，请稍后重试"), 500);
   }
 });
 
@@ -77,12 +78,12 @@ auth.all("/*", async (c) => {
     if (path.endsWith("/sign-in/email") || path.endsWith("/sign-in")) {
       const result = await checkRateLimit(c.env.GOMATE_KV, `rate:auth:signin:${ip}`, 20, 60);
       if (!result.allowed) {
-        return c.json({ success: false, error: "登录尝试过于频繁，请稍后再试", retryAfter: result.retryAfter }, 429);
+        return c.json(APIErrors.badRequest("登录尝试过于频繁，请稍后再试", { retryAfter: result.retryAfter }), 429);
       }
     } else if (path.endsWith("/sign-up/email") || path.endsWith("/sign-up")) {
       const result = await checkRateLimit(c.env.GOMATE_KV, `rate:auth:signup:${ip}`, 10, 60);
       if (!result.allowed) {
-        return c.json({ success: false, error: "注册请求过于频繁，请稍后再试", retryAfter: result.retryAfter }, 429);
+        return c.json(APIErrors.badRequest("注册请求过于频繁，请稍后再试", { retryAfter: result.retryAfter }), 429);
       }
     }
   } catch (err) {

--- a/api/src/routes/feedback.ts
+++ b/api/src/routes/feedback.ts
@@ -1,3 +1,4 @@
+import { APIErrors } from "../lib/api-errors";
 import { Hono } from "hono";
 import { z } from "zod";
 import { sendFeedbackEmail } from "../lib/email";
@@ -26,7 +27,7 @@ feedback.post("/", async (c) => {
     const body = await c.req.json();
     const parsed = feedbackSchema.safeParse(body);
     if (!parsed.success) {
-      return c.json({ success: false, error: "输入无效", details: parsed.error.errors }, 400);
+      return c.json(APIErrors.validationError("输入无效", parsed.error.errors), 400);
     }
 
     const { type, name, email, content, device, browser, steps, pageUrl } = parsed.data;
@@ -54,7 +55,7 @@ feedback.post("/", async (c) => {
 
     if (!result.success) {
       console.error("Failed to send feedback email:", result.error);
-      return c.json({ success: false, error: "发送失败，请稍后重试" }, 500);
+      return c.json(APIErrors.internalError("发送失败，请稍后重试"), 500);
     }
 
     return c.json({
@@ -63,7 +64,7 @@ feedback.post("/", async (c) => {
     });
   } catch (error) {
     console.error("Feedback API error:", error);
-    return c.json({ success: false, error: "服务器错误，请稍后重试" }, 500);
+    return c.json(APIErrors.internalError("服务器错误，请稍后重试"), 500);
   }
 });
 

--- a/api/src/routes/hiking-routes.ts
+++ b/api/src/routes/hiking-routes.ts
@@ -1,3 +1,4 @@
+import { APIErrors } from "../lib/api-errors";
 import { Hono } from "hono";
 import { eq, and, inArray, asc } from "drizzle-orm";
 import { createDb } from "../db";
@@ -108,7 +109,7 @@ hikingRoutes.get("/", async (c) => {
     return c.json({ success: true, routes: formattedRoutes });
   } catch (error) {
     console.error("Get routes error:", error);
-    return c.json({ success: false, error: "获取路线列表失败" }, 500);
+    return c.json(APIErrors.internalError("获取路线列表失败"), 500);
   }
 });
 
@@ -130,7 +131,7 @@ hikingRoutes.post("/", async (c) => {
 
     if (!body.locationId || !body.cityId || !body.name || !body.difficulty ||
         body.durationMin === undefined || body.durationMax === undefined || body.distance === undefined) {
-      return c.json({ success: false, error: "缺少必填字段" }, 400);
+      return c.json(APIErrors.badRequest("缺少必填字段"), 400);
     }
 
     const routeId = `route_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
@@ -170,10 +171,10 @@ hikingRoutes.post("/", async (c) => {
     return c.json({ success: true, routeId });
   } catch (error) {
     const message = (error as Error).message;
-    if (message === "未登录") return c.json({ success: false, error: "未登录" }, 401);
-    if (message === "无权限访问") return c.json({ success: false, error: "无权限访问" }, 403);
+    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
+    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
     console.error("Create route error:", error);
-    return c.json({ success: false, error: "创建路线失败" }, 500);
+    return c.json(APIErrors.internalError("创建路线失败"), 500);
   }
 });
 
@@ -198,7 +199,7 @@ hikingRoutes.get("/:id", async (c) => {
       .where(eq(schema.routes.id, id))
       .limit(1);
 
-    if (!result.length) return c.json({ success: false, error: "路线不存在" }, 404);
+    if (!result.length) return c.json(APIErrors.notFound("路线不存在"), 404);
 
     const { route, location, city } = result[0];
 
@@ -254,7 +255,7 @@ hikingRoutes.get("/:id", async (c) => {
     });
   } catch (error) {
     console.error("Get route error:", error);
-    return c.json({ success: false, error: "获取路线详情失败" }, 500);
+    return c.json(APIErrors.internalError("获取路线详情失败"), 500);
   }
 });
 
@@ -313,10 +314,10 @@ hikingRoutes.put("/:id", async (c) => {
     return c.json({ success: true });
   } catch (error) {
     const message = (error as Error).message;
-    if (message === "未登录") return c.json({ success: false, error: "未登录" }, 401);
-    if (message === "无权限访问") return c.json({ success: false, error: "无权限访问" }, 403);
+    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
+    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
     console.error("Update route error:", error);
-    return c.json({ success: false, error: "更新路线失败" }, 500);
+    return c.json(APIErrors.internalError("更新路线失败"), 500);
   }
 });
 
@@ -331,17 +332,17 @@ hikingRoutes.delete("/:id", async (c) => {
     const db = createDb(c.env.DB);
 
     const existing = await db.select({ id: schema.routes.id }).from(schema.routes).where(eq(schema.routes.id, id)).limit(1);
-    if (!existing.length) return c.json({ success: false, error: "路线不存在" }, 404);
+    if (!existing.length) return c.json(APIErrors.notFound("路线不存在"), 404);
 
     await db.delete(schema.routes).where(eq(schema.routes.id, id));
 
     return c.json({ success: true });
   } catch (error) {
     const message = (error as Error).message;
-    if (message === "未登录") return c.json({ success: false, error: "未登录" }, 401);
-    if (message === "无权限访问") return c.json({ success: false, error: "无权限访问" }, 403);
+    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
+    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
     console.error("Delete route error:", error);
-    return c.json({ success: false, error: "删除路线失败" }, 500);
+    return c.json(APIErrors.internalError("删除路线失败"), 500);
   }
 });
 

--- a/api/src/routes/share-image.ts
+++ b/api/src/routes/share-image.ts
@@ -1,3 +1,4 @@
+import { APIErrors } from "../lib/api-errors";
 import { Hono } from "hono";
 import type { Env } from "../lib/auth";
 import { generatePreviewImage, generateLocationImage, generateTeamImage } from "../services/share-image/generate-share-image";
@@ -40,7 +41,7 @@ shareImageRoute.get("/location/:locationId", async (c) => {
     const refresh = c.req.query("refresh") === "1";
 
     if (!locationId) {
-      return c.json({ success: false, error: "Location ID is required" }, 400);
+      return c.json(APIErrors.badRequest("Location ID is required"), 400);
     }
 
     if (refresh && c.env.R2) {
@@ -90,7 +91,7 @@ shareImageRoute.get("/team/:teamId", async (c) => {
     const refresh = c.req.query("refresh") === "1";
 
     if (!teamId) {
-      return c.json({ success: false, error: "Team ID is required" }, 400);
+      return c.json(APIErrors.badRequest("Team ID is required"), 400);
     }
 
     if (refresh && c.env.R2) {

--- a/api/src/routes/tags.ts
+++ b/api/src/routes/tags.ts
@@ -1,3 +1,4 @@
+import { APIErrors } from "../lib/api-errors";
 import { Hono } from "hono";
 import { eq } from "drizzle-orm";
 import { createDb } from "../db";
@@ -43,7 +44,7 @@ tags.get("/", async (c) => {
     return c.json({ success: true, tags: result });
   } catch (error) {
     console.error("Get tags error:", error);
-    return c.json({ success: false, error: "获取标签列表失败" }, 500);
+    return c.json(APIErrors.internalError("获取标签列表失败"), 500);
   }
 });
 
@@ -58,7 +59,7 @@ tags.post("/", async (c) => {
     const body = await c.req.json<{ name?: string; type?: string; description?: string }>();
 
     if (!body.name || !body.type) {
-      return c.json({ success: false, error: "缺少必填字段" }, 400);
+      return c.json(APIErrors.badRequest("缺少必填字段"), 400);
     }
 
     // 检查是否已存在同名同类标签
@@ -83,10 +84,10 @@ tags.post("/", async (c) => {
     return c.json({ success: true, tagId, existing: false });
   } catch (error) {
     const message = (error as Error).message;
-    if (message === "未登录") return c.json({ success: false, error: "未登录" }, 401);
-    if (message === "无权限访问") return c.json({ success: false, error: "无权限访问" }, 403);
+    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
+    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
     console.error("Create tag error:", error);
-    return c.json({ success: false, error: "创建标签失败" }, 500);
+    return c.json(APIErrors.internalError("创建标签失败"), 500);
   }
 });
 


### PR DESCRIPTION
Unifies error handling in 7 route files to use the centralized APIErrors helper.

## Updated Files
- **share-image.ts**: 2 errors unified
- **feedback.ts**: 3 errors unified
- **auth.ts**: 5 errors unified (including rate limit errors with retryAfter)
- **tags.ts**: 5 errors unified
- **amap.ts**: 6 errors unified (including timeout errors with additional context)
- **admin.ts**: 7 errors unified
- **hiking-routes.ts**: 14 errors unified

## Total in Batch 3
42 error responses unified

## Cumulative Progress
- Batch 1: 44 errors (favorites, messages, users)
- Batch 2: 33 errors (locations, activity-posts)
- Batch 3: 42 errors (7 files above)
- **Total: 119 error responses unified**

## Error Types Used
- unauthorized (401)
- forbidden (403)
- badRequest (400) - including with details for rate limits
- notFound (404)
- internalError (500) - including with details for timeouts
- validationError (400)

## Remaining for Batch 4
- pois.ts (22 errors)
- upload.ts (22 errors)
- teams/membership.ts (37 errors)
- teams/mutations.ts (26 errors)
- teams/status.ts (23 errors)

Part of #55