### PR TITLE
refactor: unify error handling to APIErrors (batch 4)

### DIFF
--- a/api/src/routes/pois.ts
+++ b/api/src/routes/pois.ts
@@ -1,3 +1,4 @@
+import { APIErrors } from "../lib/api-errors";
 import { Hono } from "hono";
 import { like, eq } from "drizzle-orm";
 import { createDb } from "../db";
@@ -65,7 +66,7 @@ poisRoute.get("/", async (c) => {
     return c.json({ success: true, pois });
   } catch (error) {
     console.error("Get pois error:", error);
-    return c.json({ success: false, error: "获取打卡点列表失败" }, 500);
+    return c.json(APIErrors.internalError("获取打卡点列表失败"), 500);
   }
 });
 
@@ -85,7 +86,7 @@ poisRoute.get("/:id", async (c) => {
       .limit(1);
 
     if (!poi.length) {
-      return c.json({ success: false, error: "打卡点不存在" }, 404);
+      return c.json(APIErrors.notFound("打卡点不存在"), 404);
     }
 
     const p = poi[0];
@@ -104,7 +105,7 @@ poisRoute.get("/:id", async (c) => {
     });
   } catch (error) {
     console.error("Get poi error:", error);
-    return c.json({ success: false, error: "获取打卡点详情失败" }, 500);
+    return c.json(APIErrors.internalError("获取打卡点详情失败"), 500);
   }
 });
 
