### PR TITLE
feat(api): 集成缓存到列表端点（任务 #72）

### DIFF
--- a/api/src/lib/cache.ts
+++ b/api/src/lib/cache.ts
@@ -17,7 +17,12 @@ export async function getCachedOrFetch<T>(
   key: string,
   fetcher: () => Promise<T>
 ): Promise<T> {
-  const cache = caches.default;
+  // Cloudflare Cache API 仅在 Workers 运行时可用；
+  // 测试环境或非 Workers 环境无 caches.default，降级为直接执行 fetcher
+  const cache = (globalThis as unknown as { caches?: { default: Cache } }).caches?.default;
+  if (!cache) {
+    return fetcher();
+  }
 
   // 尝试从缓存获取
   const cacheKey = new Request(`https://cache.internal/${key}`);
@@ -53,9 +58,31 @@ export async function getCachedOrFetch<T>(
  * @param key 缓存键
  */
 export async function invalidateCache(key: string): Promise<void> {
-  const cache = caches.default;
+  const cache = (globalThis as unknown as { caches?: { default: Cache } }).caches?.default;
+  if (!cache) return;
   const cacheKey = new Request(`https://cache.internal/${key}`);
   await cache.delete(cacheKey);
+}
+
+/**
+ * 根据资源名和查询参数构建规范化的列表缓存键。
+ *
+ * 将查询参数按 key 排序后拼接为 `资源:list:key1=val1&key2=val2`，
+ * 确保不同查询参数组合产生不同缓存键，避免数据串池。
+ *
+ * @param resource 资源名（如 teams / locations / stories）
+ * @param query 查询参数对象（Hono 的 c.req.query 只能逐个取，这里接收 Record）
+ * @returns 规范化的缓存键，如 `teams:list:page=1&pagesize=12`
+ */
+export function buildListCacheKey(
+  resource: string,
+  query: Record<string, string | undefined>
+): string {
+  const entries = Object.entries(query)
+    .filter(([, v]) => v !== undefined && v !== "")
+    .map(([k, v]) => `${k.toLowerCase()}=${v}`)
+    .sort();
+  return `${resource}:list:${entries.join("&")}`;
 }
 
 /**

--- a/api/src/routes/locations.ts
+++ b/api/src/routes/locations.ts
@@ -7,6 +7,7 @@ import * as schema from "../db/schema";
 import type { Env } from "../lib/auth";
 import { createLocationSchema, updateLocationSchema } from "../lib/validation";
 import { APIErrors } from "../lib/api-errors";
+import { getCachedOrFetch, buildListCacheKey } from "../lib/cache";
 
 const locations = new Hono<{ Bindings: Env }>();
 
@@ -83,6 +84,13 @@ locations.get("/", async (c) => {
     const type = c.req.query("type") || "";
     const view = c.req.query("view") || ""; // "card" for lightweight view
 
+    // 公共列表数据，使用缓存（键含全部查询参数，避免不同过滤串池）
+    const cacheKey = buildListCacheKey("locations", {
+      page: String(page), pageSize: String(pageSize), search, cityId,
+      tagIds: tagIdsParam, type, view,
+    });
+    const body = await getCachedOrFetch(cacheKey, async () => {
+
     // 构建过滤条件
     const conditions = [];
     if (search) conditions.push(like(schema.locations.name, `%${search}%`));
@@ -101,7 +109,7 @@ locations.get("/", async (c) => {
         ));
       tagLocationIds = [...new Set(tagMatches.map((t) => t.entityId))];
       if (tagLocationIds.length === 0) {
-        return c.json({ success: true, locations: [], pagination: { page, pageSize, total: 0, totalPages: 0 } });
+        return { success: true, locations: [], pagination: { page, pageSize, total: 0, totalPages: 0 } };
       }
       conditions.push(inArray(schema.locations.id, tagLocationIds));
     }
@@ -207,8 +215,7 @@ locations.get("/", async (c) => {
         };
       });
 
-      c.header("Cache-Control", "public, max-age=60");
-      return c.json({ success: true, locations: formattedLocations, pagination: { page, pageSize, total, totalPages } });
+      return { success: true, locations: formattedLocations, pagination: { page, pageSize, total, totalPages } };
     }
 
     // ==================== 完整模式（默认） ====================
@@ -267,7 +274,9 @@ locations.get("/", async (c) => {
       };
     });
 
-    return c.json({ success: true, locations: formattedLocations, pagination: { page, pageSize, total, totalPages } });
+    return { success: true, locations: formattedLocations, pagination: { page, pageSize, total, totalPages } };
+    });
+    return c.json(body);
   } catch (error) {
     console.error("Get locations error:", error);
     return c.json(APIErrors.internalError("获取地点列表失败"), 500);

--- a/api/src/routes/stories.ts
+++ b/api/src/routes/stories.ts
@@ -7,6 +7,7 @@ import * as schema from "../db/schema";
 import type { Env } from "../lib/auth";
 import { createStorySchema, updateStorySchema } from "../lib/validation";
 import { generateId } from "../lib/id";
+import { getCachedOrFetch, buildListCacheKey } from "../lib/cache";
 
 const stories = new Hono<{ Bindings: Env }>();
 
@@ -92,6 +93,12 @@ stories.get("/", async (c) => {
     const tag = c.req.query("tag");
     const offset = (page - 1) * limit;
 
+    // 公共故事列表，使用缓存（键含全部查询参数）
+    const cacheKey = buildListCacheKey("stories", {
+      page: String(page), limit: String(limit), status, tag: tag || "",
+    });
+    const body = await getCachedOrFetch(cacheKey, async () => {
+
     // 基础过滤条件：状态
     const whereConditions = [eq(schema.stories.status, status)];
 
@@ -120,7 +127,7 @@ stories.get("/", async (c) => {
 
       // 如果有标签但无关联故事，返回空结果
       if (storyIdsWithTag.length === 0) {
-        return c.json({
+        return {
           success: true,
           data: [],
           pagination: {
@@ -129,7 +136,7 @@ stories.get("/", async (c) => {
             total: 0,
             hasMore: false,
           },
-        });
+        };
       }
 
       // 添加故事ID过滤条件
@@ -171,7 +178,7 @@ stories.get("/", async (c) => {
         : null,
     }));
 
-    return c.json({
+    return {
       success: true,
       data: formatted,
       pagination: {
@@ -180,7 +187,9 @@ stories.get("/", async (c) => {
         total: totalResult,
         hasMore: items.length === limit,
       },
+    };
     });
+    return c.json(body);
   } catch (error) {
     console.error("Get stories error:", error);
     return c.json(APIErrors.internalError("获取故事列表失败"), 500);

--- a/api/src/routes/teams/queries.ts
+++ b/api/src/routes/teams/queries.ts
@@ -5,6 +5,7 @@ import { createDb } from "../../db";
 import * as schema from "../../db/schema";
 import type { Env } from "../../lib/auth";
 import { getTimeFilterRange, parseRequirements, getRouteTags } from "./utils";
+import { getCachedOrFetch, buildListCacheKey } from "../../lib/cache";
 
 const queries = new Hono<{ Bindings: Env }>();
 
@@ -111,11 +112,53 @@ queries.get("/", async (c) => {
       });
     }
 
-    // 特殊模式：某地点的队伍
+    // 特殊模式：某地点的队伍（公共数据，使用缓存）
     if (locationId) {
-      const conditions = [eq(schema.teams.locationId, locationId)];
+      const cacheKey = buildListCacheKey("teams", { locationId, status: statusParam });
+      const body = await getCachedOrFetch(cacheKey, async () => {
+        const conditions = [eq(schema.teams.locationId, locationId)];
 
-      // 添加 status 过滤
+        // 添加 status 过滤
+        if (statusParam) {
+          const statuses = statusParam.split(",").filter(Boolean);
+          if (statuses.length === 1) {
+            conditions.push(eq(schema.teams.status, statuses[0]));
+          } else if (statuses.length > 1) {
+            conditions.push(inArray(schema.teams.status, statuses));
+          }
+        }
+
+        const rows = await db
+          .select(teamColumns)
+          .from(schema.teams)
+          .innerJoin(schema.users, eq(schema.users.id, schema.teams.leaderId))
+          .leftJoin(schema.locations, eq(schema.locations.id, schema.teams.locationId))
+          .where(and(...conditions))
+          .orderBy(desc(schema.teams.createdAt)) as TeamRow[];
+        return {
+          success: true,
+          teams: formatTeams(rows),
+          pagination: { page: 1, pageSize: rows.length, total: rows.length, totalPages: 1, hasMore: false }
+        };
+      });
+      return c.json(body);
+    }
+
+    // 通用列表模式：支持搜索、status、difficulty、日期范围、标签、分页（公共数据，使用缓存）
+    const cacheKey = buildListCacheKey("teams", {
+      page: String(page),
+      pageSize: String(pageSize),
+      search,
+      status: statusParam,
+      difficulty: difficultyParam,
+      startDateFrom,
+      startDateTo,
+      timeFilter,
+      tagIds: tagIdsParam,
+    });
+    const body = await getCachedOrFetch(cacheKey, async () => {
+      const conditions = [];
+
       if (statusParam) {
         const statuses = statusParam.split(",").filter(Boolean);
         if (statuses.length === 1) {
@@ -125,133 +168,109 @@ queries.get("/", async (c) => {
         }
       }
 
-      result = await db
+      if (search) {
+        conditions.push(like(schema.teams.title, `%${search}%`));
+      }
+
+      // 日期范围筛选（支持 timeFilter 快捷参数或 startDateFrom/To 自定义范围）
+      let effectiveStartDate = startDateFrom;
+      let effectiveEndDate = startDateTo;
+
+      // 如果提供了 timeFilter，计算对应的日期范围
+      if (timeFilter && !effectiveStartDate && !effectiveEndDate) {
+        const range = getTimeFilterRange(timeFilter);
+        if (range) {
+          effectiveStartDate = range.start;
+          effectiveEndDate = range.end;
+        }
+      }
+
+      if (effectiveStartDate) {
+        const fromDate = new Date(effectiveStartDate);
+        fromDate.setHours(0, 0, 0, 0);
+        conditions.push(gte(schema.teams.startTime, fromDate));
+      }
+      if (effectiveEndDate) {
+        const toDate = new Date(effectiveEndDate);
+        toDate.setHours(23, 59, 59, 999);
+        conditions.push(lte(schema.teams.startTime, toDate));
+      }
+
+      // difficulty 过滤需要 join routes 表
+      const difficultyList = difficultyParam ? difficultyParam.split(",").filter(Boolean) : [];
+
+      // 标签筛选
+      const tagIds = tagIdsParam ? tagIdsParam.split(",").filter(Boolean) : [];
+
+      const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+      // 如果有标签筛选，先查出符合条件的 teamIds
+      let filteredTeamIds: string[] | null = null;
+      if (tagIds.length > 0) {
+        const tagResults = await db
+          .select({ entityId: schema.entityToTags.entityId })
+          .from(schema.entityToTags)
+          .where(
+            and(
+              eq(schema.entityToTags.entityType, "activity"),
+              inArray(schema.entityToTags.tagId, tagIds)
+            )
+          );
+        filteredTeamIds = tagResults.map(r => r.entityId);
+        if (filteredTeamIds.length === 0) {
+          // 没有符合条件的队伍，直接返回空结果
+          return {
+            success: true,
+            teams: [],
+            pagination: { page, pageSize, total: 0, totalPages: 0 },
+          };
+        }
+      }
+
+      // 构建最终 where 条件
+      const finalWhereClause = (() => {
+        const allConditions = [];
+        if (whereClause) allConditions.push(whereClause);
+        if (difficultyList.length > 0) {
+          allConditions.push(inArray(schema.routes.difficulty, difficultyList));
+        }
+        if (filteredTeamIds) {
+          allConditions.push(inArray(schema.teams.id, filteredTeamIds));
+        }
+        return allConditions.length > 0 ? and(...allConditions) : undefined;
+      })();
+
+      // 统计总数
+      const [{ cnt }] = await db
+        .select({ cnt: sql<number>`count(distinct ${schema.teams.id})` })
+        .from(schema.teams)
+        .leftJoin(schema.routes, eq(schema.routes.id, schema.teams.routeId))
+        .where(finalWhereClause);
+      const total = cnt;
+
+      const totalPages = Math.ceil(total / pageSize);
+      const hasMore = page < totalPages;
+      const offset = (page - 1) * pageSize;
+
+      // 查询列表
+      const rows = await db
         .select(teamColumns)
         .from(schema.teams)
         .innerJoin(schema.users, eq(schema.users.id, schema.teams.leaderId))
         .leftJoin(schema.locations, eq(schema.locations.id, schema.teams.locationId))
-        .where(and(...conditions))
-        .orderBy(desc(schema.teams.createdAt)) as TeamRow[];
-      return c.json({
+        .leftJoin(schema.routes, eq(schema.routes.id, schema.teams.routeId))
+        .where(finalWhereClause)
+        .orderBy(desc(schema.teams.startTime))
+        .limit(pageSize)
+        .offset(offset) as TeamRow[];
+
+      return {
         success: true,
-        teams: formatTeams(result),
-        pagination: { page: 1, pageSize: result.length, total: result.length, totalPages: 1, hasMore: false }
-      });
-    }
-
-    // 通用列表模式：支持搜索、status、difficulty、日期范围、标签、分页
-    const conditions = [];
-
-    if (statusParam) {
-      const statuses = statusParam.split(",").filter(Boolean);
-      if (statuses.length === 1) {
-        conditions.push(eq(schema.teams.status, statuses[0]));
-      } else if (statuses.length > 1) {
-        conditions.push(inArray(schema.teams.status, statuses));
-      }
-    }
-
-    if (search) {
-      conditions.push(like(schema.teams.title, `%${search}%`));
-    }
-
-    // 日期范围筛选（支持 timeFilter 快捷参数或 startDateFrom/To 自定义范围）
-    let effectiveStartDate = startDateFrom;
-    let effectiveEndDate = startDateTo;
-
-    // 如果提供了 timeFilter，计算对应的日期范围
-    if (timeFilter && !effectiveStartDate && !effectiveEndDate) {
-      const range = getTimeFilterRange(timeFilter);
-      if (range) {
-        effectiveStartDate = range.start;
-        effectiveEndDate = range.end;
-      }
-    }
-
-    if (effectiveStartDate) {
-      const fromDate = new Date(effectiveStartDate);
-      fromDate.setHours(0, 0, 0, 0);
-      conditions.push(gte(schema.teams.startTime, fromDate));
-    }
-    if (effectiveEndDate) {
-      const toDate = new Date(effectiveEndDate);
-      toDate.setHours(23, 59, 59, 999);
-      conditions.push(lte(schema.teams.startTime, toDate));
-    }
-
-    // difficulty 过滤需要 join routes 表
-    const difficultyList = difficultyParam ? difficultyParam.split(",").filter(Boolean) : [];
-
-    // 标签筛选
-    const tagIds = tagIdsParam ? tagIdsParam.split(",").filter(Boolean) : [];
-
-    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
-
-    // 如果有标签筛选，先查出符合条件的 teamIds
-    let filteredTeamIds: string[] | null = null;
-    if (tagIds.length > 0) {
-      const tagResults = await db
-        .select({ entityId: schema.entityToTags.entityId })
-        .from(schema.entityToTags)
-        .where(
-          and(
-            eq(schema.entityToTags.entityType, "activity"),
-            inArray(schema.entityToTags.tagId, tagIds)
-          )
-        );
-      filteredTeamIds = tagResults.map(r => r.entityId);
-      if (filteredTeamIds.length === 0) {
-        // 没有符合条件的队伍，直接返回空结果
-        return c.json({
-          success: true,
-          teams: [],
-          pagination: { page, pageSize, total: 0, totalPages: 0 },
-        });
-      }
-    }
-
-    // 构建最终 where 条件
-    const finalWhereClause = (() => {
-      const allConditions = [];
-      if (whereClause) allConditions.push(whereClause);
-      if (difficultyList.length > 0) {
-        allConditions.push(inArray(schema.routes.difficulty, difficultyList));
-      }
-      if (filteredTeamIds) {
-        allConditions.push(inArray(schema.teams.id, filteredTeamIds));
-      }
-      return allConditions.length > 0 ? and(...allConditions) : undefined;
-    })();
-
-    // 统计总数
-    const [{ cnt }] = await db
-      .select({ cnt: sql<number>`count(distinct ${schema.teams.id})` })
-      .from(schema.teams)
-      .leftJoin(schema.routes, eq(schema.routes.id, schema.teams.routeId))
-      .where(finalWhereClause);
-    const total = cnt;
-
-    const totalPages = Math.ceil(total / pageSize);
-    const hasMore = page < totalPages;
-    const offset = (page - 1) * pageSize;
-
-    // 查询列表
-    result = await db
-      .select(teamColumns)
-      .from(schema.teams)
-      .innerJoin(schema.users, eq(schema.users.id, schema.teams.leaderId))
-      .leftJoin(schema.locations, eq(schema.locations.id, schema.teams.locationId))
-      .leftJoin(schema.routes, eq(schema.routes.id, schema.teams.routeId))
-      .where(finalWhereClause)
-      .orderBy(desc(schema.teams.startTime))
-      .limit(pageSize)
-      .offset(offset) as TeamRow[];
-
-    return c.json({
-      success: true,
-      teams: formatTeams(result),
-      pagination: { page, pageSize, total, totalPages, hasMore },
+        teams: formatTeams(rows),
+        pagination: { page, pageSize, total, totalPages, hasMore },
+      };
     });
+    return c.json(body);
   } catch (error) {
     console.error("Get teams error:", error);
     return c.json({ success: false, error: "获取队伍列表失败" }, 500);


### PR DESCRIPTION
## 任务 #72：集成 API 缓存到列表端点

将 cache.ts 的 `getCachedOrFetch` 集成到高频列表端点，减少数据库查询负载。

## 改动范围（4 文件）

### `api/src/lib/cache.ts`
- 新增 `buildListCacheKey(resource, query)`：将查询参数按 key 排序拼接为规范化缓存键，确保不同查询参数组合产生不同键，避免数据串池
- `getCachedOrFetch` / `invalidateCache` 对无 `caches.default` 的环境降级为直接执行 fetcher（兼容测试环境，防御非 Workers 运行时）

### `api/src/routes/teams/queries.ts`
- **locationId 模式** + **通用列表模式**：用 `getCachedOrFetch` 包缓存
- 缓存键含全部查询参数（page/pageSize/search/status/difficulty/startDateFrom/To/timeFilter/tagIds）
- **userId+includeJoined 个性化模式跳过缓存**（避免用户数据串池）
- `updateExpiredTeams` 保留在缓存前执行（始终生效，不被缓存跳过）

### `api/src/routes/locations.ts`
- 通用列表（含 `view=card`）整体缓存，键含 page/pageSize/search/cityId/tagIds/type/view

### `api/src/routes/stories.ts`
- 故事列表整体缓存，键含 page/limit/status/tag

## 设计决策（与 @Martin 确认）
1. 缓存键 = `资源:list:<规范化查询参数>`（参数排序拼接）
2. teams 的 `userId+includeJoined` 个性化模式不缓存（避免用户A看到用户B的加入队伍）
3. `updateExpiredTeams` 始终执行（副作用，不被缓存跳过）
4. locations/stories 整体缓存（公共数据）

## 本地验证
- `pnpm --filter @gomate/api lint` → 0 错误
- `pnpm --filter @gomate/api build`（tsc）→ 通过
- `pnpm --filter @gomate/api test` → 165 测试全过（含 teams/locations/stories 集成测试）

## 已知风险
- 缓存 TTL 5 分钟（cache.ts 配置），队伍状态变更（如过期标记）最多 5 分钟延迟反映到公共列表
- 暂未实现缓存失效（数据变更时主动 invalidate），后续任务处理（Martin 方案注明）

## 回滚
单 commit，revert 即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)