### PR TITLE
refactor: unify error handling to APIErrors (batch 5 - final)

### DIFF
--- a/api/src/routes/teams/membership.ts
+++ b/api/src/routes/teams/membership.ts
@@ -1,3 +1,4 @@
+import { APIErrors } from "../../lib/api-errors";
 import { Hono } from "hono";
 import { eq, and, sql } from "drizzle-orm";
 import { createAuth } from "../../lib/auth";
@@ -16,7 +17,7 @@ membership.post("/join", async (c) => {
   try {
     const authInstance = createAuth(c.env);
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
-    if (!session) return c.json({ success: false, error: "请先登录" }, 401);
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
 
     const userId = session.user.id;
     const db = createDb(c.env.DB);
@@ -27,21 +28,21 @@ membership.post("/join", async (c) => {
       .where(eq(schema.users.id, userId))
       .then((rows) => rows[0]);
 
-    if (!userRecord?.wechat) return c.json({ success: false, error: "请先填写微信号才能加入队伍" }, 400);
+    if (!userRecord?.wechat) return c.json(APIErrors.badRequest("请先填写微信号才能加入队伍"), 400);
 
     const teamId = c.req.param("id");
-    if (!teamId) return c.json({ success: false, error: "缺少队伍ID" }, 400);
+    if (!teamId) return c.json(APIErrors.badRequest("缺少队伍ID"), 400);
 
     const team = await db.query.teams.findFirst({ where: eq(schema.teams.id, teamId as string) });
-    if (!team) return c.json({ success: false, error: "队伍不存在" }, 404);
-    if (team.status !== "recruiting") return c.json({ success: false, error: "该队伍当前不接受新成员" }, 400);
+    if (!team) return c.json(APIErrors.notFound("队伍不存在"), 404);
+    if (team.status !== "recruiting") return c.json(APIErrors.badRequest("该队伍当前不接受新成员"), 400);
 
     const [{ approvedCount }] = await db
       .select({ approvedCount: sql<number>`count(*)` })
       .from(schema.teamMembers)
       .where(and(eq(schema.teamMembers.teamId, teamId as string), eq(schema.teamMembers.status, "approved")));
 
-    if (approvedCount >= team.maxMembers) return c.json({ success: false, error: "队伍已满" }, 400);
+    if (approvedCount >= team.maxMembers) return c.json(APIErrors.badRequest("队伍已满"), 400);
 
     const existingMembers = await db.query.teamMembers.findMany({
       where: and(eq(schema.teamMembers.teamId, teamId as string), eq(schema.teamMembers.userId, userId)),
@@ -50,8 +51,8 @@ membership.post("/join", async (c) => {
     const existing = existingMembers[0];
 
     if (existing) {
-      if (existing.status === "approved") return c.json({ success: false, error: "你已经是该队伍的成员" }, 400);
-      if (existing.status === "pending") return c.json({ success: false, error: "你已经提交了申请，请等待审核" }, 400);
+      if (existing.status === "approved") return c.json(APIErrors.badRequest("你已经是该队伍的成员"), 400);
+      if (existing.status === "pending") return c.json(APIErrors.badRequest("你已经提交了申请，请等待审核"), 400);
       if (existing.status === "rejected") {
         await db.update(schema.teamMembers)
           .set({ status: "pending", createdAt: new Date(), statusUpdatedAt: new Date() })
@@ -90,7 +91,7 @@ membership.post("/join", async (c) => {
     return c.json({ success: true, message: "申请已提交，等待队长审核" });
   } catch (error) {
     console.error("Join team error:", error);
-    return c.json({ success: false, error: "申请加入失败" }, 500);
+    return c.json(APIErrors.internalError("申请加入失败"), 500);
   }
 });
 
@@ -102,33 +103,33 @@ membership.post("/members/:userId/approve", async (c) => {
   try {
     const authInstance = createAuth(c.env);
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
-    if (!session) return c.json({ success: false, error: "请先登录" }, 401);
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
 
     const teamId = c.req.param("id");
     const targetUserId = c.req.param("userId");
     const db = createDb(c.env.DB);
 
-    if (!teamId) return c.json({ success: false, error: "缺少队伍ID" }, 400);
+    if (!teamId) return c.json(APIErrors.badRequest("缺少队伍ID"), 400);
 
     const team = await db.query.teams.findFirst({
       where: eq(schema.teams.id, teamId as string), with: { location: true },
     });
-    if (!team) return c.json({ success: false, error: "队伍不存在" }, 404);
-    if (team.leaderId !== session.user.id) return c.json({ success: false, error: "只有队长可以审核成员" }, 403);
+    if (!team) return c.json(APIErrors.notFound("队伍不存在"), 404);
+    if (team.leaderId !== session.user.id) return c.json(APIErrors.forbidden("只有队长可以审核成员"), 403);
 
     const members = await db.query.teamMembers.findMany({
       where: and(eq(schema.teamMembers.teamId, teamId as string), eq(schema.teamMembers.userId, targetUserId), eq(schema.teamMembers.status, "pending")),
       limit: 1,
     });
     const membership = members[0];
-    if (!membership) return c.json({ success: false, error: "未找到该成员的申请" }, 404);
+    if (!membership) return c.json(APIErrors.notFound("未找到该成员的申请"), 404);
 
     const [{ approvedCount }] = await db
       .select({ approvedCount: sql<number>`count(*)` })
       .from(schema.teamMembers)
       .where(and(eq(schema.teamMembers.teamId, teamId as string), eq(schema.teamMembers.status, "approved")));
 
-    if (approvedCount >= team.maxMembers) return c.json({ success: false, error: "队伍已满，无法批准新成员" }, 400);
+    if (approvedCount >= team.maxMembers) return c.json(APIErrors.badRequest("队伍已满，无法批准新成员"), 400);
 
     const now = new Date();
     const newCount = approvedCount + 1;
@@ -144,7 +145,7 @@ membership.post("/members/:userId/approve", async (c) => {
     return c.json({ success: true, message: "已通过申请" });
   } catch (error) {
     console.error("Approve member error:", error);
-    return c.json({ success: false, error: "批准申请失败" }, 500);
+    return c.json(APIErrors.internalError("批准申请失败"), 500);
   }
 });
 
@@ -156,27 +157,27 @@ membership.post("/members/:userId/reject", async (c) => {
   try {
     const authInstance = createAuth(c.env);
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
-    if (!session) return c.json({ success: false, error: "请先登录" }, 401);
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
 
     const teamId = c.req.param("id");
     const targetUserId = c.req.param("userId");
     const db = createDb(c.env.DB);
 
-    if (!teamId) return c.json({ success: false, error: "缺少队伍ID" }, 400);
+    if (!teamId) return c.json(APIErrors.badRequest("缺少队伍ID"), 400);
 
     const body = await c.req.json<{ reason?: string }>().catch(() => ({} as { reason?: string }));
     const { reason } = body;
 
     const team = await db.query.teams.findFirst({ where: eq(schema.teams.id, teamId as string) });
-    if (!team) return c.json({ success: false, error: "队伍不存在" }, 404);
-    if (team.leaderId !== session.user.id) return c.json({ success: false, error: "只有队长可以审核成员" }, 403);
+    if (!team) return c.json(APIErrors.notFound("队伍不存在"), 404);
+    if (team.leaderId !== session.user.id) return c.json(APIErrors.forbidden("只有队长可以审核成员"), 403);
 
     const members = await db.query.teamMembers.findMany({
       where: and(eq(schema.teamMembers.teamId, teamId as string), eq(schema.teamMembers.userId, targetUserId), eq(schema.teamMembers.status, "pending")),
       limit: 1,
     });
     const membership = members[0];
-    if (!membership) return c.json({ success: false, error: "未找到该成员的申请" }, 404);
+    if (!membership) return c.json(APIErrors.notFound("未找到该成员的申请"), 404);
 
     const now = new Date();
     const extra = reason ? JSON.stringify({ rejectReason: reason }) : null;
@@ -195,7 +196,7 @@ membership.post("/members/:userId/reject", async (c) => {
     return c.json({ success: true, message: "已拒绝申请" });
   } catch (error) {
     console.error("Reject member error:", error);
-    return c.json({ success: false, error: "拒绝申请失败" }, 500);
+    return c.json(APIErrors.internalError("拒绝申请失败"), 500);
   }
 });
 
@@ -207,25 +208,25 @@ membership.post("/members/:userId/remove", async (c) => {
   try {
     const authInstance = createAuth(c.env);
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
-    if (!session) return c.json({ success: false, error: "请先登录" }, 401);
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
 
     const teamId = c.req.param("id");
     const targetUserId = c.req.param("userId");
     const db = createDb(c.env.DB);
 
-    if (!teamId) return c.json({ success: false, error: "缺少队伍ID" }, 400);
+    if (!teamId) return c.json(APIErrors.badRequest("缺少队伍ID"), 400);
 
     const team = await db.query.teams.findFirst({ where: eq(schema.teams.id, teamId as string) });
-    if (!team) return c.json({ success: false, error: "队伍不存在" }, 404);
-    if (team.leaderId !== session.user.id) return c.json({ success: false, error: "只有队长可以移除成员" }, 403);
-    if (targetUserId === session.user.id) return c.json({ success: false, error: "不能移除自己" }, 400);
+    if (!team) return c.json(APIErrors.notFound("队伍不存在"), 404);
+    if (team.leaderId !== session.user.id) return c.json(APIErrors.forbidden("只有队长可以移除成员"), 403);
+    if (targetUserId === session.user.id) return c.json(APIErrors.badRequest("不能移除自己"), 400);
 
     const members = await db.query.teamMembers.findMany({
       where: and(eq(schema.teamMembers.teamId, teamId as string), eq(schema.teamMembers.userId, targetUserId), eq(schema.teamMembers.status, "approved")),
       limit: 1,
     });
     const membership = members[0];
-    if (!membership) return c.json({ success: false, error: "该用户不是队伍成员" }, 404);
+    if (!membership) return c.json(APIErrors.notFound("该用户不是队伍成员"), 404);
 
     await db.delete(schema.teamMembers).where(eq(schema.teamMembers.id, membership.id));
 
@@ -241,7 +242,7 @@ membership.post("/members/:userId/remove", async (c) => {
     return c.json({ success: true, message: "已移除成员" });
   } catch (error) {
     console.error("Remove member error:", error);
-    return c.json({ success: false, error: "移除成员失败" }, 500);
+    return c.json(APIErrors.internalError("移除成员失败"), 500);
   }
 });
 
@@ -253,30 +254,30 @@ membership.post("/leave-request", async (c) => {
   try {
     const authInstance = createAuth(c.env);
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
-    if (!session) return c.json({ success: false, error: "请先登录" }, 401);
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
 
     const teamId = c.req.param("id");
     const db = createDb(c.env.DB);
 
-    if (!teamId) return c.json({ success: false, error: "缺少队伍ID" }, 400);
+    if (!teamId) return c.json(APIErrors.badRequest("缺少队伍ID"), 400);
 
     const team = await db.query.teams.findFirst({ where: eq(schema.teams.id, teamId as string) });
-    if (!team) return c.json({ success: false, error: "队伍不存在" }, 404);
-    if (team.status !== "formed") return c.json({ success: false, error: "只有已组建的队伍需要申请退出" }, 400);
+    if (!team) return c.json(APIErrors.notFound("队伍不存在"), 404);
+    if (team.status !== "formed") return c.json(APIErrors.badRequest("只有已组建的队伍需要申请退出"), 400);
 
     const members = await db.query.teamMembers.findMany({
       where: and(eq(schema.teamMembers.teamId, teamId as string), eq(schema.teamMembers.userId, session.user.id), eq(schema.teamMembers.status, "approved")),
       limit: 1,
     });
     const membership = members[0];
-    if (!membership) return c.json({ success: false, error: "你不是该队伍成员" }, 400);
-    if (membership.userId === team.leaderId) return c.json({ success: false, error: "队长不能退出队伍" }, 400);
+    if (!membership) return c.json(APIErrors.badRequest("你不是该队伍成员"), 400);
+    if (membership.userId === team.leaderId) return c.json(APIErrors.badRequest("队长不能退出队伍"), 400);
 
     const leaveRequests = await db.query.teamMembers.findMany({
       where: and(eq(schema.teamMembers.teamId, teamId as string), eq(schema.teamMembers.userId, session.user.id), eq(schema.teamMembers.status, "leave_pending")),
       limit: 1,
     });
-    if (leaveRequests.length > 0) return c.json({ success: false, error: "您已提交退出申请，请等待队长审批" }, 400);
+    if (leaveRequests.length > 0) return c.json(APIErrors.badRequest("您已提交退出申请，请等待队长审批"), 400);
 
     await db.update(schema.teamMembers)
       .set({ status: "leave_pending" })
@@ -285,7 +286,7 @@ membership.post("/leave-request", async (c) => {
     return c.json({ success: true, message: "退出申请已提交，等待队长审批" });
   } catch (error) {
     console.error("Request leave error:", error);
-    return c.json({ success: false, error: "提交退出申请失败" }, 500);
+    return c.json(APIErrors.internalError("提交退出申请失败"), 500);
   }
 });
 

--- a/api/src/routes/teams/mutations.ts
+++ b/api/src/routes/teams/mutations.ts
@@ -1,3 +1,4 @@
+import { APIErrors } from "../../lib/api-errors";
 import { Hono } from "hono";
 import { z } from "zod";
 import { eq, and, sql } from "drizzle-orm";
@@ -40,7 +41,7 @@ mutations.post("/", async (c) => {
   try {
     const authInstance = createAuth(c.env);
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
-    if (!session) return c.json({ success: false, error: "请先登录" }, 401);
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
 
     const db = createDb(c.env.DB);
     const userId = session.user.id;
@@ -52,20 +53,20 @@ mutations.post("/", async (c) => {
       .then((rows) => rows[0]);
 
     if (!userRecord?.wechat) {
-      return c.json({ success: false, error: "请先填写微信号才能创建队伍" }, 400);
+      return c.json(APIErrors.badRequest("请先填写微信号才能创建队伍"), 400);
     }
 
     const body = await c.req.json();
     const parsed = createTeamSchema.safeParse(body);
     if (!parsed.success) {
-      return c.json({ success: false, error: "输入无效", details: parsed.error.errors }, 400);
+      return c.json(APIErrors.validationError("输入无效", parsed.error.errors), 400);
     }
 
     const { locationId, routeId, title, description, date, time, duration, durationMin, maxMembers, requirements } = parsed.data;
 
     const startTime = new Date(`${date}T${time}`);
     if (isNaN(startTime.getTime())) {
-      return c.json({ success: false, error: "无效的日期或时间格式" }, 400);
+      return c.json(APIErrors.badRequest("无效的日期或时间格式"), 400);
     }
 
     const durationMinutes = durationMin || (duration
@@ -92,7 +93,7 @@ mutations.post("/", async (c) => {
     return c.json({ success: true, team: { id: teamId, locationId, routeId, leaderId: userId, title, description, startTime: startTime.toISOString(), endTime: endTime.toISOString(), durationMin: durationMinutes, maxMembers, currentMembers: 1, requirements, icon: teamIcon, status: "recruiting", createdAt: now.toISOString() } });
   } catch (error) {
     console.error("Create team error:", error);
-    return c.json({ success: false, error: "创建队伍失败" }, 500);
+    return c.json(APIErrors.internalError("创建队伍失败"), 500);
   }
 });
 
@@ -104,7 +105,7 @@ mutations.put("/:id", async (c) => {
   try {
     const authInstance = createAuth(c.env);
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
-    if (!session) return c.json({ success: false, error: "请先登录" }, 401);
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
 
     const teamId = c.req.param("id");
     const db = createDb(c.env.DB);
@@ -114,14 +115,14 @@ mutations.put("/:id", async (c) => {
       with: { location: true },
     });
 
-    if (!team) return c.json({ success: false, error: "队伍不存在" }, 404);
+    if (!team) return c.json(APIErrors.notFound("队伍不存在"), 404);
     if (team.leaderId !== session.user.id)
-      return c.json({ success: false, error: "只有队长可以修改队伍" }, 403);
+      return c.json(APIErrors.forbidden("只有队长可以修改队伍"), 403);
 
     const body = await c.req.json();
     const parsed = updateTeamSchema.safeParse(body);
     if (!parsed.success) {
-      return c.json({ success: false, error: "输入无效", details: parsed.error.errors }, 400);
+      return c.json(APIErrors.validationError("输入无效", parsed.error.errors), 400);
     }
 
     const { title, description, maxMembers, requirements, time, durationMin } = parsed.data;
@@ -164,7 +165,7 @@ mutations.put("/:id", async (c) => {
     return c.json({ success: true, message: "队伍信息已更新" });
   } catch (error) {
     console.error("Update team error:", error);
-    return c.json({ success: false, error: "更新队伍失败" }, 500);
+    return c.json(APIErrors.internalError("更新队伍失败"), 500);
   }
 });
 
@@ -176,20 +177,20 @@ mutations.delete("/:id", async (c) => {
   try {
     const authInstance = createAuth(c.env);
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
-    if (!session) return c.json({ success: false, error: "请先登录" }, 401);
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
 
     const teamId = c.req.param("id");
     const userId = session.user.id;
     const db = createDb(c.env.DB);
 
     const team = await db.query.teams.findFirst({ where: eq(schema.teams.id, teamId) });
-    if (!team) return c.json({ success: false, error: "队伍不存在" }, 404);
+    if (!team) return c.json(APIErrors.notFound("队伍不存在"), 404);
 
     if (team.leaderId !== userId)
-      return c.json({ success: false, error: "只有队长可以删除队伍" }, 403);
+      return c.json(APIErrors.forbidden("只有队长可以删除队伍"), 403);
 
     if (team.status !== "recruiting" && team.status !== "cancelled")
-      return c.json({ success: false, error: "只有招募中或已取消的队伍可以删除" }, 400);
+      return c.json(APIErrors.badRequest("只有招募中或已取消的队伍可以删除"), 400);
 
     await db.delete(schema.teamMembers).where(eq(schema.teamMembers.teamId, teamId));
     await db.delete(schema.teams).where(eq(schema.teams.id, teamId));
@@ -197,7 +198,7 @@ mutations.delete("/:id", async (c) => {
     return c.json({ success: true, message: "队伍已删除" });
   } catch (error) {
     console.error("Delete team error:", error);
-    return c.json({ success: false, error: "删除队伍失败" }, 500);
+    return c.json(APIErrors.internalError("删除队伍失败"), 500);
   }
 });
 
@@ -209,7 +210,7 @@ mutations.post("/:id/form", async (c) => {
   try {
     const authInstance = createAuth(c.env);
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
-    if (!session) return c.json({ success: false, error: "请先登录" }, 401);
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
 
     const teamId = c.req.param("id");
     const db = createDb(c.env.DB);
@@ -218,17 +219,17 @@ mutations.post("/:id/form", async (c) => {
     const isUnderfilled = body.isUnderfilled === true;
 
     const team = await db.query.teams.findFirst({ where: eq(schema.teams.id, teamId) });
-    if (!team) return c.json({ success: false, error: "队伍不存在" }, 404);
-    if (team.leaderId !== session.user.id) return c.json({ success: false, error: "只有队长可以组建队伍" }, 403);
+    if (!team) return c.json(APIErrors.notFound("队伍不存在"), 404);
+    if (team.leaderId !== session.user.id) return c.json(APIErrors.forbidden("只有队长可以组建队伍"), 403);
     if (team.status !== "recruiting" && team.status !== "full")
-      return c.json({ success: false, error: "当前队伍状态无法组建" }, 400);
+      return c.json(APIErrors.badRequest("当前队伍状态无法组建"), 400);
 
     const [{ approvedCount }] = await db
       .select({ approvedCount: sql<number>`count(*)` })
       .from(schema.teamMembers)
       .where(and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.status, "approved")));
 
-    if (approvedCount < 1) return c.json({ success: false, error: "队伍至少需要1人才能组建" }, 400);
+    if (approvedCount < 1) return c.json(APIErrors.badRequest("队伍至少需要1人才能组建"), 400);
 
     await db.update(schema.teams)
       .set({ status: "formed", updatedAt: new Date() })
@@ -237,7 +238,7 @@ mutations.post("/:id/form", async (c) => {
     return c.json({ success: true, message: "队伍已组建", isUnderfilled });
   } catch (error) {
     console.error("Form team error:", error);
-    return c.json({ success: false, error: "组建队伍失败" }, 500);
+    return c.json(APIErrors.internalError("组建队伍失败"), 500);
   }
 });
 
@@ -249,17 +250,17 @@ mutations.post("/:id/cancel", async (c) => {
   try {
     const authInstance = createAuth(c.env);
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
-    if (!session) return c.json({ success: false, error: "请先登录" }, 401);
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
 
     const teamId = c.req.param("id");
     const db = createDb(c.env.DB);
 
     const team = await db.query.teams.findFirst({ where: eq(schema.teams.id, teamId) });
-    if (!team) return c.json({ success: false, error: "队伍不存在" }, 404);
+    if (!team) return c.json(APIErrors.notFound("队伍不存在"), 404);
     if (team.leaderId !== session.user.id)
-      return c.json({ success: false, error: "只有队长可以取消队伍" }, 403);
+      return c.json(APIErrors.forbidden("只有队长可以取消队伍"), 403);
     if (team.status !== "recruiting" && team.status !== "full")
-      return c.json({ success: false, error: "当前队伍状态无法取消" }, 400);
+      return c.json(APIErrors.badRequest("当前队伍状态无法取消"), 400);
 
     await db.update(schema.teams)
       .set({ status: "cancelled", updatedAt: new Date() })
@@ -268,7 +269,7 @@ mutations.post("/:id/cancel", async (c) => {
     return c.json({ success: true, message: "队伍已取消" });
   } catch (error) {
     console.error("Cancel team error:", error);
-    return c.json({ success: false, error: "取消队伍失败" }, 500);
+    return c.json(APIErrors.internalError("取消队伍失败"), 500);
   }
 });
 

--- a/api/src/routes/teams/status.ts
+++ b/api/src/routes/teams/status.ts
@@ -1,3 +1,4 @@
+import { APIErrors } from "../../lib/api-errors";
 import { Hono } from "hono";
 import { eq, and, sql } from "drizzle-orm";
 import { createAuth } from "../../lib/auth";
@@ -15,26 +16,26 @@ status.post("/leave", async (c) => {
   try {
     const authInstance = createAuth(c.env);
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
-    if (!session) return c.json({ success: false, error: "请先登录" }, 401);
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
 
     const teamId = c.req.param("id");
     const db = createDb(c.env.DB);
 
-    if (!teamId) return c.json({ success: false, error: "缺少队伍ID" }, 400);
+    if (!teamId) return c.json(APIErrors.badRequest("缺少队伍ID"), 400);
 
     const team = await db.query.teams.findFirst({
       where: eq(schema.teams.id, teamId as string), with: { location: true },
     });
-    if (!team) return c.json({ success: false, error: "队伍不存在" }, 404);
+    if (!team) return c.json(APIErrors.notFound("队伍不存在"), 404);
 
     const members = await db.query.teamMembers.findMany({
       where: and(eq(schema.teamMembers.teamId, teamId as string), eq(schema.teamMembers.userId, session.user.id), eq(schema.teamMembers.status, "approved")),
       limit: 1,
     });
     const membership = members[0];
-    if (!membership) return c.json({ success: false, error: "你不是该队伍成员" }, 400);
-    if (membership.userId === team.leaderId) return c.json({ success: false, error: "队长不能退出队伍" }, 400);
-    if (team.status === "formed") return c.json({ success: false, error: "队伍已组建，请通过退出申请流程离开" }, 400);
+    if (!membership) return c.json(APIErrors.badRequest("你不是该队伍成员"), 400);
+    if (membership.userId === team.leaderId) return c.json(APIErrors.badRequest("队长不能退出队伍"), 400);
+    if (team.status === "formed") return c.json(APIErrors.badRequest("队伍已组建，请通过退出申请流程离开"), 400);
 
     await db.delete(schema.teamMembers).where(eq(schema.teamMembers.id, membership.id));
 
@@ -50,7 +51,7 @@ status.post("/leave", async (c) => {
     return c.json({ success: true, message: "已成功退出队伍" });
   } catch (error) {
     console.error("Leave team error:", error);
-    return c.json({ success: false, error: "退出队伍失败" }, 500);
+    return c.json(APIErrors.internalError("退出队伍失败"), 500);
   }
 });
 
@@ -62,19 +63,19 @@ status.post("/cancel-application", async (c) => {
   try {
     const authInstance = createAuth(c.env);
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
-    if (!session) return c.json({ success: false, error: "请先登录" }, 401);
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
 
     const teamId = c.req.param("id");
     const db = createDb(c.env.DB);
 
-    if (!teamId) return c.json({ success: false, error: "缺少队伍ID" }, 400);
+    if (!teamId) return c.json(APIErrors.badRequest("缺少队伍ID"), 400);
 
     const members = await db.query.teamMembers.findMany({
       where: and(eq(schema.teamMembers.teamId, teamId as string), eq(schema.teamMembers.userId, session.user.id), eq(schema.teamMembers.status, "pending")),
       limit: 1,
     });
     const membership = members[0];
-    if (!membership) return c.json({ success: false, error: "未找到待审核的申请" }, 404);
+    if (!membership) return c.json(APIErrors.notFound("未找到待审核的申请"), 404);
 
     // 改为更新状态而不是删除，保留历史记录
     await db.update(schema.teamMembers)
@@ -84,7 +85,7 @@ status.post("/cancel-application", async (c) => {
     return c.json({ success: true, message: "申请已取消" });
   } catch (error) {
     console.error("Cancel application error:", error);
-    return c.json({ success: false, error: "取消申请失败" }, 500);
+    return c.json(APIErrors.internalError("取消申请失败"), 500);
   }
 });
 
@@ -96,24 +97,24 @@ status.post("/members/:userId/approve-leave", async (c) => {
   try {
     const authInstance = createAuth(c.env);
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
-    if (!session) return c.json({ success: false, error: "请先登录" }, 401);
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
 
     const teamId = c.req.param("id");
     const targetUserId = c.req.param("userId");
     const db = createDb(c.env.DB);
 
-    if (!teamId) return c.json({ success: false, error: "缺少队伍ID" }, 400);
+    if (!teamId) return c.json(APIErrors.badRequest("缺少队伍ID"), 400);
 
     const team = await db.query.teams.findFirst({ where: eq(schema.teams.id, teamId as string) });
-    if (!team) return c.json({ success: false, error: "队伍不存在" }, 404);
-    if (team.leaderId !== session.user.id) return c.json({ success: false, error: "只有队长可以批准退出申请" }, 403);
+    if (!team) return c.json(APIErrors.notFound("队伍不存在"), 404);
+    if (team.leaderId !== session.user.id) return c.json(APIErrors.forbidden("只有队长可以批准退出申请"), 403);
 
     const members = await db.query.teamMembers.findMany({
       where: and(eq(schema.teamMembers.teamId, teamId as string), eq(schema.teamMembers.userId, targetUserId), eq(schema.teamMembers.status, "leave_pending")),
       limit: 1,
     });
     const membership = members[0];
-    if (!membership) return c.json({ success: false, error: "未找到该成员的退出申请" }, 404);
+    if (!membership) return c.json(APIErrors.notFound("未找到该成员的退出申请"), 404);
 
     await db.delete(schema.teamMembers).where(eq(schema.teamMembers.id, membership.id));
 
@@ -129,7 +130,7 @@ status.post("/members/:userId/approve-leave", async (c) => {
     return c.json({ success: true, message: "已批准退出申请" });
   } catch (error) {
     console.error("Approve leave error:", error);
-    return c.json({ success: false, error: "批准退出申请失败" }, 500);
+    return c.json(APIErrors.internalError("批准退出申请失败"), 500);
   }
 });
 
@@ -141,24 +142,24 @@ status.post("/members/:userId/reject-leave", async (c) => {
   try {
     const authInstance = createAuth(c.env);
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
-    if (!session) return c.json({ success: false, error: "请先登录" }, 401);
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
 
     const teamId = c.req.param("id");
     const targetUserId = c.req.param("userId");
     const db = createDb(c.env.DB);
 
-    if (!teamId) return c.json({ success: false, error: "缺少队伍ID" }, 400);
+    if (!teamId) return c.json(APIErrors.badRequest("缺少队伍ID"), 400);
 
     const team = await db.query.teams.findFirst({ where: eq(schema.teams.id, teamId as string) });
-    if (!team) return c.json({ success: false, error: "队伍不存在" }, 404);
-    if (team.leaderId !== session.user.id) return c.json({ success: false, error: "只有队长可以拒绝退出申请" }, 403);
+    if (!team) return c.json(APIErrors.notFound("队伍不存在"), 404);
+    if (team.leaderId !== session.user.id) return c.json(APIErrors.forbidden("只有队长可以拒绝退出申请"), 403);
 
     const members = await db.query.teamMembers.findMany({
       where: and(eq(schema.teamMembers.teamId, teamId as string), eq(schema.teamMembers.userId, targetUserId), eq(schema.teamMembers.status, "leave_pending")),
       limit: 1,
     });
     const membership = members[0];
-    if (!membership) return c.json({ success: false, error: "未找到该成员的退出申请" }, 404);
+    if (!membership) return c.json(APIErrors.notFound("未找到该成员的退出申请"), 404);
 
     await db.update(schema.teamMembers)
       .set({ status: "approved" })
@@ -167,7 +168,7 @@ status.post("/members/:userId/reject-leave", async (c) => {
     return c.json({ success: true, message: "已拒绝退出申请" });
   } catch (error) {
     console.error("Reject leave error:", error);
-    return c.json({ success: false, error: "拒绝退出申请失败" }, 500);
+    return c.json(APIErrors.internalError("拒绝退出申请失败"), 500);
   }
 });
 


### PR DESCRIPTION
Unifies error handling in the final 3 teams route files to use the centralized APIErrors helper.

## Updated Files
- **teams/membership.ts**: 37 errors unified
- **teams/mutations.ts**: 26 errors unified  
- **teams/status.ts**: 23 errors unified

## Total in Batch 5
86 error responses unified

## Cumulative Progress (All 5 Batches)
- Batch 1: 44 errors (favorites, messages, users)
- Batch 2: 33 errors (locations, activity-posts)
- Batch 3: 42 errors (share-image, feedback, auth, tags, amap, admin, hiking-routes)
- Batch 4: 67 errors (pois, upload, stories)
- Batch 5: 86 errors (teams/membership, teams/mutations, teams/status)
- **Total: 272 error responses unified** ✅

## Completion Status
**All route files now use the unified APIErrors format!**

## Error Types Used
- unauthorized (401)
- forbidden (403)
- badRequest (400)
- notFound (404)
- internalError (500)
- validationError (400)

## Benefits Achieved
✅ Consistent error response format across all endpoints
✅ Type-safe error handling with predefined error codes
✅ Easier to maintain and update error messages
✅ Better error tracking and debugging
✅ Improved API documentation

Closes #55