### PR TITLE
feat(home): 清理首页冗余元素（任务 #66）

### DIFF
--- a/frontend/src/components/features/home/home-hero.tsx
+++ b/frontend/src/components/features/home/home-hero.tsx
@@ -5,7 +5,7 @@ import type { useHomeData } from "./use-home-data";
 type HomeData = ReturnType<typeof useHomeData>;
 
 export function HomeHero({ data }: { data: HomeData }) {
-  const { isDark, animate, parallaxY, search, handleSearch } = data;
+  const { isDark, animate, search, handleSearch } = data;
   const { t } = useI18n(["home", "common", "content"]);
 
   // SSR 默认使用亮色模式，hydration 完成后客户端主题会自动同步
@@ -18,20 +18,6 @@ export function HomeHero({ data }: { data: HomeData }) {
           ? "linear-gradient(160deg, #1a1510 0%, rgba(217,119,6,0.04) 38%, #12100d 65%, #1a1510 100%)"
           : "linear-gradient(160deg, #FEF3C7 0%, rgba(255,122,101,0.06) 38%, #faf8f5 65%, #f5f0e8 100%)",
       }} />
-
-      <div className="absolute -top-40 -left-40 w-[640px] h-[640px] rounded-full pointer-events-none"
-        style={{ background: "radial-gradient(circle, rgba(217,119,6,0.13) 0%, transparent 68%)", transform: `translateY(${parallaxY * 0.8}px)` }} aria-hidden="true" />
-      <div className="absolute -bottom-28 -right-28 w-[520px] h-[520px] rounded-full pointer-events-none"
-        style={{ background: "radial-gradient(circle, rgba(255,122,101,0.10) 0%, transparent 68%)", transform: `translateY(${-parallaxY * 0.6}px)` }} aria-hidden="true" />
-      <div className="absolute top-1/3 right-1/4 w-[220px] h-[220px] rounded-full pointer-events-none"
-        style={{ background: "radial-gradient(circle, rgba(252,211,77,0.16) 0%, transparent 70%)", transform: `translateY(${parallaxY * 1.2}px)` }} aria-hidden="true" />
-
-      <svg className="absolute bottom-0 left-0 right-0 w-full pointer-events-none"
-        style={{ opacity: 0.12, transform: `translateY(${parallaxY * 0.5}px)` }}
-        viewBox="0 0 1440 260" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" preserveAspectRatio="none">
-        <path d="M0 260L100 200L200 230L320 160L440 210L560 130L680 185L800 95L920 150L1040 55L1160 110L1280 35L1440 90V260H0Z" fill="#D97706" />
-        <path d="M0 260L160 220L300 250L460 190L600 240L760 165L900 215L1060 145L1200 195L1360 130L1440 170V260H0Z" fill="#92400E" opacity="0.65" />
-      </svg>
 
       <div className="relative z-10 text-center px-4 max-w-5xl mx-auto pt-24 pb-16">
         <span className={`inline-flex items-center gap-1.5 mb-7 px-4 py-1.5 text-sm font-medium rounded-full border ${animate.badge}`}
@@ -99,26 +85,6 @@ export function HomeHero({ data }: { data: HomeData }) {
             </div>
           ))}
         </div>
-      </div>
-
-      <div className="absolute left-4 sm:left-8 top-1/3 hidden sm:flex flex-col gap-2 sm:gap-3" aria-hidden="true">
-        {[{ icon: "🏔️", label: t("home.floatingLabels.mountain1"), delay: "0s" }].map((item) => (
-          <div key={item.label} className="flex items-center gap-1.5 sm:gap-2 px-2 sm:px-3 py-1.5 sm:py-2 rounded-xl sm:rounded-2xl bg-gradient-to-br from-card/95 to-amber-50/80 dark:to-amber-950/60 border border-amber-200/50 dark:border-amber-900/50 animate-float-up"
-            style={{ boxShadow: "0 4px 16px rgba(217,119,6,0.12), 0 2px 8px rgba(0,0,0,0.06)", backdropFilter: "blur(12px)", animationDelay: item.delay }}>
-            <span className="flex items-center justify-center w-6 h-6 sm:w-7 sm:h-7 rounded-lg bg-amber-50 dark:bg-amber-950/30 text-sm sm:text-base">{item.icon}</span>
-            <span className="text-xs sm:text-sm font-medium text-foreground whitespace-nowrap hidden sm:inline">{item.label}</span>
-          </div>
-        ))}
-      </div>
-
-      <div className="absolute right-4 sm:right-8 top-1/3 hidden sm:flex flex-col gap-2 sm:gap-3" aria-hidden="true">
-        {[{ icon: "👥", label: t("home.floatingLabels.teamJoined").replace("{count}", "3"), delay: "-1s" }].map((item) => (
-          <div key={item.label} className="flex items-center gap-1.5 sm:gap-2 px-2 sm:px-3 py-1.5 sm:py-2 rounded-xl sm:rounded-2xl bg-gradient-to-br from-card/95 to-amber-50/80 dark:to-amber-950/60 border border-amber-200/50 dark:border-amber-900/50 animate-float-down"
-            style={{ boxShadow: "0 4px 16px rgba(217,119,6,0.12), 0 2px 8px rgba(0,0,0,0.06)", backdropFilter: "blur(12px)", animationDelay: item.delay }}>
-            <span className="flex items-center justify-center w-6 h-6 sm:w-7 sm:h-7 rounded-lg bg-amber-50 dark:bg-amber-950/30 text-sm sm:text-base">{item.icon}</span>
-            <span className="text-xs sm:text-sm font-medium text-foreground whitespace-nowrap hidden sm:inline">{item.label}</span>
-          </div>
-        ))}
       </div>
     </section>
   );

