### PR TITLE
feat(home): TeamCard 精简和动画效果 (#60)

### DIFF
--- a/frontend/src/components/features/home/home-team-card.tsx
+++ b/frontend/src/components/features/home/home-team-card.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { MapPin, Calendar, Clock, ArrowRight } from "lucide-react";
+import { MapPin, Calendar, ArrowRight } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import type { TranslationKey } from "@/i18n";
 import { getDaysUntil } from "@/lib/date-utils";
@@ -151,15 +151,11 @@ export function TeamCard({ team, featured = false }: { team: Team; featured?: bo
           <h3 className="font-bold text-foreground line-clamp-1 mb-2 leading-snug"
             style={{ fontSize: "15px", color: hovered ? "#D97706" : undefined, transition: "color 0.2s ease" }}>{team.title}</h3>
 
+          {/* 精简信息：只保留日期，移除时长 */}
           <div className="flex items-center gap-3 mb-3">
             <span className="text-xs text-muted-foreground flex items-center gap-1">
               <Calendar className="h-3 w-3 flex-shrink-0" style={{ color: "#D97706" }} />{team.date}{team.time && <span className="ml-0.5 font-medium">{team.time}</span>}
             </span>
-            {team.duration && (
-              <span className="text-xs text-muted-foreground flex items-center gap-1">
-                <Clock className="h-3 w-3 flex-shrink-0" style={{ color: "#D97706" }} />{t("common.approx")} {team.duration}
-              </span>
-            )}
             {!hasCover && departureLabel && (
               <span className="ml-auto flex-shrink-0 text-[11px] font-bold px-2 py-0.5 rounded-full"
                 style={{ background: departureLabel.urgent ? "rgba(239,68,68,0.10)" : "rgba(217,119,6,0.08)", color: departureLabel.urgent ? "#b91c1c" : "#D97706" }}>

--- a/frontend/src/components/features/home/home-teams-section.tsx
+++ b/frontend/src/components/features/home/home-teams-section.tsx
@@ -92,10 +92,19 @@ export function HomeTeamsSection({ data }: { data: HomeData }) {
             </a>
           </div>
         ) : (
-          /* 正常状态 - 队伍列表 */
+          /* 正常状态 - 队伍列表（带 stagger 动画） */
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {teams.slice(0, 6).map((team, index) => (
-              <TeamCard key={team.id} team={team} featured={index === 0} />
+              <div
+                key={team.id}
+                className="opacity-0 animate-fade-in-up"
+                style={{
+                  animationDelay: `${index * 100}ms`,
+                  animationFillMode: 'forwards',
+                }}
+              >
+                <TeamCard team={team} featured={index === 0} />
+              </div>
             ))}
           </div>
         )}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -781,3 +781,21 @@
    - 无外部字体请求，减少网络开销
    - 通过 swap 策略确保文字始终可见
    ============================================================ */
+
+/* ============================================================
+   Stagger Animation for Team Cards
+   ============================================================ */
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-in-up {
+  animation: fade-in-up 0.6s ease-out;
+}


### PR DESCRIPTION
## 任务 60 - P2 TeamCard 精简和动画效果

### 改动内容

1. TeamCard 信息精简
   - 移除次要信息（时长 duration）
   - 保留核心信息（地点、时间、成员、进度）
   - 优化视觉层级

2. 动画和过渡效果
   - 添加卡片 stagger 动画（fade-in-up）
   - 每个卡片延迟 100ms 依次出现
   - 平滑的淡入和向上滑动效果

3. CSS 动画定义
   - 在 globals.css 中添加 fade-in-up 动画
   - 动画时长 0.6s，ease-out 缓动

### 应用技能
- frontend-ui-engineering

Closes #60