### PR TITLE
refactor(api): 拆分 locations.ts 和 users.ts 为模块化结构（任务 #73）

### DIFF
--- a/api/src/routes/locations/index.ts
+++ b/api/src/routes/locations/index.ts
@@ -1,0 +1,26 @@
+import { Hono } from "hono";
+import type { Env } from "../../lib/auth";
+
+import queries from "./queries";
+import mutations from "./mutations";
+
+const locations = new Hono<{ Bindings: Env }>();
+
+// Mount query routes (GET endpoints)
+// GET /locations
+// GET /locations/:id
+// GET /locations/:id/pois
+// GET /locations/:id/tags
+// GET /locations/search
+locations.route("/", queries);
+
+// Mount mutation routes (POST, PUT, DELETE)
+// POST /locations
+// PUT /locations
+// DELETE /locations/:id
+// PUT /locations/:id/tags
+// PUT /locations/:id/pois
+locations.route("/", mutations);
+
+export default locations;
+export { locations as locationsRoute };

--- a/api/src/routes/locations/mutations.ts
+++ b/api/src/routes/locations/mutations.ts
@@ -1,0 +1,217 @@
+import { Hono } from "hono";
+import { eq, and } from "drizzle-orm";
+import { generateId } from "../../lib/id";
+import { createDb } from "../../db";
+import * as schema from "../../db/schema";
+import type { Env } from "../../lib/auth";
+import { createLocationSchema, updateLocationSchema } from "../../lib/validation";
+import { APIErrors } from "../../lib/api-errors";
+import { requireAdmin } from "./utils";
+
+const mutations = new Hono<{ Bindings: Env }>();
+
+/**
+ * POST /locations
+ * 创建新地点（需要管理员权限）
+ */
+mutations.post("/", async (c) => {
+  try {
+    await requireAdmin(c);
+    const db = createDb(c.env.DB);
+    const body = await c.req.json();
+
+    // Validate input
+    const parsed = createLocationSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json(APIErrors.validationError("输入验证失败", parsed.error.errors), 400);
+    }
+
+    const data = parsed.data;
+    const id = generateId();
+    const slug = data.slug || data.name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+
+    await db.insert(schema.locations).values({
+      id, name: data.name, slug, type: data.type || null, subtitle: data.subtitle || null,
+      description: data.description, address: data.address || null,
+      cityId: data.cityId, cityName: data.cityName || null,
+      bestSeason: JSON.stringify(data.bestSeason || []),
+      coverImage: data.coverImage,
+      images: JSON.stringify(data.images || []),
+      coordinates: JSON.stringify(data.coordinates || { lat: 0, lng: 0 }),
+      extra: data.extra ? JSON.stringify(data.extra) : null,
+      createdAt: new Date(), updatedAt: new Date(),
+    });
+
+    return c.json({ success: true, location: { id, slug } });
+  } catch (error) {
+    const message = (error as Error).message;
+    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
+    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
+    console.error("Create location error:", error);
+    return c.json(APIErrors.internalError("创建地点失败"), 500);
+  }
+});
+
+/**
+ * PUT /locations
+ * 更新地点（需要管理员权限）
+ */
+mutations.put("/", async (c) => {
+  try {
+    await requireAdmin(c);
+    const db = createDb(c.env.DB);
+    const body = await c.req.json();
+
+    // Validate input
+    const parsed = updateLocationSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json(APIErrors.validationError("输入验证失败", parsed.error.errors), 400);
+    }
+
+    const { id, ...updateData } = parsed.data;
+
+    const dataToUpdate: Record<string, unknown> = { updatedAt: new Date() };
+    if (updateData.name !== undefined) dataToUpdate.name = updateData.name;
+    if (updateData.slug !== undefined) dataToUpdate.slug = updateData.slug;
+    if (updateData.type !== undefined) dataToUpdate.type = updateData.type || null;
+    if (updateData.subtitle !== undefined) dataToUpdate.subtitle = updateData.subtitle || null;
+    if (updateData.description !== undefined) dataToUpdate.description = updateData.description;
+    if (updateData.address !== undefined) dataToUpdate.address = updateData.address || null;
+    if (updateData.cityId !== undefined) dataToUpdate.cityId = updateData.cityId;
+    if (updateData.cityName !== undefined) dataToUpdate.cityName = updateData.cityName || null;
+    if (updateData.bestSeason !== undefined) dataToUpdate.bestSeason = JSON.stringify(updateData.bestSeason);
+    if (updateData.coverImage !== undefined) dataToUpdate.coverImage = updateData.coverImage;
+    if (updateData.images !== undefined) dataToUpdate.images = JSON.stringify(updateData.images);
+    if (updateData.coordinates !== undefined) dataToUpdate.coordinates = JSON.stringify(updateData.coordinates);
+    if (updateData.extra !== undefined) dataToUpdate.extra = updateData.extra ? JSON.stringify(updateData.extra) : null;
+
+    await db.update(schema.locations).set(dataToUpdate).where(eq(schema.locations.id, id));
+
+    return c.json({ success: true });
+  } catch (error) {
+    const message = (error as Error).message;
+    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
+    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
+    console.error("Update location error:", error);
+    return c.json(APIErrors.internalError("更新地点失败"), 500);
+  }
+});
+
+/**
+ * DELETE /locations/:id
+ * 删除地点（需要管理员权限）
+ */
+mutations.delete("/:id", async (c) => {
+  try {
+    await requireAdmin(c);
+    const id = c.req.param("id");
+    const db = createDb(c.env.DB);
+
+    const existing = await db.query.locations.findFirst({ where: eq(schema.locations.id, id) });
+    if (!existing) return c.json(APIErrors.notFound("地点不存在"), 404);
+
+    await db.delete(schema.locations).where(eq(schema.locations.id, id));
+
+    return c.json({ success: true });
+  } catch (error) {
+    const message = (error as Error).message;
+    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
+    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
+    console.error("Delete location error:", error);
+    return c.json(APIErrors.internalError("删除地点失败"), 500);
+  }
+});
+
+/**
+ * PUT /locations/:id/tags
+ * 全量替换地点关联的标签（需要管理员权限）
+ * body: { tagIds: string[] }
+ */
+mutations.put("/:id/tags", async (c) => {
+  try {
+    await requireAdmin(c);
+    const id = c.req.param("id");
+    const { tagIds } = await c.req.json<{ tagIds: string[] }>();
+    const db = createDb(c.env.DB);
+
+    // 删除旧关联
+    await db
+      .delete(schema.entityToTags)
+      .where(
+        and(
+          eq(schema.entityToTags.entityId, id),
+          eq(schema.entityToTags.entityType, "location")
+        )
+      );
+
+    // 批量插入新关联
+    if (tagIds && tagIds.length > 0) {
+      await db.insert(schema.entityToTags).values(
+        tagIds.map((tagId) => ({
+          id: generateId(),
+          entityId: id,
+          entityType: "location" as const,
+          tagId,
+        }))
+      );
+    }
+
+    return c.json({ success: true });
+  } catch (error) {
+    const message = (error as Error).message;
+    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
+    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
+    console.error("Update location tags error:", error);
+    return c.json(APIErrors.internalError("更新标签失败"), 500);
+  }
+});
+
+/**
+ * PUT /locations/:id/pois
+ * 全量替换地点关联的打卡点（需要管理员权限）
+ * body: { pois: Array<{ poiId: string; roleType: string; order: number }> }
+ */
+mutations.put("/:id/pois", async (c) => {
+  try {
+    await requireAdmin(c);
+    const id = c.req.param("id");
+    const { pois: poiLinks } = await c.req.json<{
+      pois: Array<{ poiId: string; roleType: string; order: number }>;
+    }>();
+    const db = createDb(c.env.DB);
+
+    // 删除旧关联
+    await db
+      .delete(schema.entityToPois)
+      .where(
+        and(
+          eq(schema.entityToPois.entityId, id),
+          eq(schema.entityToPois.entityType, "location")
+        )
+      );
+
+    // 批量插入新关联
+    if (poiLinks && poiLinks.length > 0) {
+      await db.insert(schema.entityToPois).values(
+        poiLinks.map((link) => ({
+          id: generateId(),
+          entityId: id,
+          entityType: "location" as const,
+          poiId: link.poiId,
+          roleType: link.roleType as schema.PoiRoleType,
+          order: link.order,
+        }))
+      );
+    }
+
+    return c.json({ success: true });
+  } catch (error) {
+    const message = (error as Error).message;
+    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
+    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
+    console.error("Update location pois error:", error);
+    return c.json(APIErrors.internalError("更新打卡点失败"), 500);
+  }
+});
+
+export default mutations;