--- a/frontend/src/components/features/home/home-how-it-works.tsx
+++ b/frontend/src/components/features/home/home-how-it-works.tsx
@@ -12,7 +12,7 @@ export function HomeHowItWorksSection({ sectionRef, isInView }: { sectionRef: Re
   ];
 
   return (
-    <section ref={sectionRef} className={`py-12 sm:py-16 lg:py-20 section-hidden bg-muted/30 dark:bg-muted/10 ${isInView ? "section-visible" : ""}`}>
+    <section ref={sectionRef} className={`py-16 sm:py-20 lg:py-24 section-hidden bg-muted/30 dark:bg-muted/10 ${isInView ? "section-visible" : ""}`}>
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-14">
           <span className="inline-block mb-4 px-3 py-1 text-xs font-semibold rounded-full uppercase tracking-widest bg-amber-50/80 dark:bg-amber-950/30 text-amber-800 dark:text-amber-300">{t("home.howItWorks.badge")}</span>

--- a/frontend/src/components/features/home/home-locations-section.tsx
+++ b/frontend/src/components/features/home/home-locations-section.tsx
@@ -1,4 +1,3 @@
-import { ArrowRight } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import type { useHomeData } from "./use-home-data";
 import { LocationCard } from "./home-location-card";
@@ -6,7 +5,7 @@ import { LocationCard } from "./home-location-card";
 type HomeData = ReturnType<typeof useHomeData>;
 
 export function HomeLocationsSection({ data }: { data: HomeData }) {
-  const { locations, isLoading, pagination, currentPage, locationsRef, locationsInView, setCurrentPage, fetchLocations } = data;
+  const { locations, isLoading, locationsRef, locationsInView } = data;
   const { t } = useI18n(["home", "locations", "common"]);
 
   return (
@@ -33,24 +32,6 @@ export function HomeLocationsSection({ data }: { data: HomeData }) {
           </div>
         )}
 
-        {pagination.totalPages > 1 && (
-          <div className="flex justify-center gap-2 mt-10">
-            {Array.from({ length: pagination.totalPages }, (_, i) => i + 1).map((page) => (
-              <button key={page} onClick={() => { setCurrentPage(page); fetchLocations(page); }}
-                className={`w-10 h-10 rounded-full text-sm font-medium transition-all duration-150 ${page === currentPage ? "bg-brand text-brand-foreground shadow-brand-glow" : "bg-muted text-muted-foreground hover:bg-accent hover:text-brand"}`}>
-                {page}
-              </button>
-            ))}
-          </div>
-        )}
-
-        <div className="text-center mt-10">
-          <a href="/locations">
-            <button className="border border-border hover:bg-accent text-foreground hover:text-brand px-7 py-3 rounded-xl text-sm font-medium transition-all duration-150 inline-flex items-center gap-2">
-              {t("common.viewAll")}<ArrowRight className="h-4 w-4" />
-            </button>
-          </a>
-        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
## 任务 #66：首页冗余元素清理

## 改动范围
- **HomeHero** (`home-hero.tsx`)
  - 移除浮动标签（左右两组 🏔️ / 👥）
  - 移除 3 个背景装饰圆形
  - 移除 SVG 山形装饰
  - 清理未使用的 `parallaxY`
- **HomeLocationsSection** (`home-locations-section.tsx`)
  - 移除分页按钮
  - 移除"查看全部"按钮
  - 清理未使用的 `ArrowRight` / `pagination` / `currentPage` / `setCurrentPage` / `fetchLocations`
- **HomeHowItWorksSection** (`home-how-it-works.tsx`)
  - 间距 `py-12 sm:py-16 lg:py-20` → `py-16 sm:py-20 lg:py-24`

## 净变化
3 files changed, 3 insertions(+), 56 deletions(-)

## 本地验证
- `pnpm --filter @gomate/frontend type-check` → 0 错误
- `eslint`（改动文件）→ 0 错误 0 警告
- `pnpm --filter @gomate/frontend build` → 通过

## 已知风险
- 首页地点区不再有分页和"查看全部"入口，仅展示首页地点卡片；用户可通过顶部导航进入 `/locations` 完整列表。符合 Peter 的清理方案。

## 回滚
单 commit，revert 即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)