### PR TITLE
feat(home): 简化 CTA 区域 UI（任务 #67）

### DIFF
--- a/frontend/src/components/features/home/home-cta-section.tsx
+++ b/frontend/src/components/features/home/home-cta-section.tsx
@@ -1,73 +1,42 @@
-import { Sparkles, Users, ArrowRight, Check } from "lucide-react";
+import { Sparkles } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import type { useHomeData } from "./use-home-data";
 
 type HomeData = ReturnType<typeof useHomeData>;
 
 export function HomeCtaSection({ data }: { data: Omit<HomeData, "isLoggedIn"> & { isLoggedIn?: boolean } }) {
-  const { isDark, ctaRef, ctaInView } = data;
+  const { ctaRef, ctaInView } = data;
   const { t } = useI18n(["home"]);
-
-  // SSR 默认使用亮色模式，hydration 完成后客户端主题会自动同步
-  const effectiveIsDark = isDark;
 
   return (
     <section ref={ctaRef}
-      className={`py-24 sm:py-32 section-hidden ${ctaInView ? "section-visible" : ""}`}
-      style={{
-        background: effectiveIsDark
-          ? "linear-gradient(160deg, #1c1608 0%, #12100d 50%, #1a1510 100%)"
-          : "linear-gradient(180deg, #fef3c7 0%, #faf8f5 50%, #f5f0e8 100%)",
-      }}>
-      <div className="max-w-4xl mx-auto px-4 text-center">
-        {/* 1. 标题区域优化 - 大图标和动画 */}
-        <div className="mb-8 relative">
-          <div className="inline-flex items-center justify-center w-24 h-24 rounded-3xl bg-gradient-to-br from-amber-500 to-orange-600 mb-6 shadow-2xl animate-float">
-            <Users className="w-12 h-12 text-white" />
-          </div>
+      className={`py-16 sm:py-20 lg:py-24 section-hidden bg-muted/30 dark:bg-muted/10 ${ctaInView ? "section-visible" : ""}`}>
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+        {/* 小徽章 */}
+        <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-amber-50/80 dark:bg-amber-950/30 text-amber-800 dark:text-amber-300 text-sm mb-6">
+          <Sparkles className="h-3.5 w-3.5" />
+          <span className="text-xs font-semibold uppercase tracking-widest">{t("home.cta.title")}</span>
         </div>
 
-        {/* Badge with icon */}
-        <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-[20px] mb-6" style={{ background: "#fffbeb", border: "1px solid rgba(217,119,6,0.2)" }}>
-          <Sparkles className="h-3.5 w-3.5" style={{ color: "#D97706" }} />
-          <span className="text-xs font-semibold uppercase tracking-widest" style={{ color: "#D97706" }}>{t("home.cta.title")}</span>
-        </div>
-
-        {/* 2. 主标题 - 增大字号到 56px */}
-        <h2 className="font-bold leading-tight mb-6 text-foreground" style={{ fontSize: "56px", letterSpacing: "-1px" }}>
+        {/* 适中标题 */}
+        <h2 className="text-3xl sm:text-4xl font-bold text-foreground mb-4">
           {t("home.cta.subtitle")}
         </h2>
 
-        {/* 3. 副标题优化 - 添加统计数据和图标 */}
-        <div className="flex items-center justify-center gap-6 mb-12">
-          <div className="flex items-center gap-2">
-            <div className="w-8 h-8 rounded-full bg-green-100 flex items-center justify-center">
-              <Check className="w-4 h-4 text-green-600" />
-            </div>
-            <span className="text-lg text-muted-foreground">
-              <strong className="text-foreground">200+</strong> 伙伴已找到同行的人
-            </span>
-          </div>
-        </div>
+        {/* 简洁副标题 */}
+        <p className="text-muted-foreground text-base mb-8">
+          <strong className="text-foreground">200+</strong> 伙伴已找到同行的人
+        </p>
 
-        {/* 4. 按钮样式优化 - 增强渐变和动画 */}
-        <div className="flex flex-row gap-4 justify-center items-center">
-          {/* Primary button with enhanced gradient and animation */}
+        {/* 统一按钮样式 - rounded-lg */}
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
           <a href="/teams/create"
-            className="group relative inline-flex items-center gap-3 px-10 py-5 font-bold rounded-[32px] text-white text-lg transition-all duration-300 hover:scale-105"
-            style={{
-              background: "linear-gradient(135deg, #D97706 0%, #F59E0B 100%)",
-              boxShadow: "0 8px 24px rgba(217,119,6,0.4)"
-            }}>
-            <Users className="w-5 h-5" />
+            className="px-6 py-3 bg-primary text-primary-foreground rounded-lg font-medium hover:bg-primary/90 transition-colors">
             {t("home.cta.createTeamBtn")}
-            <ArrowRight className="w-5 h-5 opacity-0 group-hover:opacity-100 group-hover:translate-x-1 transition-all" />
           </a>
-          {/* Secondary button with optimized border and hover */}
           <a href="/teams"
-            className="inline-flex items-center gap-2 px-8 py-5 font-semibold rounded-[32px] text-foreground text-lg transition-all duration-300 bg-white/80 backdrop-blur border-2 border-amber-200 hover:border-amber-400 hover:bg-white">
+            className="px-6 py-3 border border-border rounded-lg font-medium hover:bg-accent transition-colors">
             {t("home.cta.viewAllTeamsLink")}
-            <ArrowRight className="h-5 w-5" style={{ color: "#D97706" }} />
           </a>
         </div>
       </div>


### PR DESCRIPTION
## 任务 #67：首页 CTA 区域 UI 简化

## 改动范围
**HomeCtaSection** (`home-cta-section.tsx`)，1 文件 +18 / -49

## 改动内容（按 Peter 方案）
- 移除大图标（`w-24 h-24` Users 渐变方块）和 `animate-float` 动画
- 主标题 `56px` 内联样式 → `text-3xl sm:text-4xl` 语义化
- 移除复杂渐变背景（亮/暗双套 linear-gradient 内联样式）→ `bg-muted/30 dark:bg-muted/10` 语义类
- 按钮圆角 `rounded-[32px]` → 统一 `rounded-lg`
- 移除 `Check` 统计图块，副标题精简为「200+ 伙伴已找到同行的人」
- 按钮去掉 `hover:scale-105` / `ArrowRight` 渐变动效，保留 `transition-colors`
- 清理未使用的 `Users` / `ArrowRight` / `Check` 导入和 `isDark` / `effectiveIsDark` 逻辑
- 间距 `py-24 sm:py-32` → `py-16 sm:py-20 lg:py-24`（与 HowItWorks 等区域一致）

## 本地验证
- `pnpm --filter @gomate/frontend type-check` → 0 错误
- `eslint`（改动文件）→ 0 错误 0 警告
- `pnpm --filter @gomate/frontend build` → 通过

## 已知风险
- CTA 视觉冲击力降低（移除大图标/渐变/动效），符合「与整体风格统一」的目标
- i18n key 沿用现有 `home.cta.title/subtitle/createTeamBtn/viewAllTeamsLink`，无新增
- 注：`home.cta.viewAllTeamsLink` 在 locale data 中存在，但 `i18n/types.ts` 漏声明（预存问题，本次未动，避免越界）

## 回滚
单 commit，revert 即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)