--- a/api/src/routes/locations/queries.ts
+++ b/api/src/routes/locations/queries.ts
@@ -1,43 +1,13 @@
 import { Hono } from "hono";
 import { eq, like, and, sql, inArray, asc } from "drizzle-orm";
-import { generateId } from "../lib/id";
-import { createAuth } from "../lib/auth";
-import { createDb } from "../db";
-import * as schema from "../db/schema";
-import type { Env } from "../lib/auth";
-import { createLocationSchema, updateLocationSchema } from "../lib/validation";
-import { APIErrors } from "../lib/api-errors";
-import { getCachedOrFetch, buildListCacheKey, setPublicCacheHeaders } from "../lib/cache";
+import { createDb } from "../../db";
+import * as schema from "../../db/schema";
+import type { Env } from "../../lib/auth";
+import { APIErrors } from "../../lib/api-errors";
+import { getCachedOrFetch, buildListCacheKey, setPublicCacheHeaders } from "../../lib/cache";
+import { safeJsonParse } from "./utils";
 
-const locations = new Hono<{ Bindings: Env }>();
-
-/** 安全解析 JSON 字段 */
-function safeJsonParse<T>(value: string | null | undefined, fallback: T): T {
-  if (!value) return fallback;
-  try {
-    return JSON.parse(value);
-  } catch {
-    if (Array.isArray(fallback)) {
-      return value.split(/[,、]/).map((s: string) => s.trim()).filter(Boolean) as unknown as T;
-    }
-    return fallback;
-  }
-}
-
-/** 验证管理员权限 */
-async function requireAdmin(c: { env: Env; req: { raw: Request } }) {
-  const authInstance = createAuth(c.env);
-  const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
-  if (!session) throw new Error("未登录");
-  const db = createDb(c.env.DB);
-  const user = await db
-    .select({ role: schema.users.role })
-    .from(schema.users)
-    .where(eq(schema.users.id, session.user.id))
-    .then((rows) => rows[0]);
-  if (!user || user.role !== "admin") throw new Error("无权限访问");
-  return session;
-}
+const queries = new Hono<{ Bindings: Env }>();
 
 /**
  * GET /locations
@@ -46,7 +16,7 @@ async function requireAdmin(c: { env: Env; req: { raw: Request } }) {
  * ?allTags=true 返回按类型分组的所有标签
  * ?view=card 返回轻量卡片视图（首页用），跳过 routes/tags/images 等重字段
  */
