### PR TITLE
refactor: 替换 Story Markdown 渲染为 react-markdown + remark-gfm

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,8 @@
     "nanostores": "^1.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "tailwind-merge": "^2.5.0",
     "tailwindcss": "^4.0.0",
     "zod": "^3.23.0"
@@ -39,6 +41,8 @@
     "@astrojs/sitemap": "^3.7.2",
     "@eslint/js": "9",
     "@tailwindcss/typography": "^0.5.19",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "@vitest/coverage-v8": "^2.0.0",

--- a/frontend/src/__tests__/markdown-content.test.tsx
+++ b/frontend/src/__tests__/markdown-content.test.tsx
@@ -1,0 +1,236 @@
+ import { describe, it, expect } from "vitest";
+ import { render, screen } from "@testing-library/react";
+ import { MarkdownContent } from "../components/features/discover/markdown-content";
+
+ describe("MarkdownContent", () => {
+   describe("基础渲染", () => {
+     it("渲染段落", () => {
+       render(<MarkdownContent content="这是一段测试文本" />);
+       expect(screen.getByText("这是一段测试文本")).toBeInTheDocument();
+     });
+
+     it("空内容返回 null", () => {
+       const { container } = render(<MarkdownContent content="" />);
+       expect(container.firstChild).toBeNull();
+     });
+
+     it("undefined 内容返回 null", () => {
+       const { container } = render(<MarkdownContent content={undefined as any} />);
+       expect(container.firstChild).toBeNull();
+     });
+   });
+
+   describe("标题", () => {
+     it("渲染 h1 标题", () => {
+       render(<MarkdownContent content="# 一级标题" />);
+       const heading = screen.getByRole("heading", { level: 1 });
+       expect(heading).toHaveTextContent("一级标题");
+     });
+
+     it("渲染 h2 标题", () => {
+       render(<MarkdownContent content="## 二级标题" />);
+       const heading = screen.getByRole("heading", { level: 2 });
+       expect(heading).toHaveTextContent("二级标题");
+     });
+
+     it("渲染 h3 标题", () => {
+       render(<MarkdownContent content="### 三级标题" />);
+       const heading = screen.getByRole("heading", { level: 3 });
+       expect(heading).toHaveTextContent("三级标题");
+     });
+
+    it("渲染 h4-h6 标题", () => {
+      const { container } = render(
+        <MarkdownContent content={`#### 四级标题
+##### 五级标题
+###### 六级标题`} />
+      );
+      expect(container.querySelector("h4")).toHaveTextContent("四级标题");
+      expect(container.querySelector("h5")).toHaveTextContent("五级标题");
+      expect(container.querySelector("h6")).toHaveTextContent("六级标题");
+    });
+   });
+
+   describe("文本格式", () => {
+     it("渲染粗体", () => {
+       render(<MarkdownContent content="这是**粗体**文本" />);
+       const strong = screen.getByText("粗体");
+       expect(strong.tagName).toBe("STRONG");
+     });
+
+     it("渲染斜体", () => {
+       render(<MarkdownContent content="这是*斜体*文本" />);
+       const em = screen.getByText("斜体");
+       expect(em.tagName).toBe("EM");
+     });
+
+     it("渲染删除线", () => {
+       render(<MarkdownContent content="这是~~删除线~~文本" />);
+       const del = screen.getByText("删除线");
+       expect(del.tagName).toBe("DEL");
+     });
+   });
+
+   describe("链接", () => {
+     it("渲染链接并添加 target 和 rel 属性", () => {
+       render(<MarkdownContent content="[测试链接](https://example.com)" />);
+       const link = screen.getByRole("link", { name: "测试链接" });
+       expect(link).toHaveAttribute("href", "https://example.com");
+       expect(link).toHaveAttribute("target", "_blank");
+       expect(link).toHaveAttribute("rel", "noopener noreferrer");
+     });
+
+     it("渲染自动链接", () => {
+       render(<MarkdownContent content="https://example.com" />);
+       const link = screen.getByRole("link", { name: "https://example.com" });
+       expect(link).toHaveAttribute("href", "https://example.com");
+     });
+   });
+
+   describe("列表", () => {
+    it("渲染无序列表", () => {
+      const { container } = render(
+        <MarkdownContent content={`- 项目一
+- 项目二
+- 项目三`} />
+      );
+      const ul = container.querySelector("ul");
+      expect(ul).toBeInTheDocument();
+       const items = ul?.querySelectorAll("li");
+       expect(items).toHaveLength(3);
+       expect(items?.[0]).toHaveTextContent("项目一");
+     });
+
+    it("渲染有序列表", () => {
+      const { container } = render(
+        <MarkdownContent content={`1. 第一项
+2. 第二项
+3. 第三项`} />
+      );
+      const ol = container.querySelector("ol");
+      expect(ol).toBeInTheDocument();
+       const items = ol?.querySelectorAll("li");
+       expect(items).toHaveLength(3);
+       expect(items?.[0]).toHaveTextContent("第一项");
+     });
+
+    it("渲染嵌套列表", () => {
+      const { container } = render(
+        <MarkdownContent content={`- 外层一
+  - 内层一
+  - 内层二
+- 外层二`} />
+      );
+      const outerUl = container.querySelector("ul");
+      expect(outerUl).toBeInTheDocument();
+       const innerUl = outerUl?.querySelector("ul");
+       expect(innerUl).toBeInTheDocument();
+       const innerItems = innerUl?.querySelectorAll("li");
+       expect(innerItems).toHaveLength(2);
+     });
+   });
+
+   describe("代码", () => {
+     it("渲染行内代码", () => {
+       render(<MarkdownContent content="这是`行内代码`文本" />);
+       const code = screen.getByText("行内代码");
+       expect(code.tagName).toBe("CODE");
+     });
+
+    it("渲染代码块", () => {
+      const { container } = render(
+        <MarkdownContent content={`\`\`\`javascript
+const x = 1;
+console.log(x);
+\`\`\``} />
+      );
+      const pre = container.querySelector("pre");
+      expect(pre).toBeInTheDocument();
+       const code = pre?.querySelector("code");
+      expect(code).toBeInTheDocument();
+      expect(code?.textContent).toContain("const x = 1;");
+      expect(code?.textContent).toContain("console.log(x);");
+     });
+
+    it("代码块内的特殊字符不被转义", () => {
+      const { container } = render(
+        <MarkdownContent content={`\`\`\`
+<div>test</div>
+\`\`\``} />
+      );
+      const code = container.querySelector("code");
+      expect(code).toHaveTextContent("<div>test</div>");
+     });
+   });
+
+   describe("GFM 扩展语法", () => {
+     it("渲染表格", () => {
+       const markdown = `| 列一 | 列二 |
+ | ---- | ---- |
+ | 值一 | 值二 |`;
+       const { container } = render(<MarkdownContent content={markdown} />);
+       const table = container.querySelector("table");
+       expect(table).toBeInTheDocument();
+       const ths = table?.querySelectorAll("th");
+       expect(ths).toHaveLength(2);
+       expect(ths?.[0]).toHaveTextContent("列一");
+       expect(ths?.[1]).toHaveTextContent("列二");
+       const tds = table?.querySelectorAll("td");
+       expect(tds).toHaveLength(2);
+       expect(tds?.[0]).toHaveTextContent("值一");
+     });
+
+    it("渲染任务列表", () => {
+      const { container } = render(
+        <MarkdownContent content={`- [ ] 未完成任务
+- [x] 已完成任务`} />
+      );
+      const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+      expect(checkboxes).toHaveLength(2);
+       expect(checkboxes[0]).not.toBeChecked();
+       expect(checkboxes[1]).toBeChecked();
+     });
+   });
+
+   describe("XSS 防御", () => {
+     it("不渲染 script 标签", () => {
+       const { container } = render(
+         <MarkdownContent content='<script>alert("XSS")</script>' />
+       );
+       const script = container.querySelector("script");
+       expect(script).toBeNull();
+     });
+
+     it("不渲染 HTML 标签", () => {
+       const { container } = render(
+         <MarkdownContent content='<div onclick="alert(1)">点击我</div>' />
+       );
+       const div = container.querySelector("div[onclick]");
+       expect(div).toBeNull();
+     });
+
+    it("转义特殊字符", () => {
+      const { container } = render(<MarkdownContent content="这是 <div> 标签" />);
+      // react-markdown 默认剥离 HTML 标签，<div> 不会渲染为 DOM 元素
+      const div = container.querySelector("div.prose-content > div");
+      expect(div).toBeNull();
+    });
+  });
+
+  describe("样式类名", () => {
+    it("添加 prose-content 类名", () => {
+      const { container } = render(<MarkdownContent content="测试" />);
+      const wrapper = container.firstElementChild as HTMLElement;
+      expect(wrapper).toHaveClass("prose-content");
+    });
+
+    it("支持自定义类名", () => {
+      const { container } = render(
+        <MarkdownContent content="测试" className="custom-class" />
+      );
+      const wrapper = container.firstElementChild as HTMLElement;
+      expect(wrapper).toHaveClass("prose-content");
+      expect(wrapper).toHaveClass("custom-class");
+    });
+  });
+ });

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -1,0 +1,1 @@
+ import "@testing-library/jest-dom/vitest";

