### PR TITLE
feat: 点赞功能（DB 迁移 + API toggle + 前端 UI）

### DIFF
--- a/api/db/migrations/0007_add_user_story_likes.sql
+++ b/api/db/migrations/0007_add_user_story_likes.sql
@@ -1,0 +1,12 @@
+-- Migration: Add user_story_likes table for story like toggle
+-- Created: 2026-06-28
+
+CREATE TABLE IF NOT EXISTS user_story_likes (
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  story_id TEXT NOT NULL REFERENCES stories(id) ON DELETE CASCADE,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+  PRIMARY KEY (user_id, story_id)
+);
+
+CREATE INDEX IF NOT EXISTS user_story_likes_user_idx ON user_story_likes(user_id);
+CREATE INDEX IF NOT EXISTS user_story_likes_story_idx ON user_story_likes(story_id);

--- a/api/src/__tests__/helpers/db.ts
+++ b/api/src/__tests__/helpers/db.ts
@@ -223,6 +223,13 @@ export function createTestDb() {
       updated_at INTEGER NOT NULL
     );
 
+    CREATE TABLE IF NOT EXISTS user_story_likes (
+      user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      story_id TEXT NOT NULL REFERENCES stories(id) ON DELETE CASCADE,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+      PRIMARY KEY (user_id, story_id)
+    );
+
     CREATE TABLE IF NOT EXISTS conversations (
       id TEXT PRIMARY KEY,
       team_id TEXT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -5,6 +5,7 @@ import {
   real,
   index,
   uniqueIndex,
+  primaryKey,
 } from "drizzle-orm/sqlite-core";
 import { relations } from "drizzle-orm";
 
@@ -354,6 +355,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   sessions: many(sessions),
   accounts: many(accounts),
   favorites: many(userFavorites),
+  storyLikes: many(userStoryLikes),
 }));
 
 export const sessionsRelations = relations(sessions, ({ one }) => ({
@@ -586,9 +588,10 @@ export const stories = sqliteTable(
   })
 );
 
-export const storiesRelations = relations(stories, ({ one }) => ({
+export const storiesRelations = relations(stories, ({ one, many }) => ({
   author: one(users, { fields: [stories.authorId], references: [users.id] }),
   location: one(locations, { fields: [stories.locationId], references: [locations.id] }),
+  likes: many(userStoryLikes),
 }));
 
 export type Story = typeof stories.$inferSelect;
@@ -596,6 +599,30 @@ export type NewStory = typeof stories.$inferInsert;
 
 // 发现内容状态
 export type StoryStatus = "draft" | "published" | "hidden";
+
+// ==================== User Story Likes (点赞) ====================
+
+export const userStoryLikes = sqliteTable(
+  "user_story_likes",
+  {
+    userId: text("user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
+    storyId: text("story_id").references(() => stories.id, { onDelete: "cascade" }).notNull(),
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).$defaultFn(() => new Date()).notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.userId, table.storyId] }),
+    userIdx: index("user_story_likes_user_idx").on(table.userId),
+    storyIdx: index("user_story_likes_story_idx").on(table.storyId),
+  })
+);
+
+export const userStoryLikesRelations = relations(userStoryLikes, ({ one }) => ({
+  user: one(users, { fields: [userStoryLikes.userId], references: [users.id] }),
+  story: one(stories, { fields: [userStoryLikes.storyId], references: [stories.id] }),
+}));
+
+export type UserStoryLike = typeof userStoryLikes.$inferSelect;
+export type NewUserStoryLike = typeof userStoryLikes.$inferInsert;
 
 // ==================== Image Cache (分享图图片预缓存) ====================
 