-locations.get("/", async (c) => {
+queries.get("/", async (c) => {
   try {
     const db = createDb(c.env.DB);
 
@@ -285,97 +255,10 @@ locations.get("/", async (c) => {
 });
 
 /**
- * POST /locations
- * 创建新地点（需要管理员权限）
- */
-locations.post("/", async (c) => {
-  try {
-    await requireAdmin(c);
-    const db = createDb(c.env.DB);
-    const body = await c.req.json();
-
-    // Validate input
-    const parsed = createLocationSchema.safeParse(body);
-    if (!parsed.success) {
-      return c.json(APIErrors.validationError("输入验证失败", parsed.error.errors), 400);
-    }
-
-    const data = parsed.data;
-    const id = generateId();
-    const slug = data.slug || data.name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
-
-    await db.insert(schema.locations).values({
-      id, name: data.name, slug, type: data.type || null, subtitle: data.subtitle || null,
-      description: data.description, address: data.address || null,
-      cityId: data.cityId, cityName: data.cityName || null,
-      bestSeason: JSON.stringify(data.bestSeason || []),
-      coverImage: data.coverImage,
-      images: JSON.stringify(data.images || []),
-      coordinates: JSON.stringify(data.coordinates || { lat: 0, lng: 0 }),
-      extra: data.extra ? JSON.stringify(data.extra) : null,
-      createdAt: new Date(), updatedAt: new Date(),
-    });
-
-    return c.json({ success: true, location: { id, slug } });
-  } catch (error) {
-    const message = (error as Error).message;
-    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
-    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
-    console.error("Create location error:", error);
-    return c.json(APIErrors.internalError("创建地点失败"), 500);
-  }
-});
-
-/**
- * PUT /locations
- * 更新地点（需要管理员权限）
- */
-locations.put("/", async (c) => {
-  try {
-    await requireAdmin(c);
-    const db = createDb(c.env.DB);
-    const body = await c.req.json();
-
-    // Validate input
-    const parsed = updateLocationSchema.safeParse(body);
-    if (!parsed.success) {
-      return c.json(APIErrors.validationError("输入验证失败", parsed.error.errors), 400);
-    }
-
-    const { id, ...updateData } = parsed.data;
-
-    const dataToUpdate: Record<string, unknown> = { updatedAt: new Date() };
-    if (updateData.name !== undefined) dataToUpdate.name = updateData.name;
-    if (updateData.slug !== undefined) dataToUpdate.slug = updateData.slug;
-    if (updateData.type !== undefined) dataToUpdate.type = updateData.type || null;
-    if (updateData.subtitle !== undefined) dataToUpdate.subtitle = updateData.subtitle || null;
-    if (updateData.description !== undefined) dataToUpdate.description = updateData.description;
-    if (updateData.address !== undefined) dataToUpdate.address = updateData.address || null;
-    if (updateData.cityId !== undefined) dataToUpdate.cityId = updateData.cityId;
-    if (updateData.cityName !== undefined) dataToUpdate.cityName = updateData.cityName || null;
-    if (updateData.bestSeason !== undefined) dataToUpdate.bestSeason = JSON.stringify(updateData.bestSeason);
-    if (updateData.coverImage !== undefined) dataToUpdate.coverImage = updateData.coverImage;
-    if (updateData.images !== undefined) dataToUpdate.images = JSON.stringify(updateData.images);
-    if (updateData.coordinates !== undefined) dataToUpdate.coordinates = JSON.stringify(updateData.coordinates);
-    if (updateData.extra !== undefined) dataToUpdate.extra = updateData.extra ? JSON.stringify(updateData.extra) : null;
-
-    await db.update(schema.locations).set(dataToUpdate).where(eq(schema.locations.id, id));
-
-    return c.json({ success: true });
-  } catch (error) {
-    const message = (error as Error).message;
-    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
-    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
-    console.error("Update location error:", error);
-    return c.json(APIErrors.internalError("更新地点失败"), 500);
-  }
-});
-
-/**
  * GET /locations/:id
  * 获取单个地点详情
  */
-locations.get("/:id", async (c) => {
+queries.get("/:id", async (c) => {
   try {
     const idOrSlug = c.req.param("id");
     const db = createDb(c.env.DB);
@@ -447,7 +330,7 @@ locations.get("/:id", async (c) => {
  * GET /locations/:id/pois
  * 获取地点关联的打卡点（POI）列表
  */
-locations.get("/:id/pois", async (c) => {
+queries.get("/:id/pois", async (c) => {
   try {
     const idOrSlug = c.req.param("id");
     const db = createDb(c.env.DB);
@@ -502,35 +385,10 @@ locations.get("/:id/pois", async (c) => {
 });
 
 /**
- * DELETE /locations/:id
- * 删除地点（需要管理员权限）
- */
-locations.delete("/:id", async (c) => {
-  try {
-    await requireAdmin(c);
-    const id = c.req.param("id");
-    const db = createDb(c.env.DB);
-
-    const existing = await db.query.locations.findFirst({ where: eq(schema.locations.id, id) });
-    if (!existing) return c.json(APIErrors.notFound("地点不存在"), 404);
-
-    await db.delete(schema.locations).where(eq(schema.locations.id, id));
-
-    return c.json({ success: true });
-  } catch (error) {
-    const message = (error as Error).message;
-    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
-    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
-    console.error("Delete location error:", error);
-    return c.json(APIErrors.internalError("删除地点失败"), 500);
-  }
-});
-
-/**
  * GET /locations/:id/tags
  * 获取地点当前关联的标签列表
  */
-locations.get("/:id/tags", async (c) => {
+queries.get("/:id/tags", async (c) => {
   try {
     const id = c.req.param("id");
     const db = createDb(c.env.DB);
@@ -554,103 +412,11 @@ locations.get("/:id/tags", async (c) => {
 });
 
 /**
- * PUT /locations/:id/tags
- * 全量替换地点关联的标签（需要管理员权限）
- * body: { tagIds: string[] }
- */
-locations.put("/:id/tags", async (c) => {
-  try {
-    await requireAdmin(c);
-    const id = c.req.param("id");
-    const { tagIds } = await c.req.json<{ tagIds: string[] }>();
-    const db = createDb(c.env.DB);
-
-    // 删除旧关联
-    await db
-      .delete(schema.entityToTags)
-      .where(
-        and(
-          eq(schema.entityToTags.entityId, id),
-          eq(schema.entityToTags.entityType, "location")
-        )
-      );
-
-    // 批量插入新关联
-    if (tagIds && tagIds.length > 0) {
-      await db.insert(schema.entityToTags).values(
-        tagIds.map((tagId) => ({
-          id: generateId(),
-          entityId: id,
-          entityType: "location" as const,
-          tagId,
-        }))
-      );
-    }
-
-    return c.json({ success: true });
-  } catch (error) {
-    const message = (error as Error).message;
-    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
-    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
-    console.error("Update location tags error:", error);
-    return c.json(APIErrors.internalError("更新标签失败"), 500);
-  }
-});
-
-/**
- * PUT /locations/:id/pois
- * 全量替换地点关联的打卡点（需要管理员权限）
- * body: { pois: Array<{ poiId: string; roleType: string; order: number }> }
- */
-locations.put("/:id/pois", async (c) => {
-  try {
-    await requireAdmin(c);
-    const id = c.req.param("id");
-    const { pois: poiLinks } = await c.req.json<{
-      pois: Array<{ poiId: string; roleType: string; order: number }>;
-    }>();
-    const db = createDb(c.env.DB);
-
-    // 删除旧关联
-    await db
-      .delete(schema.entityToPois)
-      .where(
-        and(
-          eq(schema.entityToPois.entityId, id),
-          eq(schema.entityToPois.entityType, "location")
-        )
-      );
-
-    // 批量插入新关联
-    if (poiLinks && poiLinks.length > 0) {
-      await db.insert(schema.entityToPois).values(
-        poiLinks.map((link) => ({
-          id: generateId(),
-          entityId: id,
-          entityType: "location" as const,
-          poiId: link.poiId,
-          roleType: link.roleType as schema.PoiRoleType,
-          order: link.order,
-        }))
-      );
-    }
-
-    return c.json({ success: true });
-  } catch (error) {
-    const message = (error as Error).message;
-    if (message === "未登录") return c.json(APIErrors.unauthorized("未登录"), 401);
-    if (message === "无权限访问") return c.json(APIErrors.forbidden("无权限访问"), 403);
-    console.error("Update location pois error:", error);
-    return c.json(APIErrors.internalError("更新打卡点失败"), 500);
-  }
-});
-
-/**
  * GET /locations/search
  * 前缀搜索地点（用于搜索框实时提示）
  * Query: q=keyword&limit=10
  */
-locations.get("/search", async (c) => {
+queries.get("/search", async (c) => {
   try {
     const db = createDb(c.env.DB);
     const query = c.req.query("q") || "";
@@ -693,4 +459,4 @@ locations.get("/search", async (c) => {
   }
 });
 
-export { locations as locationsRoute };
+export default queries;

--- a/api/src/routes/locations/utils.ts
+++ b/api/src/routes/locations/utils.ts
@@ -1,0 +1,33 @@
+import { eq } from "drizzle-orm";
+import { createAuth } from "../../lib/auth";
+import { createDb } from "../../db";
+import * as schema from "../../db/schema";
+import type { Env } from "../../lib/auth";
+
+/** 安全解析 JSON 字段 */
+export function safeJsonParse<T>(value: string | null | undefined, fallback: T): T {
+  if (!value) return fallback;
+  try {
+    return JSON.parse(value);
+  } catch {
+    if (Array.isArray(fallback)) {
+      return value.split(/[,、]/).map((s: string) => s.trim()).filter(Boolean) as unknown as T;
+    }
+    return fallback;
+  }
+}
+
+/** 验证管理员权限 */
+export async function requireAdmin(c: { env: Env; req: { raw: Request } }) {
+  const authInstance = createAuth(c.env);
+  const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
+  if (!session) throw new Error("未登录");
+  const db = createDb(c.env.DB);
+  const user = await db
+    .select({ role: schema.users.role })
+    .from(schema.users)
+    .where(eq(schema.users.id, session.user.id))
+    .then((rows) => rows[0]);
+  if (!user || user.role !== "admin") throw new Error("无权限访问");
+  return session;
+}

--- a/api/src/routes/users/index.ts
+++ b/api/src/routes/users/index.ts
@@ -1,0 +1,23 @@
+import { Hono } from "hono";
+import type { Env } from "../../lib/auth";
+
+import queries from "./queries";
+import mutations from "./mutations";
+
+const users = new Hono<{ Bindings: Env }>();
+
+// Mount query routes (GET endpoints)
+// GET /users?id={userId}
+// GET /users/pending-approvals
+// GET /users/applications
+// GET /users/teams/joined
+// GET /users/created-teams
+// GET /users/:id
+users.route("/", queries);
+
+// Mount mutation routes (POST, PUT, PATCH, DELETE)
+// PATCH /users/update
+users.route("/", mutations);
+
+export default users;
+export { users as usersRoute };

--- a/api/src/routes/users/mutations.ts
+++ b/api/src/routes/users/mutations.ts
@@ -1,0 +1,94 @@
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+import { createAuth } from "../../lib/auth";
+import { createDb } from "../../db";
+import * as schema from "../../db/schema";
+import type { Env } from "../../lib/auth";
+import { APIErrors } from "../../lib/api-errors";
+import { sanitizeUser, validateUserExtra } from "./utils";
+
+const mutations = new Hono<{ Bindings: Env }>();
+
+/**
+ * PATCH /users/update
+ * 更新用户信息（需登录，只能修改自己的资料）
+ */
+mutations.patch("/update", async (c) => {
+  try {
+    const authInstance = createAuth(c.env);
+    const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
+
+    const db = createDb(c.env.DB);
+    const body = await c.req.json<{
+      userId?: string; name?: string; nickname?: string; bio?: string;
+      level?: string; image?: string; wechat?: string; gender?: string;
+      birthday?: string | number; extra?: unknown;
+    }>();
+    const { userId, name, nickname, bio, level, image, wechat, gender, birthday, extra } = body;
+
+    if (!userId) return c.json(APIErrors.badRequest("User ID is required"), 400);
+
+    const updateData: Partial<typeof schema.users.$inferInsert> = {};
+    if (name !== undefined) updateData.name = name;
+    if (nickname !== undefined) updateData.nickname = nickname;
+    if (bio !== undefined) updateData.bio = bio;
+    if (level !== undefined) updateData.level = level;
+    if (image !== undefined) updateData.image = image;
+    if (wechat !== undefined) updateData.wechat = wechat;
+    if (gender !== undefined) updateData.gender = gender;
+    if (birthday !== undefined) {
+      updateData.birthday = birthday === null ? null : new Date(birthday as number);
+    }
+    if (extra !== undefined) {
+      if (!validateUserExtra(extra)) return c.json(APIErrors.badRequest("Invalid extra field format"), 400);
+      updateData.extra = JSON.stringify(extra);
+    }
+    updateData.updatedAt = new Date();
+
+    // 支持 email 或 id 查找用户
+    let targetUserId = userId;
+    const byEmail = await db
+      .select({ id: schema.users.id })
+      .from(schema.users)
+      .where(eq(schema.users.email, userId))
+      .limit(1);
+    if (byEmail.length > 0) targetUserId = byEmail[0].id;
+
+    // 鉴权：只允许修改自己的资料（管理员除外）
+    if (targetUserId !== session.user.id) {
+      const sessionUser = await db
+        .select({ role: schema.users.role })
+        .from(schema.users)
+        .where(eq(schema.users.id, session.user.id))
+        .limit(1);
+      if (!sessionUser.length || sessionUser[0].role !== "admin") {
+        return c.json(APIErrors.forbidden("无权限修改他人资料"), 403);
+      }
+    }
+
+    const existing = await db
+      .select({ id: schema.users.id })
+      .from(schema.users)
+      .where(eq(schema.users.id, targetUserId))
+      .limit(1);
+    if (!existing.length) return c.json(APIErrors.notFound(`User not found: ${targetUserId}`), 404);
+
+    await db.update(schema.users).set(updateData).where(eq(schema.users.id, targetUserId));
+
+    // 读取更新后的完整用户数据
+    const updatedRows = await db
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.id, targetUserId))
+      .limit(1);
+    const updatedUser = updatedRows[0];
+
+    return c.json({ success: true, user: sanitizeUser(updatedUser) });
+  } catch (error) {
+    console.error("User update error:", error);
+    return c.json(APIErrors.internalError("Failed to update user"), 500);
+  }
+});
+
+export default mutations;

--- a/api/src/routes/users/queries.ts
+++ b/api/src/routes/users/queries.ts
@@ -1,59 +1,19 @@
-import { APIErrors } from "../lib/api-errors";
 import { Hono } from "hono";
-import { and, eq, ne, gt, inArray } from "drizzle-orm";
-import { createAuth } from "../lib/auth";
-import { createDb } from "../db";
-import * as schema from "../db/schema";
-import type { Env } from "../lib/auth";
+import { and, eq } from "drizzle-orm";
+import { createAuth } from "../../lib/auth";
+import { createDb } from "../../db";
+import * as schema from "../../db/schema";
+import type { Env } from "../../lib/auth";
+import { APIErrors } from "../../lib/api-errors";
+import { formatBeijingDateTime, getUserStats, getUserOngoingTeams } from "./utils";
 
-/** 格式化日期为北京时间（UTC+8）的 date 和 time 字符串 */
-function formatBeijingDateTime(date: Date | null): { date: string | null; time: string | null } {
-  if (!date) return { date: null, time: null };
-  const beijingDate = new Date(date.getTime() + 8 * 60 * 60 * 1000);
-  return {
-    date: beijingDate.toISOString().split("T")[0],
-    time: beijingDate.toISOString().slice(11, 16),
-  };
-}
-
-/** 返回安全的用户对象（时间戳格式） */
-function sanitizeUser(user: typeof schema.users.$inferSelect) {
-  return {
-    id: user.id,
-    name: user.name,
-    nickname: user.nickname,
-    email: user.email,
-    avatar: user.image,
-    bio: user.bio,
-    gender: user.gender,
-    birthday: user.birthday,
-    level: user.level || "beginner",
-    completedHikes: user.completedHikes ?? 0,
-    wechat: user.wechat,
-    extra: user.extra,
-    role: user.role || "user",
-    status: user.status,
-    createdAt: user.createdAt,
-    updatedAt: user.updatedAt,
-  };
-}
-
-const users = new Hono<{ Bindings: Env }>();
-
-/** 校验 UserExtra 字段格式 */
-function validateUserExtra(extra: unknown): extra is { equipment?: string[]; experience?: string } {
-  if (typeof extra !== "object" || extra === null) return false;
-  const e = extra as Record<string, unknown>;
-  if (e.equipment !== undefined && !Array.isArray(e.equipment)) return false;
-  if (e.experience !== undefined && typeof e.experience !== "string") return false;
-  return true;
-}
+const queries = new Hono<{ Bindings: Env }>();
 
 /**
  * GET /users?id={userId}
  * 获取用户信息
  */
-users.get("/", async (c) => {
+queries.get("/", async (c) => {
   try {
     const userId = c.req.query("id");
     if (!userId) return c.json(APIErrors.badRequest("User ID is required"), 400);
@@ -88,92 +48,10 @@ users.get("/", async (c) => {
 });
 
 /**
- * PATCH /users/update
- * 更新用户信息（需登录，只能修改自己的资料）
- */
-users.patch("/update", async (c) => {
-  try {
-    const authInstance = createAuth(c.env);
-    const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
-    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
-
-    const db = createDb(c.env.DB);
-    const body = await c.req.json<{
-      userId?: string; name?: string; nickname?: string; bio?: string;
-      level?: string; image?: string; wechat?: string; gender?: string;
-      birthday?: string | number; extra?: unknown;
-    }>();
-    const { userId, name, nickname, bio, level, image, wechat, gender, birthday, extra } = body;
-
-    if (!userId) return c.json(APIErrors.badRequest("User ID is required"), 400);
-
-    const updateData: Partial<typeof schema.users.$inferInsert> = {};
-    if (name !== undefined) updateData.name = name;
-    if (nickname !== undefined) updateData.nickname = nickname;
-    if (bio !== undefined) updateData.bio = bio;
-    if (level !== undefined) updateData.level = level;
-    if (image !== undefined) updateData.image = image;
-    if (wechat !== undefined) updateData.wechat = wechat;
-    if (gender !== undefined) updateData.gender = gender;
-    if (birthday !== undefined) {
-      updateData.birthday = birthday === null ? null : new Date(birthday as number);
-    }
-    if (extra !== undefined) {
-      if (!validateUserExtra(extra)) return c.json(APIErrors.badRequest("Invalid extra field format"), 400);
-      updateData.extra = JSON.stringify(extra);
-    }
-    updateData.updatedAt = new Date();
-
-    // 支持 email 或 id 查找用户
-    let targetUserId = userId;
-    const byEmail = await db
-      .select({ id: schema.users.id })
-      .from(schema.users)
-      .where(eq(schema.users.email, userId))
-      .limit(1);
-    if (byEmail.length > 0) targetUserId = byEmail[0].id;
-
-    // 鉴权：只允许修改自己的资料（管理员除外）
-    if (targetUserId !== session.user.id) {
-      const sessionUser = await db
-        .select({ role: schema.users.role })
-        .from(schema.users)
-        .where(eq(schema.users.id, session.user.id))
-        .limit(1);
-      if (!sessionUser.length || sessionUser[0].role !== "admin") {
-        return c.json(APIErrors.forbidden("无权限修改他人资料"), 403);
-      }
-    }
-
-    const existing = await db
-      .select({ id: schema.users.id })
-      .from(schema.users)
-      .where(eq(schema.users.id, targetUserId))
-      .limit(1);
-    if (!existing.length) return c.json(APIErrors.notFound(`User not found: ${targetUserId}`), 404);
-
-    await db.update(schema.users).set(updateData).where(eq(schema.users.id, targetUserId));
-
-    // 读取更新后的完整用户数据
-    const updatedRows = await db
-      .select()
-      .from(schema.users)
-      .where(eq(schema.users.id, targetUserId))
-      .limit(1);
-    const updatedUser = updatedRows[0];
-
-    return c.json({ success: true, user: sanitizeUser(updatedUser) });
-  } catch (error) {
-    console.error("User update error:", error);
-    return c.json(APIErrors.internalError("Failed to update user"), 500);
-  }
-});
-
-/**
  * GET /users/pending-approvals
  * 获取当前用户作为队长需要审批的所有申请（支持分页）
  */
-users.get("/pending-approvals", async (c) => {
+queries.get("/pending-approvals", async (c) => {
   try {
     const authInstance = createAuth(c.env);
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
@@ -248,7 +126,7 @@ users.get("/pending-approvals", async (c) => {
  * GET /users/applications
  * 获取当前用户的所有申请记录（以成员身份申请的，不含自己作为队长的）（支持分页）
  */
-users.get("/applications", async (c) => {
+queries.get("/applications", async (c) => {
   try {
     const authInstance = createAuth(c.env);
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
@@ -379,7 +257,7 @@ const totalPages = Math.ceil(total / pageSize);
  * GET /users/teams/joined
  * 获取当前用户以成员身份加入（已审批通过）的所有队伍（支持分页）
  */
-users.get("/teams/joined", async (c) => {
+queries.get("/teams/joined", async (c) => {
   try {
     const authInstance = createAuth(c.env);
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
@@ -465,7 +343,7 @@ users.get("/teams/joined", async (c) => {
  * GET /users/created-teams
  * 获取当前用户创建的所有队伍（支持分页）
  */
-users.get("/created-teams", async (c) => {
+queries.get("/created-teams", async (c) => {
   try {
     const authInstance = createAuth(c.env);
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
@@ -539,7 +417,7 @@ users.get("/created-teams", async (c) => {
  * GET /users/:id
  * 获取指定用户的公开资料（必须放在所有具体路径之后，避免被提前匹配）
  */
-users.get("/:id", async (c) => {
+queries.get("/:id", async (c) => {
   try {
     const id = c.req.param("id");
     const db = createDb(c.env.DB);
@@ -559,128 +437,8 @@ users.get("/:id", async (c) => {
     const session = await authInstance.api.getSession({ headers: c.req.raw.headers }).catch(() => null);
     const isSelf = session?.user?.id === id;
 
-    // 统计创建的队伍数
-    const createdTeamsCount = await db
-      .select({ count: schema.teams.id })
-      .from(schema.teams)
-      .where(eq(schema.teams.leaderId, id));
-
-    // 统计参加的队伍数（已审批通过，排除自己作为队长的）
-    const joinedTeamsCount = await db
-      .select({ count: schema.teamMembers.id })
-      .from(schema.teamMembers)
-      .innerJoin(schema.teams, eq(schema.teamMembers.teamId, schema.teams.id))
-      .where(
-        and(
-          eq(schema.teamMembers.userId, id),
-          eq(schema.teamMembers.status, "approved"),
-          // 排除自己作为队长的队伍
-          ne(schema.teams.leaderId, id)
-        )
-      );
-
-    // 统计已完成的队伍数（包括自己创建的和参加的）
-    const completedAsLeaderCount = await db
-      .select({ count: schema.teams.id })
-      .from(schema.teams)
-      .where(
-        and(
-          eq(schema.teams.leaderId, id),
-          eq(schema.teams.status, "completed")
-        )
-      );
-
-    const completedAsMemberCount = await db
-      .select({ count: schema.teamMembers.id })
-      .from(schema.teamMembers)
-      .innerJoin(schema.teams, eq(schema.teamMembers.teamId, schema.teams.id))
-      .where(
-        and(
-          eq(schema.teamMembers.userId, id),
-          eq(schema.teamMembers.status, "approved"),
-          eq(schema.teams.status, "completed"),
-          // 排除自己作为队长的队伍（避免重复计数）
-          ne(schema.teams.leaderId, id)
-        )
-      );
-
-    const stats = {
-      createdTeams: createdTeamsCount.length,
-      joinedTeams: joinedTeamsCount.length,
-      completedTeams: completedAsLeaderCount.length + completedAsMemberCount.length,
-    };
-
-    // 查询正在进行中的队伍（作为队长或已批准成员）
-    const now = new Date();
-    const activeStatuses = ["recruiting", "full", "formed"];
-
-    // 获取用户参与的所有队伍ID（作为队长或已批准成员）
-    const { sql } = await import("drizzle-orm");
-    const currentMembersSubquery = sql<number>`(SELECT COUNT(*) FROM team_members WHERE team_members.team_id = ${schema.teams.id} AND team_members.status = 'approved')`;
-
-    // 查询作为队长的正在进行中的队伍
-    const createdOngoingTeams = await db
-      .select({
-        id: schema.teams.id, title: schema.teams.title, startTime: schema.teams.startTime,
-        endTime: schema.teams.endTime, maxMembers: schema.teams.maxMembers, status: schema.teams.status,
-        locationName: schema.locations.name, locationCoverImage: schema.locations.coverImage,
-        currentMembers: currentMembersSubquery,
-      })
-      .from(schema.teams)
-      .leftJoin(schema.locations, eq(schema.locations.id, schema.teams.locationId))
-      .where(
-        and(
-          eq(schema.teams.leaderId, id),
-          inArray(schema.teams.status, activeStatuses),
-          gt(schema.teams.endTime, now)
-        )
-      )
-      .limit(5);
-
-    // 查询作为成员加入的正在进行中的队伍
-    const joinedOngoingTeams = await db
-      .select({
-        id: schema.teams.id, title: schema.teams.title, startTime: schema.teams.startTime,
-        endTime: schema.teams.endTime, maxMembers: schema.teams.maxMembers, status: schema.teams.status,
-        locationName: schema.locations.name, locationCoverImage: schema.locations.coverImage,
-        currentMembers: currentMembersSubquery,
-      })
-      .from(schema.teams)
-      .innerJoin(schema.teamMembers, eq(schema.teamMembers.teamId, schema.teams.id))
-      .leftJoin(schema.locations, eq(schema.locations.id, schema.teams.locationId))
-      .where(
-        and(
-          eq(schema.teamMembers.userId, id),
-          eq(schema.teamMembers.status, "approved"),
-          ne(schema.teams.leaderId, id), // 排除自己作为队长的
-          inArray(schema.teams.status, activeStatuses),
-          gt(schema.teams.endTime, now)
-        )
-      )
-      .limit(5);
-
-    // 合并并格式化正在进行中的队伍
-    const allOngoingTeams = [...createdOngoingTeams, ...joinedOngoingTeams]
-      .sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime())
-      .slice(0, 8);
-
-    const ongoingTeams = allOngoingTeams.map((row) => {
-      const startDate = new Date(row.startTime);
-      const { date, time } = formatBeijingDateTime(startDate);
-      return {
-        id: row.id,
-        title: row.title,
-        date,
-        time,
-        status: row.status,
-        currentMembers: row.currentMembers ?? 0,
-        maxMembers: row.maxMembers,
-        location: row.locationName ? {
-          name: row.locationName,
-          coverImage: row.locationCoverImage || "",
-        } : null,
-      };
-    });
+    const stats = await getUserStats(db, id);
+    const ongoingTeams = await getUserOngoingTeams(db, id);
 
     return c.json({
       success: true,
@@ -704,4 +462,4 @@ users.get("/:id", async (c) => {
   }
 });
 
-export { users as usersRoute };
+export default queries;

--- a/api/src/routes/users/utils.ts
+++ b/api/src/routes/users/utils.ts
@@ -1,0 +1,150 @@
+import * as schema from "../../db/schema";
+import { and, eq, ne, gt, inArray } from "drizzle-orm";
+import type { createDb } from "../../db";
+
+type Db = ReturnType<typeof createDb>;
+
+/** 格式化日期为北京时间（UTC+8）的 date 和 time 字符串 */
+export function formatBeijingDateTime(date: Date | null): { date: string | null; time: string | null } {
+  if (!date) return { date: null, time: null };
+  const beijingDate = new Date(date.getTime() + 8 * 60 * 60 * 1000);
+  return {
+    date: beijingDate.toISOString().split("T")[0],
+    time: beijingDate.toISOString().slice(11, 16),
+  };
+}
+
+/** 返回安全的用户对象（时间戳格式） */
+export function sanitizeUser(user: typeof schema.users.$inferSelect) {
+  return {
+    id: user.id,
+    name: user.name,
+    nickname: user.nickname,
+    email: user.email,
+    avatar: user.image,
+    bio: user.bio,
+    gender: user.gender,
+    birthday: user.birthday,
+    level: user.level || "beginner",
+    completedHikes: user.completedHikes ?? 0,
+    wechat: user.wechat,
+    extra: user.extra,
+    role: user.role || "user",
+    status: user.status,
+    createdAt: user.createdAt,
+    updatedAt: user.updatedAt,
+  };
+}
+
+/** 校验 UserExtra 字段格式 */
+export function validateUserExtra(extra: unknown): extra is { equipment?: string[]; experience?: string } {
+  if (typeof extra !== "object" || extra === null) return false;
+  const e = extra as Record<string, unknown>;
+  if (e.equipment !== undefined && !Array.isArray(e.equipment)) return false;
+  if (e.experience !== undefined && typeof e.experience !== "string") return false;
+  return true;
+}
+
+/** 统计用户创建/参加/完成的队伍数 */
+export async function getUserStats(db: Db, id: string) {
+  const createdTeamsCount = await db
+    .select({ count: schema.teams.id })
+    .from(schema.teams)
+    .where(eq(schema.teams.leaderId, id));
+
+  const joinedTeamsCount = await db
+    .select({ count: schema.teamMembers.id })
+    .from(schema.teamMembers)
+    .innerJoin(schema.teams, eq(schema.teamMembers.teamId, schema.teams.id))
+    .where(
+      and(
+        eq(schema.teamMembers.userId, id),
+        eq(schema.teamMembers.status, "approved"),
+        ne(schema.teams.leaderId, id)
+      )
+    );
+
+  const completedAsLeaderCount = await db
+    .select({ count: schema.teams.id })
+    .from(schema.teams)
+    .where(and(eq(schema.teams.leaderId, id), eq(schema.teams.status, "completed")));
+
+  const completedAsMemberCount = await db
+    .select({ count: schema.teamMembers.id })
+    .from(schema.teamMembers)
+    .innerJoin(schema.teams, eq(schema.teamMembers.teamId, schema.teams.id))
+    .where(
+      and(
+        eq(schema.teamMembers.userId, id),
+        eq(schema.teamMembers.status, "approved"),
+        eq(schema.teams.status, "completed"),
+        ne(schema.teams.leaderId, id)
+      )
+    );
+
+  return {
+    createdTeams: createdTeamsCount.length,
+    joinedTeams: joinedTeamsCount.length,
+    completedTeams: completedAsLeaderCount.length + completedAsMemberCount.length,
+  };
+}
+
+/** 查询用户正在进行中的队伍（作为队长或已批准成员），最多 8 条 */
+export async function getUserOngoingTeams(db: Db, id: string) {
+  const now = new Date();
+  const activeStatuses = ["recruiting", "full", "formed"];
+  const { sql } = await import("drizzle-orm");
+  const currentMembersSubquery = sql<number>`(SELECT COUNT(*) FROM team_members WHERE team_members.team_id = ${schema.teams.id} AND team_members.status = 'approved')`;
+
+  const ongoingSelect = {
+    id: schema.teams.id, title: schema.teams.title, startTime: schema.teams.startTime,
+    endTime: schema.teams.endTime, maxMembers: schema.teams.maxMembers, status: schema.teams.status,
+    locationName: schema.locations.name, locationCoverImage: schema.locations.coverImage,
+    currentMembers: currentMembersSubquery,
+  };
+
+  const createdOngoingTeams = await db
+    .select(ongoingSelect)
+    .from(schema.teams)
+    .leftJoin(schema.locations, eq(schema.locations.id, schema.teams.locationId))
+    .where(and(eq(schema.teams.leaderId, id), inArray(schema.teams.status, activeStatuses), gt(schema.teams.endTime, now)))
+    .limit(5);
+
+  const joinedOngoingTeams = await db
+    .select(ongoingSelect)
+    .from(schema.teams)
+    .innerJoin(schema.teamMembers, eq(schema.teamMembers.teamId, schema.teams.id))
+    .leftJoin(schema.locations, eq(schema.locations.id, schema.teams.locationId))
+    .where(
+      and(
+        eq(schema.teamMembers.userId, id),
+        eq(schema.teamMembers.status, "approved"),
+        ne(schema.teams.leaderId, id),
+        inArray(schema.teams.status, activeStatuses),
+        gt(schema.teams.endTime, now)
+      )
+    )
+    .limit(5);
+
+  const allOngoingTeams = [...createdOngoingTeams, ...joinedOngoingTeams]
+    .sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime())
+    .slice(0, 8);
+
+  return allOngoingTeams.map((row) => {
+    const startDate = new Date(row.startTime);
+    const { date, time } = formatBeijingDateTime(startDate);
+    return {
+      id: row.id,
+      title: row.title,
+      date,
+      time,
+      status: row.status,
+      currentMembers: row.currentMembers ?? 0,
+      maxMembers: row.maxMembers,
+      location: row.locationName ? {
+        name: row.locationName,
+        coverImage: row.locationCoverImage || "",
+      } : null,
+    };
+  });
+}


### PR DESCRIPTION
## 任务 #73：locations.ts 和 users.ts 模块化拆分

参照 `teams/` 模式，将超 500 行的单文件拆为模块化目录。

## 改动范围（8 文件）

### `locations/`（原 `locations.ts` 696 行）
- `index.ts` (26 行)：路由注册 + 导出 `locationsRoute`
- `queries.ts` (462 行)：GET `/`、`/:id`、`/:id/pois`、`/:id/tags`、`/search`
- `mutations.ts` (217 行)：POST `/`、PUT `/`、DELETE `/:id`、PUT `/:id/tags`、`/:id/pois`
- `utils.ts` (33 行)：`safeJsonParse`、`requireAdmin`

### `users/`（原 `users.ts` 707 行）
- `index.ts` (23 行)：路由注册 + 导出 `usersRoute`
- `queries.ts` (465 行)：GET `/`、`/pending-approvals`、`/applications`、`/teams/joined`、`/created-teams`、`/:id`
- `mutations.ts` (94 行)：PATCH `/update`
- `utils.ts` (150 行)：`formatBeijingDateTime`、`sanitizeUser`、`validateUserExtra`、`getUserStats`、`getUserOngoingTeams`

## 设计
- 纯重构，不改任何功能，API 端点行为完全一致
- 原导入路径兼容：`api/src/index.ts` 的 `import { locationsRoute } from "./routes/locations"` 自动解析到 `locations/index.ts`
- 为满足 <500 行验收标准，将 `users/:id` 端点的 stats 计算和 ongoingTeams 查询提取为 `utils.ts` 的 `getUserStats` / `getUserOngoingTeams`
- 所有文件 <500 行 ✅

## 本地验证
- `pnpm --filter @gomate/api build`（tsc）→ 通过
- `pnpm --filter @gomate/api lint` → 0 错误
- `pnpm --filter @gomate/api test` → 178 测试全过

## 已知风险
- 无功能变更，回滚 revert 即可

🤖 Generated with [Claude Code](https://claude.com/claude-code)