--- a/frontend/src/components/features/discover/markdown-content.tsx
+++ b/frontend/src/components/features/discover/markdown-content.tsx
@@ -1,81 +1,36 @@
-"use client";
+ "use client";
 
-import * as React from "react";
-import { cn } from "@/lib/utils";
+ import ReactMarkdown from "react-markdown";
+ import remarkGfm from "remark-gfm";
+ import { cn } from "@/lib/utils";
 
-interface MarkdownContentProps {
-  content: string;
-  className?: string;
-}
+ interface MarkdownContentProps {
+   content: string;
+   className?: string;
+ }
 
-/**
- * 简单的 Markdown 渲染组件
- * 支持：标题、粗体、斜体、链接、列表、代码块
- */
-export function MarkdownContent({ content, className }: MarkdownContentProps) {
-  const html = React.useMemo(() => {
-    if (!content) return "";
+ /**
+  * Markdown 渲染组件
+  * 基于 react-markdown + remark-gfm，支持 GFM 扩展语法
+  * 通过 @tailwindcss/typography 的 prose 系列 class 控制样式
+  */
+ export function MarkdownContent({ content, className }: MarkdownContentProps) {
+   if (!content) return null;
 
-    let html = content
-      // 转义 HTML 特殊字符
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      // 代码块 (```code```)
-      .replace(/```([\s\S]*?)```/g, '<pre class="bg-muted/70 p-4 rounded-lg overflow-x-auto my-6 text-sm"><code>$1</code></pre>')
-      // 行内代码 (`code`)
-      .replace(/`([^`]+)`/g, '<code class="bg-muted px-1.5 py-0.5 rounded text-sm font-mono text-primary/80">$1</code>')
-      // 标题 ######
-      .replace(/^###### (.*$)/gim, '<h6 class="text-base font-semibold mt-6 mb-2 text-foreground/90">$1</h6>')
-      // 标题 #####
-      .replace(/^##### (.*$)/gim, '<h5 class="text-lg font-semibold mt-8 mb-3 text-foreground/90">$1</h5>')
-      // 标题 ####
-      .replace(/^#### (.*$)/gim, '<h4 class="text-xl font-semibold mt-8 mb-3 text-foreground">$1</h4>')
-      // 标题 ###
-      .replace(/^### (.*$)/gim, '<h3 class="text-2xl font-bold mt-10 mb-4 text-foreground border-b border-border/50 pb-2">$1</h3>')
-      // 标题 ##
-      .replace(/^## (.*$)/gim, '<h2 class="text-3xl font-bold mt-12 mb-6 text-foreground">$1</h2>')
-      // 标题 #
-      .replace(/^# (.*$)/gim, '<h1 class="text-4xl font-bold mt-12 mb-6 text-foreground">$1</h1>')
-      // 粗体
-      .replace(/\*\*(.*?)\*\*/g, '<strong class="font-semibold text-foreground">$1</strong>')
-      // 斜体
-      .replace(/\*(.*?)\*/g, '<em class="italic text-muted-foreground">$1</em>')
-      // 删除线
-      .replace(/~~(.*?)~~/g, '<del class="line-through text-muted-foreground">$1</del>')
-      // 链接
-      .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" class="text-primary hover:underline font-medium" target="_blank" rel="noopener noreferrer">$1</a>')
-      // 无序列表 - 改进样式
-      .replace(/^\s*[-*+] (.*$)/gim, '<li class="py-1.5 pl-6 relative">$1</li>')
-      // 有序列表 - 添加 data-index 属性用于区分
-      .replace(/^\s*(\d+)\. (.*$)/gim, '<li class="py-1.5 pl-6" data-index="$1">$2</li>')
-      // 引用块 - 增强样式
-      .replace(/^> (.*$)/gim, '<blockquote class="border-l-4 border-primary/40 bg-accent/30 pl-5 pr-4 py-3 my-6 rounded-r-lg text-foreground/80">$1</blockquote>')
-      // 分隔线
-      .replace(/^---$/gim, '<hr class="my-8 border-border/60" />')
-      // 段落 - 增加行高和间距
-      .replace(/\n\n/g, '</p><p class="mb-5 leading-[1.8] text-foreground/90">')
-      // 换行
-      .replace(/\n/g, '<br />');
-
-    // 包裹在段落中
-    if (!html.startsWith('<h') && !html.startsWith('<pre') && !html.startsWith('<blockquote') && !html.startsWith('<li')) {
-      html = '<p class="mb-5 leading-[1.8] text-foreground/90">' + html + '</p>';
-    }
-
-    // 包裹列表项 - 分别处理有序和无序列表
-    // 无序列表（没有 data-index 属性的 li）
-    html = html.replace(/(<li(?![^>]*data-index)[^>]*>.*?<\/li>\s*)+/gs, '<ul class="my-5 space-y-1 list-disc list-inside marker:text-primary/60">$&</ul>');
-    // 有序列表（有 data-index 属性的 li）
-    html = html.replace(/(<li[^>]*data-index[^>]*>.*?<\/li>\s*)+/gs, '<ol class="my-5 space-y-1 list-decimal list-inside marker:text-muted-foreground marker:font-semibold">$&</ol>');
-
-    return html;
-  }, [content]);
-
-  return (
-    <div
-      className={cn("prose prose-neutral dark:prose-invert max-w-none", className)}
-      dangerouslySetInnerHTML={{ __html: html }}
-    />
-  );
-}
+   return (
+     <div className={cn("prose-content", className)}>
+       <ReactMarkdown
+         remarkPlugins={[remarkGfm]}
+         components={{
+           a: ({ href, children, ...props }) => (
+             <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
+               {children}
+             </a>
+           ),
+         }}
+       >
+         {content}
+       </ReactMarkdown>
+     </div>
+   );
+ }

--- a/frontend/src/components/features/discover/story-detail.tsx
+++ b/frontend/src/components/features/discover/story-detail.tsx
@@ -325,7 +325,7 @@ export function StoryDetail({ storyId }: StoryDetailProps) {
         )}
 
         {/* Article Content - Enhanced typography */}
-        <article className="prose prose-lg max-w-none prose-headings:font-bold prose-p:leading-relaxed prose-a:text-primary hover:prose-a:underline">
+        <article className="prose prose-lg max-w-none prose-headings:font-bold prose-p:leading-relaxed prose-a:text-primary hover:prose-a:underline prose-code:bg-muted prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:font-mono prose-code:before:content-none prose-code:after:content-none prose-pre:bg-muted/70 prose-pre:p-4 prose-pre:rounded-lg prose-pre:overflow-x-auto prose-pre:text-sm prose-blockquote:border-l-4 prose-blockquote:border-primary/40 prose-blockquote:bg-accent/30 prose-blockquote:rounded-r-lg prose-hr:my-8 prose-hr:border-border/60">
           <MarkdownContent content={story.content} />
         </article>
 

--- a/frontend/src/components/features/discover/story-detail.tsx
+++ b/frontend/src/components/features/discover/story-detail.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { ArrowLeft, Heart, Share2, Eye, Loader2, MapPin, Quote, Clock, FileText, ArrowRight } from "lucide-react";
+import { ArrowLeft, Heart, Share2, Eye, MapPin, Quote, Clock, FileText, ArrowRight } from "lucide-react";
 import { apiGet, apiPost } from "@/lib/api";
 import { Avatar } from "@/components/ui/avatar";
 import { cn } from "@/lib/utils";

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -831,25 +831,24 @@
 }
 
 /* Prose enhancements for story content */
-.prose-lg p {
-  margin-bottom: 1.5em;
-  line-height: 1.8;
-}
-
-.prose-lg h2 {
-  margin-top: 2em;
-  margin-bottom: 0.8em;
-  font-size: 1.8em;
-}
-
-.prose-lg h3 {
-  margin-top: 1.5em;
-  margin-bottom: 0.6em;
-  font-size: 1.4em;
-}
-
-.prose-lg img {
+.prose-content img {
   border-radius: 12px;
   margin: 2em 0;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.prose-content table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.prose-content th,
+.prose-content td {
+  border: 1px solid var(--border);
+  padding: 0.5rem 0.75rem;
+}
+
+.prose-content th {
+  background: var(--muted);
+  font-weight: 600;
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
+    setupFiles: ["./src/__tests__/setup.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,12 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@18.3.29)(react@18.3.1)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       tailwind-merge:
         specifier: ^2.5.0
         version: 2.6.1
@@ -157,6 +163,12 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.3.0)
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: ^18.3.0
         version: 18.3.29
@@ -197,6 +209,9 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -349,6 +364,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
@@ -1878,6 +1897,32 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -1895,6 +1940,9 @@ packages:
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1939,6 +1987,9 @@ packages:
 
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -2111,6 +2162,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -2124,6 +2179,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -2315,6 +2373,9 @@ packages:
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
 
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
@@ -2420,6 +2481,9 @@ packages:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -2500,6 +2564,12 @@ packages:
 
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -2753,6 +2823,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
@@ -2934,6 +3007,9 @@ packages:
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
   hast-util-to-parse5@8.0.1:
     resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
 
@@ -2968,6 +3044,9 @@ packages:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
 
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
@@ -2996,14 +3075,30 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -3026,6 +3121,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
@@ -3243,6 +3341,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -3285,6 +3387,15 @@ packages:
 
   mdast-util-gfm@3.1.0:
     resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
@@ -3391,6 +3502,10 @@ packages:
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   miniflare@4.20260611.0:
     resolution: {integrity: sha512-i+JwEo8vN96naz1WL3ntFgFyRluBDYL408zwhHKvR2jefJ464KsZ/gCmJAQ5k+oaWeb5Ug+s7yne5AyiAEswjg==}
@@ -3548,6 +3663,9 @@ packages:
   parse-css-color@0.2.1:
     resolution: {integrity: sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
 
@@ -3635,6 +3753,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
@@ -3666,6 +3788,15 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
+
   react-promise-suspense@0.3.4:
     resolution: {integrity: sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==}
 
@@ -3688,6 +3819,10 @@ packages:
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
@@ -3906,6 +4041,10 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
@@ -3913,6 +4052,12 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
@@ -4562,6 +4707,8 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.5.0': {}
+
   '@ampproject/remapping@2.3.0':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -4823,6 +4970,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.29.7':
     dependencies:
@@ -5848,6 +5997,38 @@ snapshots:
       tailwindcss: 4.3.0
       vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.29
+      '@types/react-dom': 18.3.7(@types/react@18.3.29)
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.7
@@ -5876,6 +6057,10 @@ snapshots:
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
 
   '@types/estree@1.0.8': {}
 
@@ -5923,6 +6108,8 @@ snapshots:
   '@types/sax@1.2.7':
     dependencies:
       '@types/node': 24.12.4
+
+  '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
@@ -6171,6 +6358,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   anymatch@3.1.3:
@@ -6181,6 +6370,10 @@ snapshots:
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -6416,6 +6609,8 @@ snapshots:
 
   character-entities@2.0.2: {}
 
+  character-reference-invalid@2.0.1: {}
+
   check-error@2.1.3: {}
 
   chokidar@4.0.3:
@@ -6517,6 +6712,8 @@ snapshots:
 
   css-what@6.2.2: {}
 
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
 
   csso@5.0.5:
@@ -6573,6 +6770,10 @@ snapshots:
   diff@8.0.4: {}
 
   dijkstrajs@1.0.3: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -6870,6 +7071,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
@@ -7069,6 +7272,26 @@ snapshots:
       stringify-entities: 4.0.4
       zwitch: 2.0.4
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   hast-util-to-parse5@8.0.1:
     dependencies:
       '@types/hast': 3.0.4
@@ -7120,6 +7343,8 @@ snapshots:
       htmlparser2: 8.0.2
       selderee: 0.11.0
 
+  html-url-attributes@3.0.1: {}
+
   html-void-elements@3.0.0: {}
 
   htmlparser2@8.0.2:
@@ -7144,11 +7369,24 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0: {}
+
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
 
+  inline-style-parser@0.2.7: {}
+
   iron-webcrypto@1.2.1: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-decimal@2.0.1: {}
 
   is-docker@3.0.0: {}
 
@@ -7161,6 +7399,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
 
   is-inside-container@1.0.0:
     dependencies:
@@ -7354,6 +7594,8 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -7459,6 +7701,45 @@ snapshots:
       mdast-util-gfm-strikethrough: 2.0.0
       mdast-util-gfm-table: 2.0.0
       mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -7693,6 +7974,8 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
+  min-indent@1.0.1: {}
+
   miniflare@4.20260611.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -7840,6 +8123,16 @@ snapshots:
       color-name: 1.1.4
       hex-rgb: 4.3.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse-latin@7.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
@@ -7925,6 +8218,12 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prismjs@1.30.0: {}
 
   property-information@7.1.0: {}
@@ -7957,6 +8256,26 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-is@17.0.2: {}
+
+  react-markdown@10.1.0(@types/react@18.3.29)(react@18.3.1):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 18.3.29
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 18.3.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   react-promise-suspense@0.3.4:
     dependencies:
       fast-deep-equal: 2.0.1
@@ -7976,6 +8295,11 @@ snapshots:
   readdirp@4.1.2: {}
 
   readdirp@5.0.0: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   regex-recursion@6.0.2:
     dependencies:
@@ -8295,9 +8619,21 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   supports-color@10.2.2: {}
 


### PR DESCRIPTION
## 改动概述

将 Story 详情页的 Markdown 渲染从手写正则替换方案迁移到 react-markdown + remark-gfm，解决嵌套语法不支持、列表处理粗糙、XSS 风险等问题。

## 改动内容

### 1. 核心组件重写
- 移除 `markdown-content.tsx` 中 80+ 行正则替换链
- 改用 `react-markdown` AST 解析渲染，输出 React 元素
- 添加 `remark-gfm` 支持 GFM 扩展语法（表格、任务列表、删除线、自动链接）
- 链接自动添加 `target="_blank" rel="noopener noreferrer"`

### 2. 样式迁移
- `story-detail.tsx` 外层 `<article>` 添加 prose modifier class（`prose-code:*`、`prose-pre:*`、`prose-blockquote:*`、`prose-hr:*`）
- `globals.css` 移除旧的 `.prose-lg` 覆盖规则（与 typography 插件冲突），改为 `.prose-content` 作用域下的表格和图片样式

### 3. 测试环境
- 新增 `@testing-library/react` 和 `@testing-library/jest-dom` 依赖
- 配置 `vitest.config.ts` 的 `setupFiles`
- 新增 `setup.ts` 引入 jest-dom matchers

### 4. 单元测试
- 新增 25 个测试用例覆盖：
  - 基础语法（段落、标题、粗体、斜体、删除线）
  - 链接（手动链接、自动链接、target/rel 属性）
  - 列表（无序、有序、嵌套）
  - 代码（行内代码、代码块、特殊字符不转义）
  - GFM 扩展（表格、任务列表）
  - XSS 防御（script 标签、HTML 标签、特殊字符转义）
  - 样式类名（prose-content、自定义 className）

## 验证结果

- ✅ 85 个单元测试全部通过（含 25 个新增）
- ✅ `astro build` 构建通过，无 TypeScript 错误
- ✅ 无 lint 错误

## 文件变更

- 8 files changed, 629 insertions(+), 97 deletions(-)
- 新增依赖：`react-markdown` 10.1.0、`remark-gfm` 4.0.1、`@testing-library/react` 16.3.2、`@testing-library/jest-dom` 6.9.1

## 风险与回滚

- 风险：prose 样式与手写样式存在细微差异，已通过 prose modifier 微调
- 回滚：`git revert` 即可恢复旧实现，无数据迁移