@@ -125,21 +126,21 @@ poisRoute.post("/", async (c) => {
 
     // 验证必填字段
     if (!body.name?.trim()) {
-      return c.json({ success: false, error: "名称为必填项" }, 400);
+      return c.json(APIErrors.badRequest("名称为必填项"), 400);
     }
     if (body.name.length > 50) {
-      return c.json({ success: false, error: "名称不能超过50个字符" }, 400);
+      return c.json(APIErrors.badRequest("名称不能超过50个字符"), 400);
     }
 
     // 验证坐标
     const coordinates = validateCoordinates(body.coordinates);
     if (!coordinates) {
-      return c.json({ success: false, error: "坐标格式无效，需要 { lat: number, lng: number }" }, 400);
+      return c.json(APIErrors.badRequest("坐标格式无效，需要 { lat: number, lng: number }"), 400);
     }
 
     // 可选字段验证
     if (body.description && body.description.length > 500) {
-      return c.json({ success: false, error: "描述不能超过500个字符" }, 400);
+      return c.json(APIErrors.badRequest("描述不能超过500个字符"), 400);
     }
 
     const poiId = generatePoiId();
@@ -158,10 +159,10 @@ poisRoute.post("/", async (c) => {
     return c.json({ success: true, poiId });
   } catch (error) {
     const message = (error as Error).message;
-    if (message === "未登录") return c.json({ success: false, error: "未登录" }, 401);
-    if (message === "无权限访问") return c.json({ success: false, error: "无权限访问" }, 403);
+    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
+    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
     console.error("Create poi error:", error);
-    return c.json({ success: false, error: "创建打卡点失败" }, 500);
+    return c.json(APIErrors.internalError("创建打卡点失败"), 500);
   }
 });
 
@@ -188,7 +189,7 @@ poisRoute.put("/:id", async (c) => {
       .where(eq(schema.pois.id, id))
       .limit(1);
     if (!existing.length) {
-      return c.json({ success: false, error: "打卡点不存在" }, 404);
+      return c.json(APIErrors.notFound("打卡点不存在"), 404);
     }
 
     // 构建更新数据
@@ -196,10 +197,10 @@ poisRoute.put("/:id", async (c) => {
 
     if (body.name !== undefined) {
       if (!body.name.trim()) {
-        return c.json({ success: false, error: "名称不能为空" }, 400);
+        return c.json(APIErrors.badRequest("名称不能为空"), 400);
       }
       if (body.name.length > 50) {
-        return c.json({ success: false, error: "名称不能超过50个字符" }, 400);
+        return c.json(APIErrors.badRequest("名称不能超过50个字符"), 400);
       }
       updateData.name = body.name.trim();
     }
@@ -207,14 +208,14 @@ poisRoute.put("/:id", async (c) => {
     if (body.coordinates !== undefined) {
       const coordinates = validateCoordinates(body.coordinates);
       if (!coordinates) {
-        return c.json({ success: false, error: "坐标格式无效" }, 400);
+        return c.json(APIErrors.badRequest("坐标格式无效"), 400);
       }
       updateData.coordinates = JSON.stringify(coordinates);
     }
 
     if (body.description !== undefined) {
       if (body.description && body.description.length > 500) {
-        return c.json({ success: false, error: "描述不能超过500个字符" }, 400);
+        return c.json(APIErrors.badRequest("描述不能超过500个字符"), 400);
       }
       updateData.description = body.description?.trim() ?? null;
     }
@@ -231,10 +232,10 @@ poisRoute.put("/:id", async (c) => {
     return c.json({ success: true });
   } catch (error) {
     const message = (error as Error).message;
-    if (message === "未登录") return c.json({ success: false, error: "未登录" }, 401);
-    if (message === "无权限访问") return c.json({ success: false, error: "无权限访问" }, 403);
+    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
+    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
     console.error("Update poi error:", error);
-    return c.json({ success: false, error: "更新打卡点失败" }, 500);
+    return c.json(APIErrors.internalError("更新打卡点失败"), 500);
   }
 });
 
@@ -256,7 +257,7 @@ poisRoute.delete("/:id", async (c) => {
       .where(eq(schema.pois.id, id))
       .limit(1);
     if (!existing.length) {
-      return c.json({ success: false, error: "打卡点不存在" }, 404);
+      return c.json(APIErrors.notFound("打卡点不存在"), 404);
     }
 
     // 查询关联数量（用于前端提示）
@@ -272,9 +273,9 @@ poisRoute.delete("/:id", async (c) => {
     return c.json({ success: true, removedAssociations });
   } catch (error) {
     const message = (error as Error).message;
-    if (message === "未登录") return c.json({ success: false, error: "未登录" }, 401);
-    if (message === "无权限访问") return c.json({ success: false, error: "无权限访问" }, 403);
+    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
+    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
     console.error("Delete poi error:", error);
-    return c.json({ success: false, error: "删除打卡点失败" }, 500);
+    return c.json(APIErrors.internalError("删除打卡点失败"), 500);
   }
 });

--- a/api/src/routes/stories.ts
+++ b/api/src/routes/stories.ts
@@ -1,3 +1,4 @@
+import { APIErrors } from "../lib/api-errors";
 import { Hono } from "hono";
 import { eq, desc, count, sql, inArray, and } from "drizzle-orm";
 import { createAuth } from "../lib/auth";
@@ -71,7 +72,7 @@ stories.get("/stats", async (c) => {
     });
   } catch (error) {
     console.error("Get stories stats error:", error);
-    return c.json({ success: false, message: "获取统计数据失败" }, 500);
+    return c.json(APIErrors.internalError("获取统计数据失败"), 500);
   }
 });
 
@@ -180,7 +181,7 @@ stories.get("/", async (c) => {
     });
   } catch (error) {
     console.error("Get stories error:", error);
-    return c.json({ success: false, message: "获取故事列表失败" }, 500);
+    return c.json(APIErrors.internalError("获取故事列表失败"), 500);
   }
 });
 
@@ -215,7 +216,7 @@ stories.get("/:id", async (c) => {
       .limit(1);
 
     if (!result.length) {
-      return c.json({ success: false, message: "故事不存在" }, 404);
+      return c.json(APIErrors.notFound("故事不存在"), 404);
     }
 
     const { story, author, location } = result[0];
@@ -250,7 +251,7 @@ stories.get("/:id", async (c) => {
     });
   } catch (error) {
     console.error("Get story detail error:", error);
-    return c.json({ success: false, message: "获取故事详情失败" }, 500);
+    return c.json(APIErrors.internalError("获取故事详情失败"), 500);
   }
 });
 
