### PR TITLE
优化故事详情正文排版

### DIFF
--- a/frontend/src/__tests__/markdown-content.test.tsx
+++ b/frontend/src/__tests__/markdown-content.test.tsx
@@ -15,7 +15,7 @@
      });
 
      it("undefined 内容返回 null", () => {
-       const { container } = render(<MarkdownContent content={undefined as any} />);
+       const { container } = render(<MarkdownContent content={undefined as unknown as string} />);
        expect(container.firstChild).toBeNull();
      });
    });
@@ -38,6 +38,17 @@
        const heading = screen.getByRole("heading", { level: 3 });
        expect(heading).toHaveTextContent("三级标题");
      });
+
+    it("支持将标题层级整体下移一级", () => {
+      render(<MarkdownContent content={`# 一级标题
+## 二级标题
+### 三级标题`} headingOffset={1} />);
+
+      expect(screen.queryByRole("heading", { level: 1 })).not.toBeInTheDocument();
+      expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("一级标题");
+      expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent("二级标题");
+      expect(screen.getByRole("heading", { level: 4 })).toHaveTextContent("三级标题");
+    });
 
     it("渲染 h4-h6 标题", () => {
       const { container } = render(

--- a/frontend/src/components/features/discover/markdown-content.tsx
+++ b/frontend/src/components/features/discover/markdown-content.tsx
@@ -1,36 +1,51 @@
- "use client";
+"use client";
 
- import ReactMarkdown from "react-markdown";
- import remarkGfm from "remark-gfm";
- import { cn } from "@/lib/utils";
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { cn } from "@/lib/utils";
 
- interface MarkdownContentProps {
-   content: string;
-   className?: string;
- }
+interface MarkdownContentProps {
+  content: string;
+  className?: string;
+  headingOffset?: 0 | 1;
+}
 
- /**
-  * Markdown 渲染组件
-  * 基于 react-markdown + remark-gfm，支持 GFM 扩展语法
-  * 通过 @tailwindcss/typography 的 prose 系列 class 控制样式
-  */
- export function MarkdownContent({ content, className }: MarkdownContentProps) {
-   if (!content) return null;
+const baseComponents: Components = {
+  a: ({ href, children, ...props }) => (
+    <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
+      {children}
+    </a>
+  ),
+};
 
-   return (
-     <div className={cn("prose-content", className)}>
-       <ReactMarkdown
-         remarkPlugins={[remarkGfm]}
-         components={{
-           a: ({ href, children, ...props }) => (
-             <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
-               {children}
-             </a>
-           ),
-         }}
-       >
-         {content}
-       </ReactMarkdown>
-     </div>
-   );
- }
+const shiftedHeadingComponents: Components = {
+  h1: ({ node: _node, ...props }) => <h2 {...props} />,
+  h2: ({ node: _node, ...props }) => <h3 {...props} />,
+  h3: ({ node: _node, ...props }) => <h4 {...props} />,
+  h4: ({ node: _node, ...props }) => <h5 {...props} />,
+  h5: ({ node: _node, ...props }) => <h6 {...props} />,
+};
+
+/**
+ * Markdown 渲染组件
+ * 基于 react-markdown + remark-gfm，支持 GFM 扩展语法
+ * 通过 @tailwindcss/typography 的 prose 系列 class 控制样式
+ */
+export function MarkdownContent({ content, className, headingOffset = 0 }: MarkdownContentProps) {
+  if (!content) return null;
+
+  const components = headingOffset === 1
+    ? { ...baseComponents, ...shiftedHeadingComponents }
+    : baseComponents;
+
+  return (
+    <div className={cn("prose-content", className)}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={components}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/frontend/src/components/features/discover/story-detail.tsx
+++ b/frontend/src/components/features/discover/story-detail.tsx
@@ -40,6 +40,8 @@ interface StoryDetailProps {
   storyId: string;
 }
 
+const contentSkeletonWidths = ["92%", "78%", "88%", "64%", "84%", "72%"];
+
 export function StoryDetail({ storyId }: StoryDetailProps) {
   const { t } = useI18n(["content"]);
   const [story, setStory] = React.useState<Story | null>(null);
@@ -159,8 +161,8 @@ export function StoryDetail({ storyId }: StoryDetailProps) {
 
           {/* Content skeleton */}
           <div className="space-y-4">
-            {[1, 2, 3, 4, 5, 6].map((i) => (
-              <div key={i} className="h-4 bg-muted rounded animate-pulse" style={{ width: `${Math.random() * 40 + 60}%` }} />
+            {contentSkeletonWidths.map((width) => (
+              <div key={width} className="h-4 bg-muted rounded animate-pulse" style={{ width }} />
             ))}
           </div>
         </main>
@@ -325,8 +327,11 @@ export function StoryDetail({ storyId }: StoryDetailProps) {
         )}
 
         {/* Article Content - Enhanced typography */}
-        <article className="prose prose-lg max-w-none prose-headings:font-bold prose-p:leading-relaxed prose-a:text-primary hover:prose-a:underline prose-code:bg-muted prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:font-mono prose-code:before:content-none prose-code:after:content-none prose-pre:bg-muted/70 prose-pre:p-4 prose-pre:rounded-lg prose-pre:overflow-x-auto prose-pre:text-sm prose-blockquote:border-l-4 prose-blockquote:border-primary/40 prose-blockquote:bg-accent/30 prose-blockquote:rounded-r-lg prose-hr:my-8 prose-hr:border-border/60">
-          <MarkdownContent content={story.content} />
+        <article
+          aria-label="故事正文"
+          className="story-prose prose mx-auto w-full prose-a:text-primary hover:prose-a:underline prose-code:before:content-none prose-code:after:content-none"
+        >
+          <MarkdownContent content={story.content} headingOffset={1} />
         </article>
 
         {/* Actions - Enhanced style */}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -784,7 +784,7 @@
   animation: slide-in-right 0.4s ease-out;
 }
 
-/* Prose enhancements for story content */
+/* Prose enhancements for Markdown content */
 .prose-content img {
   border-radius: 12px;
   margin: 2em 0;
@@ -805,4 +805,199 @@
 .prose-content th {
   background: var(--muted);
   font-weight: 600;
+}
+
+/* Story detail reading rhythm: tuned for Chinese outdoor guides. */
+.story-prose {
+  max-width: 45rem;
+  color: rgb(from var(--foreground) r g b / 0.84);
+  font-size: 1.0625rem;
+  line-height: 1.9;
+  letter-spacing: 0;
+  overflow-wrap: break-word;
+}
+
+.story-prose .prose-content > :first-child {
+  margin-top: 0;
+}
+
+.story-prose .prose-content > :last-child {
+  margin-bottom: 0;
+}
+
+.story-prose :where(p) {
+  margin: 0 0 1.25rem;
+  color: rgb(from var(--foreground) r g b / 0.82);
+  line-height: 1.9;
+}
+
+.story-prose :where(h1, h2, h3, h4, h5, h6) {
+  color: var(--foreground);
+  font-weight: 700;
+  letter-spacing: 0;
+  scroll-margin-top: 6rem;
+}
+
+.story-prose :where(h1) {
+  margin: 0 0 1rem;
+  font-size: 2rem;
+  line-height: 1.35;
+}
+
+.story-prose :where(h2) {
+  margin: 0 0 1rem;
+  font-size: 1.75rem;
+  line-height: 1.35;
+}
+
+.story-prose :where(h2:not(:first-child)) {
+  margin-top: 3rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid rgb(from var(--border) r g b / 0.8);
+}
+
+.story-prose :where(h3) {
+  margin: 2.25rem 0 0.75rem;
+  font-size: 1.375rem;
+  line-height: 1.45;
+}
+
+.story-prose :where(h4) {
+  margin: 1.75rem 0 0.625rem;
+  font-size: 1.125rem;
+  line-height: 1.5;
+}
+
+.story-prose :where(h5, h6) {
+  margin: 1.5rem 0 0.5rem;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.story-prose :where(h1 + p, h2 + p, h3 + p, h4 + p) {
+  margin-top: 0;
+}
+
+.story-prose :where(strong) {
+  color: var(--foreground);
+  font-weight: 700;
+}
+
+.story-prose :where(a) {
+  font-weight: 600;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+.story-prose :where(ul, ol) {
+  margin: 1.25rem 0 2rem;
+  padding-left: 1.35rem;
+}
+
+.story-prose :where(ul) {
+  list-style-type: disc;
+}
+
+.story-prose :where(ol) {
+  list-style-type: decimal;
+}
+
+.story-prose :where(li) {
+  margin: 0.65rem 0;
+  padding-left: 0.25rem;
+  line-height: 1.85;
+}
+
+.story-prose :where(li)::marker {
+  color: var(--primary);
+  font-weight: 700;
+}
+
+.story-prose :where(li > p) {
+  margin: 0.35rem 0;
+}
+
+.story-prose :where(blockquote) {
+  margin: 2rem 0;
+  padding: 1rem 1.25rem;
+  border-left: 4px solid var(--primary);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  background: rgb(from var(--accent) r g b / 0.55);
+  color: rgb(from var(--foreground) r g b / 0.86);
+  font-style: normal;
+}
+
+.story-prose :where(blockquote p) {
+  margin-bottom: 0;
+}
+
+.story-prose :where(code) {
+  border-radius: var(--radius-sm);
+  background: var(--muted);
+  color: var(--foreground);
+  padding: 0.125rem 0.375rem;
+  font-size: 0.9em;
+  font-weight: 500;
+}
+
+.story-prose :where(pre) {
+  margin: 1.75rem 0;
+  border-radius: var(--radius-md);
+  background: var(--muted);
+  padding: 1rem;
+  overflow-x: auto;
+}
+
+.story-prose :where(pre code) {
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  font-size: 0.875rem;
+  font-weight: 400;
+}
+
+.story-prose :where(hr) {
+  margin: 2.5rem 0;
+  border-color: rgb(from var(--border) r g b / 0.8);
+}
+
+.story-prose :where(img) {
+  width: 100%;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-warm);
+}
+
+@media (max-width: 640px) {
+  .story-prose {
+    max-width: none;
+    font-size: 1rem;
+    line-height: 1.85;
+  }
+
+  .story-prose :where(p) {
+    margin-bottom: 1.125rem;
+    line-height: 1.85;
+  }
+
+  .story-prose :where(h1) {
+    font-size: 1.625rem;
+  }
+
+  .story-prose :where(h2) {
+    font-size: 1.45rem;
+  }
+
+  .story-prose :where(h2:not(:first-child)) {
+    margin-top: 2.5rem;
+    padding-top: 1rem;
+  }
+
+  .story-prose :where(h3) {
+    margin-top: 2rem;
+    font-size: 1.2rem;
+  }
+
+  .story-prose :where(ul, ol) {
+    padding-left: 1.2rem;
+  }
 }


### PR DESCRIPTION
## 改动说明
- 为故事详情正文增加独立 `.story-prose` 排版规则，收窄中文阅读宽度并优化标题、段落、列表、引用块节奏
- Markdown 渲染新增 `headingOffset`，详情页正文标题整体降一级，避免页面内重复 h1
- 将故事详情 loading skeleton 宽度改为固定序列，避免随机宽度导致 hydration mismatch
- 补充 Markdown 标题降级测试

## 验证
- `pnpm --filter @gomate/frontend test -- markdown-content`
- `pnpm --filter @gomate/frontend lint`
- `pnpm --filter @gomate/frontend type-check`
- `pnpm --filter @gomate/frontend build`
- 本地浏览器验证 `/discover/story_wutong_typography` 桌面和移动正文布局

## 备注
- 浏览器验证中仍观察到既有 Footer hydration 警告：服务端空文本 vs 客户端 footer 文案，不属于本次故事详情正文改造范围。