--- a/api/src/routes/stories.ts
+++ b/api/src/routes/stories.ts
@@ -95,6 +95,10 @@ stories.get("/", async (c) => {
     const tag = c.req.query("tag");
     const offset = (page - 1) * limit;
 
+    // 获取当前登录用户（可选），用于 isLiked 判断
+    const auth = createAuth(c.env);
+    const session = await auth.api.getSession({ headers: c.req.raw.headers }).catch(() => null);
+
     // 基础过滤条件：状态
     const whereConditions = [eq(schema.stories.status, status)];
 
@@ -164,8 +168,19 @@ stories.get("/", async (c) => {
 
     const totalResult = await db.$count(schema.stories, whereClause);
 
+    // 查询当前用户已点赞的故事ID列表
+    let likedStoryIds = new Set<string>();
+    if (session) {
+      const userLikes = await db
+        .select({ storyId: schema.userStoryLikes.storyId })
+        .from(schema.userStoryLikes)
+        .where(eq(schema.userStoryLikes.userId, session.user.id));
+      likedStoryIds = new Set(userLikes.map((l) => l.storyId));
+    }
+
     const formatted = items.map(({ story, author }) => ({
       ...story,
+      isLiked: likedStoryIds.has(story.id),
       author: author
         ? {
             id: author.id,
@@ -293,11 +308,27 @@ stories.get("/:id", async (c) => {
       .set({ viewCount: currentViewCount + 1 })
       .where(eq(schema.stories.id, id));
 
+    // 检查当前用户是否已点赞（仅登录用户）
+    let isLiked = false;
+    const authInstance = createAuth(c.env);
+    const session = await authInstance.api.getSession({ headers: c.req.raw.headers }).catch(() => null);
+    if (session) {
+      const likeRecord = await db.query.userStoryLikes.findFirst({
+        where: and(
+          eq(schema.userStoryLikes.userId, session.user.id),
+          eq(schema.userStoryLikes.storyId, id)
+        ),
+        columns: { userId: true },
+      });
+      isLiked = !!likeRecord;
+    }
+
     return c.json({
       success: true,
       data: {
         ...story,
         viewCount: currentViewCount + 1,
+        isLiked,
         author: author
           ? {
               id: author.id,
@@ -532,7 +563,9 @@ stories.delete("/:id", async (c) => {
 
 /**
  * POST /stories/:id/like
- * 点赞故事
+ * 点赞/取消点赞故事（toggle）
+ * 已点赞 → 取消点赞（likeCount -1）
+ * 未点赞 → 点赞（likeCount +1）
  */
 stories.post("/:id/like", async (c) => {
   try {
@@ -545,27 +578,69 @@ stories.post("/:id/like", async (c) => {
 
     const db = createDb(c.env.DB);
     const id = c.req.param("id");
+    const userId = session.user.id;
 
     const story = await db.query.stories.findFirst({
       where: eq(schema.stories.id, id),
+      columns: { id: true, likeCount: true },
     });
 
     if (!story) {
       return c.json(APIErrors.notFound("故事不存在"), 404);
     }
 
-    await db
-      .update(schema.stories)
-      .set({
-        likeCount: (story.likeCount ?? 0) + 1,
-        updatedAt: new Date(),
-      })
-      .where(eq(schema.stories.id, id));
-
-    return c.json({
-      success: true,
-      message: "点赞成功",
+    // 检查是否已点赞
+    const existingLike = await db.query.userStoryLikes.findFirst({
+      where: and(
+        eq(schema.userStoryLikes.userId, userId),
+        eq(schema.userStoryLikes.storyId, id)
+      ),
+      columns: { userId: true },
     });
+
+    if (existingLike) {
+      // 已点赞 → 取消点赞
+      await db.batch([
+        db.delete(schema.userStoryLikes).where(
+          and(
+            eq(schema.userStoryLikes.userId, userId),
+            eq(schema.userStoryLikes.storyId, id)
+          )
+        ),
+        db.update(schema.stories)
+          .set({
+            likeCount: Math.max(0, (story.likeCount ?? 0) - 1),
+            updatedAt: new Date(),
+          })
+          .where(eq(schema.stories.id, id)),
+      ]);
+
+      return c.json({
+        success: true,
+        liked: false,
+        message: "取消点赞成功",
+      });
+    } else {
+      // 未点赞 → 点赞
+      await db.batch([
+        db.insert(schema.userStoryLikes).values({
+          userId,
+          storyId: id,
+        }),
+        db.update(schema.stories)
+          .set({
+            likeCount: (story.likeCount ?? 0) + 1,
+            updatedAt: new Date(),
+          })
+          .where(eq(schema.stories.id, id)),
+      ]);
+
+      return c.json({
+        success: true,
+        liked: true,
+        message: "点赞成功",
+      });
+    }
   } catch (error) {
     console.error("Like story error:", error);
     return c.json(APIErrors.internalError("点赞失败"), 500);

--- a/frontend/src/components/features/discover/story-detail-types.ts
+++ b/frontend/src/components/features/discover/story-detail-types.ts
@@ -6,6 +6,7 @@ export interface Story {
   coverImage?: string;
   viewCount: number;
   likeCount: number;
+  isLiked?: boolean;
   createdAt: number;
   updatedAt: number;
   status: string;

--- a/frontend/src/components/features/discover/story-detail-ui.tsx
+++ b/frontend/src/components/features/discover/story-detail-ui.tsx
@@ -115,7 +115,7 @@ export function StoryActions({
         <button
           type="button"
           onClick={onLike}
-          disabled={isLiking || liked}
+          disabled={isLiking}
           aria-pressed={liked}
           className={cn(
             "inline-flex min-h-11 items-center justify-center gap-2 rounded-lg px-5 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed",

--- a/frontend/src/components/features/discover/story-detail.tsx
+++ b/frontend/src/components/features/discover/story-detail.tsx
@@ -33,6 +33,14 @@ export function StoryDetail({ storyId }: StoryDetailProps) {
   const [error, setError] = React.useState<string | null>(null);
   const [isLiking, setIsLiking] = React.useState(false);
   const [liked, setLiked] = React.useState(false);
+
+  // 从 API 响应初始化点赞状态
+  React.useEffect(() => {
+    if (story) {
+      setLiked(story.isLiked ?? false);
+    }
+  }, [story?.id, story?.isLiked]);
+
   const [deleteConfirmOpen, setDeleteConfirmOpen] = React.useState(false);
   const [isDeleting, setIsDeleting] = React.useState(false);
   const [deleteError, setDeleteError] = React.useState("");
@@ -110,30 +118,48 @@ export function StoryDetail({ storyId }: StoryDetailProps) {
   }, [copyCurrentUrl, story]);
 
   const handleLike = React.useCallback(async () => {
-    if (isLiking || liked) return;
+    if (isLiking) return;
+
+    // 乐观更新：先翻转本地状态
+    const prevLiked = liked;
+    const prevLikeCount = story?.likeCount ?? 0;
+    setLiked(!liked);
+    setStory((prev) =>
+      prev ? { ...prev, likeCount: prev.likeCount + (liked ? -1 : 1) } : prev,
+    );
 
     try {
       setIsLiking(true);
-      const response = await apiPost<{ success: boolean; message: string }>(
+      const response = await apiPost<{ success: boolean; liked: boolean; message: string }>(
         `/stories/${storyId}/like`,
       );
 
       if (response.success) {
-        setLiked(true);
-        setStory((prev) =>
-          prev ? { ...prev, likeCount: prev.likeCount + 1 } : prev,
-        );
-        showToast({ type: "success", message: t("content.discover.liked") });
+        setLiked(response.liked);
+        showToast({
+          type: "success",
+          message: response.liked ? t("content.discover.liked") : t("content.discover.unliked"),
+        });
       } else {
+        // API 返回失败 → 回滚本地状态
+        setLiked(prevLiked);
+        setStory((prev) =>
+          prev ? { ...prev, likeCount: prevLikeCount } : prev,
+        );
         showToast({ type: "error", message: t("content.discover.likeFailed") });
       }
     } catch (err) {
+      // 网络异常 → 回滚本地状态
+      setLiked(prevLiked);
+      setStory((prev) =>
+        prev ? { ...prev, likeCount: prevLikeCount } : prev,
+      );
       showToast({ type: "error", message: t("content.discover.likeFailed") });
       console.error("Like story error:", err);
     } finally {
       setIsLiking(false);
     }
-  }, [isLiking, liked, showToast, storyId, t]);
+  }, [isLiking, liked, story, showToast, storyId, t]);
 
   const handleDelete = React.useCallback(async () => {
     if (!canDelete || isDeleting) return;

--- a/frontend/src/i18n/types.ts
+++ b/frontend/src/i18n/types.ts
@@ -505,6 +505,7 @@ export type TranslationKey =
   | "content.discover.anonymous"
   | "content.discover.relatedLocation"
   | "content.discover.liked"
+	  | "content.discover.unliked"
   | "content.discover.like"
   | "content.discover.linkCopied"
   | "content.discover.today"


### PR DESCRIPTION
## 任务 #74 #75 #76：点赞功能完整实现

依赖链：#74(DB) → #75(API) → #76(前端)，按顺序执行。

### #74 — DB 迁移 + Schema
- `api/db/migrations/0007_add_user_story_likes.sql`：user_story_likes 表，复合主键 `(user_id, story_id)`，外键级联删除，两个索引
- `api/src/db/schema.ts`：新增 userStoryLikes 表定义、relations、types；users 和 stories relations 补充 likes

### #75 — API like toggle + isLiked 字段
- `POST /stories/:id/like` 改为 toggle：已点赞则取消（likeCount -1），未点赞则点赞（likeCount +1），返回 `liked: boolean`
- `GET /stories` 列表响应新增 `isLiked: boolean`（登录用户查询所有点赞的 storyId）
- `GET /stories/:id` 详情响应新增 `isLiked: boolean`
- 未登录用户点赞返回 401
- 使用 `db.batch()` 保证 likeCount + user_story_likes 一致性
- 测试 DB 补充 user_story_likes 表

### #76 — 前端 toggle UI + 乐观更新 + i18n
- `liked` 初始值从 `story.isLiked` 读取，不再硬编码 false
- 按钮 `disabled={liked}` 移除，始终可点击（除非 loading）
- 乐观更新：先翻转本地状态，API 失败回滚
- 新增 `unliked` 翻译（中/英/日），toast 显示"取消点赞成功"
- `StoryDetailTypes` 新增 `isLiked?: boolean`

## 分支
符合命名规范：`raft/add-like-db-schema`

## 本地验证
- `pnpm --filter @gomate/api build` → 通过
- `pnpm --filter @gomate/api lint` → 0 错误
- `pnpm --filter @gomate/api test` → 178 测试全过
- `pnpm --filter @gomate/frontend build` → 通过

## 已知风险
- 新表需在生产环境运行迁移
- unliked 翻译已添加，需确认文案是否符合编辑风格

🤖 Generated with [Claude Code](https://claude.com/claude-code)