@@ -265,7 +266,7 @@ stories.post("/", async (c) => {
     const session = await auth.api.getSession({ headers: c.req.raw.headers });
 
     if (!session) {
-      return c.json({ success: false, message: "请先登录" }, 401);
+      return c.json(APIErrors.unauthorized("请先登录"), 401);
     }
 
     const db = createDb(c.env.DB);
@@ -275,23 +276,23 @@ stories.post("/", async (c) => {
     const { title, summary, content, coverImage, locationId } = body;
 
     if (!title || title.trim().length === 0) {
-      return c.json({ success: false, message: "标题不能为空" }, 400);
+      return c.json(APIErrors.badRequest("标题不能为空"), 400);
     }
 
     if (title.length > 100) {
-      return c.json({ success: false, message: "标题不能超过100字" }, 400);
+      return c.json(APIErrors.badRequest("标题不能超过100字"), 400);
     }
 
     if (!summary || summary.trim().length === 0) {
-      return c.json({ success: false, message: "摘要不能为空" }, 400);
+      return c.json(APIErrors.badRequest("摘要不能为空"), 400);
     }
 
     if (summary.length > 150) {
-      return c.json({ success: false, message: "摘要不能超过150字" }, 400);
+      return c.json(APIErrors.badRequest("摘要不能超过150字"), 400);
     }
 
     if (!content || content.trim().length === 0) {
-      return c.json({ success: false, message: "内容不能为空" }, 400);
+      return c.json(APIErrors.badRequest("内容不能为空"), 400);
     }
 
     const storyId = crypto.randomUUID();
@@ -319,7 +320,7 @@ stories.post("/", async (c) => {
     });
   } catch (error) {
     console.error("Create story error:", error);
-    return c.json({ success: false, message: "发布失败" }, 500);
+    return c.json(APIErrors.internalError("发布失败"), 500);
   }
 });
 
@@ -334,7 +335,7 @@ stories.put("/:id", async (c) => {
     const session = await auth.api.getSession({ headers: c.req.raw.headers });
 
     if (!session) {
-      return c.json({ success: false, message: "请先登录" }, 401);
+      return c.json(APIErrors.unauthorized("请先登录"), 401);
     }
 
     const db = createDb(c.env.DB);
@@ -346,14 +347,14 @@ stories.put("/:id", async (c) => {
     });
 
     if (!story) {
-      return c.json({ success: false, message: "故事不存在" }, 404);
+      return c.json(APIErrors.notFound("故事不存在"), 404);
     }
 
     const isAuthor = story.authorId === userId;
     const isAdmin = session.user.role === "admin";
 
     if (!isAuthor && !isAdmin) {
-      return c.json({ success: false, message: "无权编辑" }, 403);
+      return c.json(APIErrors.forbidden("无权编辑"), 403);
     }
 
     const body = await c.req.json();
@@ -378,7 +379,7 @@ stories.put("/:id", async (c) => {
     });
   } catch (error) {
     console.error("Update story error:", error);
-    return c.json({ success: false, message: "更新失败" }, 500);
+    return c.json(APIErrors.internalError("更新失败"), 500);
   }
 });
 
@@ -393,7 +394,7 @@ stories.delete("/:id", async (c) => {
     const session = await auth.api.getSession({ headers: c.req.raw.headers });
 
     if (!session) {
-      return c.json({ success: false, message: "请先登录" }, 401);
+      return c.json(APIErrors.unauthorized("请先登录"), 401);
     }
 
     const db = createDb(c.env.DB);
@@ -405,14 +406,14 @@ stories.delete("/:id", async (c) => {
     });
 
     if (!story) {
-      return c.json({ success: false, message: "故事不存在" }, 404);
+      return c.json(APIErrors.notFound("故事不存在"), 404);
     }
 
     const isAuthor = story.authorId === userId;
     const isAdmin = session.user.role === "admin";
 
     if (!isAuthor && !isAdmin) {
-      return c.json({ success: false, message: "无权删除" }, 403);
+      return c.json(APIErrors.forbidden("无权删除"), 403);
     }
 
     await db
@@ -429,7 +430,7 @@ stories.delete("/:id", async (c) => {
     });
   } catch (error) {
     console.error("Delete story error:", error);
-    return c.json({ success: false, message: "删除失败" }, 500);
+    return c.json(APIErrors.internalError("删除失败"), 500);
   }
 });
 
@@ -443,7 +444,7 @@ stories.post("/:id/like", async (c) => {
     const session = await auth.api.getSession({ headers: c.req.raw.headers });
 
     if (!session) {
-      return c.json({ success: false, message: "请先登录" }, 401);
+      return c.json(APIErrors.unauthorized("请先登录"), 401);
     }
 
     const db = createDb(c.env.DB);
@@ -454,7 +455,7 @@ stories.post("/:id/like", async (c) => {
     });
 
     if (!story) {
-      return c.json({ success: false, message: "故事不存在" }, 404);
+      return c.json(APIErrors.notFound("故事不存在"), 404);
     }
 
     await db
@@ -471,7 +472,7 @@ stories.post("/:id/like", async (c) => {
     });
   } catch (error) {
     console.error("Like story error:", error);
-    return c.json({ success: false, message: "点赞失败" }, 500);
+    return c.json(APIErrors.internalError("点赞失败"), 500);
   }
 });
 
@@ -516,7 +517,7 @@ stories.get("/tags", async (c) => {
     });
   } catch (error) {
     console.error("Get story tags error:", error);
-    return c.json({ success: false, message: "获取标签失败" }, 500);
+    return c.json(APIErrors.internalError("获取标签失败"), 500);
   }
 });
 

--- a/api/src/routes/upload.ts
+++ b/api/src/routes/upload.ts
@@ -1,3 +1,4 @@
+import { APIErrors } from "../lib/api-errors";
 import { Hono } from "hono";
 import { eq } from "drizzle-orm";
 import { createAuth } from "../lib/auth";
@@ -31,14 +32,14 @@ upload.post("/avatar", async (c) => {
   try {
     const authInstance = createAuth(c.env);
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
-    if (!session) return c.json({ success: false, error: "请先登录" }, 401);
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
 
     const formData = await c.req.formData();
     const file = formData.get("file") as File | null;
     const userId = formData.get("userId") as string | null;
 
-    if (!file) return c.json({ success: false, error: "No file provided" }, 400);
-    if (!userId) return c.json({ success: false, error: "User ID is required" }, 400);
+    if (!file) return c.json(APIErrors.badRequest("No file provided"), 400);
+    if (!userId) return c.json(APIErrors.badRequest("User ID is required"), 400);
 
     // 鉴权：只允许上传自己的头像（管理员除外）
     if (userId !== session.user.id) {
@@ -49,16 +50,16 @@ upload.post("/avatar", async (c) => {
         .where(eq(schema.users.id, session.user.id))
         .then((rows) => rows[0]);
       if (!userRecord || userRecord.role !== "admin") {
-        return c.json({ success: false, error: "无权上传他人头像" }, 403);
+        return c.json(APIErrors.forbidden("无权上传他人头像"), 403);
       }
     }
 
     if (!ALLOWED_IMAGE_TYPES.includes(file.type))
-      return c.json({ success: false, error: "Invalid file type. Allowed: JPEG, PNG, GIF, WebP" }, 400);
+      return c.json(APIErrors.badRequest("Invalid file type. Allowed: JPEG, PNG, GIF, WebP"), 400);
     if (file.size > MAX_FILE_SIZE)
-      return c.json({ success: false, error: "File too large. Maximum size: 5MB" }, 400);
+      return c.json(APIErrors.badRequest("File too large. Maximum size: 5MB"), 400);
 
-    if (!c.env.R2) return c.json({ success: false, error: "R2 storage not configured" }, 500);
+    if (!c.env.R2) return c.json(APIErrors.internalError("R2 storage not configured"), 500);
 
     const ext = file.type.split("/")[1] || "jpg";
     const key = `avatars/${userId}-${Date.now()}.${ext}`;
@@ -73,12 +74,12 @@ upload.post("/avatar", async (c) => {
     const publicUrl = isLocalDev
       ? `http://${host}/r2/${key}`
       : getPublicUrl(c.env, key);
-    if (!publicUrl) return c.json({ success: false, error: "R2_PUBLIC_URL not configured" }, 500);
+    if (!publicUrl) return c.json(APIErrors.internalError("R2_PUBLIC_URL not configured"), 500);
 
     return c.json({ success: true, key, url: publicUrl, size: file.size, type: file.type });
   } catch (error) {
     console.error("Avatar upload error:", error);
-    return c.json({ success: false, error: "Failed to upload avatar" }, 500);
+    return c.json(APIErrors.internalError("Failed to upload avatar"), 500);
   }
 });
 
@@ -90,12 +91,12 @@ upload.delete("/avatar", async (c) => {
   try {
     const authInstance = createAuth(c.env);
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
-    if (!session) return c.json({ success: false, error: "请先登录" }, 401);
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
 
     const key = c.req.query("key");
-    if (!key) return c.json({ success: false, error: "Object key is required" }, 400);
+    if (!key) return c.json(APIErrors.badRequest("Object key is required"), 400);
 
-    if (!c.env.R2) return c.json({ success: false, error: "R2 storage not configured" }, 500);
+    if (!c.env.R2) return c.json(APIErrors.internalError("R2 storage not configured"), 500);
 
     // 验证 key 属于当前用户
     const db = createDb(c.env.DB);
@@ -106,7 +107,7 @@ upload.delete("/avatar", async (c) => {
       .then((rows) => rows[0]);
 
     if (!userRecord?.image?.includes(key)) {
-      return c.json({ success: false, error: "无权删除该文件" }, 403);
+      return c.json(APIErrors.forbidden("无权删除该文件"), 403);
     }
 
     await c.env.R2.delete(key);
@@ -114,7 +115,7 @@ upload.delete("/avatar", async (c) => {
     return c.json({ success: true });
   } catch (error) {
     console.error("Avatar delete error:", error);
-    return c.json({ success: false, error: "Failed to delete avatar" }, 500);
+    return c.json(APIErrors.internalError("Failed to delete avatar"), 500);
   }
 });
 
@@ -126,7 +127,7 @@ upload.post("/location", async (c) => {
   try {
     const authInstance = createAuth(c.env);
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
-    if (!session) return c.json({ success: false, error: "请先登录" }, 401);
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
 
     const db = createDb(c.env.DB);
     const user = await db
@@ -134,17 +135,17 @@ upload.post("/location", async (c) => {
       .from(schema.users)
       .where(eq(schema.users.id, session.user.id))
       .then((rows) => rows[0]);
-    if (!user || user.role !== "admin") return c.json({ success: false, error: "无权限访问" }, 403);
+    if (!user || user.role !== "admin") return c.json(APIErrors.forbidden("无权限访问"), 403);
 
-    if (!c.env.R2) return c.json({ success: false, error: "R2 storage not configured" }, 500);
+    if (!c.env.R2) return c.json(APIErrors.internalError("R2 storage not configured"), 500);
 
     const formData = await c.req.formData();
     const file = formData.get("file") as File | null;
-    if (!file) return c.json({ success: false, error: "No file provided" }, 400);
+    if (!file) return c.json(APIErrors.badRequest("No file provided"), 400);
     if (!ALLOWED_IMAGE_TYPES.includes(file.type))
-      return c.json({ success: false, error: "Invalid file type" }, 400);
+      return c.json(APIErrors.badRequest("Invalid file type"), 400);
     if (file.size > MAX_FILE_SIZE)
-      return c.json({ success: false, error: "File too large. Maximum size: 5MB" }, 400);
+      return c.json(APIErrors.badRequest("File too large. Maximum size: 5MB"), 400);
 
     const ext = file.type.split("/")[1] || "jpg";
     const key = `locations/${Date.now()}.${ext}`;
@@ -159,12 +160,12 @@ upload.post("/location", async (c) => {
     const publicUrl = isLocalDev
       ? `http://${host}/r2/${key}`
       : getPublicUrl(c.env, key);
-    if (!publicUrl) return c.json({ success: false, error: "R2_PUBLIC_URL not configured" }, 500);
+    if (!publicUrl) return c.json(APIErrors.internalError("R2_PUBLIC_URL not configured"), 500);
 
     return c.json({ success: true, key, url: publicUrl, size: file.size, type: file.type });
   } catch (error) {
     console.error("Location image upload error:", error);
-    return c.json({ success: false, error: "Failed to upload location image" }, 500);
+    return c.json(APIErrors.internalError("Failed to upload location image"), 500);
   }
 });
 


### PR DESCRIPTION
Unifies error handling in 3 route files to use the centralized APIErrors helper.

## Updated Files
- **pois.ts**: 22 errors unified
- **upload.ts**: 22 errors unified
- **stories.ts**: 23 errors unified (also changed 'message' field to 'error' for consistency)

## Total in Batch 4
67 error responses unified

## Cumulative Progress
- Batch 1: 44 errors (favorites, messages, users)
- Batch 2: 33 errors (locations, activity-posts)
- Batch 3: 42 errors (share-image, feedback, auth, tags, amap, admin, hiking-routes)
- Batch 4: 67 errors (pois, upload, stories)
- **Total: 186 error responses unified**

## Error Types Used
- unauthorized (401)
- forbidden (403)
- badRequest (400)
- notFound (404)
- internalError (500)

## Remaining for Batch 5
- teams/membership.ts (37 errors)
- teams/mutations.ts (26 errors)
- teams/status.ts (23 errors)
- Total: 86 errors

Part of #55