### PR TITLE
feat(admin): POI 服务端搜索 + 拖拽排序（任务 #78）

### DIFF
--- a/frontend/src/components/features/location-edit-client.tsx
+++ b/frontend/src/components/features/location-edit-client.tsx
@@ -443,7 +443,7 @@ export function LocationEditClient({ locationId }: LocationEditClientProps) {
               updateField={form.updateField} handlePoiSearch={form.handlePoiSearch}
               handleOpenCreatePoi={form.handleOpenCreatePoi} handleOpenEditPoi={form.handleOpenEditPoi}
               handlePoiModalSuccess={form.handlePoiModalSuccess} handleOpenDeletePoi={form.handleOpenDeletePoi}
-              handleConfirmDeletePoi={form.handleConfirmDeletePoi} clearPoiSearchResults={form.clearPoiSearchResults} />
+              handleConfirmDeletePoi={form.handleConfirmDeletePoi} clearPoiSearchResults={form.clearPoiSearchResults} isSearchingPois={form.isSearchingPois} />
             <LocationActionBar isDirty={form.isDirty} isSaving={form.isSaving} onSave={form.handleSave} onDiscard={form.handleDiscard} />
           </div>
 

--- a/frontend/src/components/features/location-form/location-form-route-fields.tsx
+++ b/frontend/src/components/features/location-form/location-form-route-fields.tsx
@@ -74,6 +74,7 @@ interface LocationFormRouteFieldsProps {
   handleOpenDeletePoi: (poiId: string, poiName: string) => Promise<void>;
   handleConfirmDeletePoi: () => Promise<void>;
   clearPoiSearchResults: () => void;
+  isSearchingPois?: boolean;
 }
 
 export function LocationFormRouteFields({
@@ -81,7 +82,7 @@ export function LocationFormRouteFields({
   deleteConfirmOpen, deletingPoi, deletingPoiAssociations, isDeletingPoi,
   poiSearch, poiSearchResults, updateField, handlePoiSearch,
   handleOpenCreatePoi, handleOpenEditPoi, handlePoiModalSuccess,
-  handleOpenDeletePoi, handleConfirmDeletePoi, clearPoiSearchResults,
+  handleOpenDeletePoi, handleConfirmDeletePoi, clearPoiSearchResults, isSearchingPois = false,
 }: LocationFormRouteFieldsProps) {
   const { t } = useI18n(["admin", "pois"]);
   const { toast, show: showToast, isExiting } = useToast();
@@ -104,6 +105,11 @@ export function LocationFormRouteFields({
           className="flex items-center gap-1.5 px-3 py-2.5 rounded-xl text-sm font-medium text-white bg-gradient-to-r from-amber-500 to-orange-500 hover:opacity-90 transition-opacity shrink-0">
           <Plus className="h-4 w-4" /><span className="hidden sm:inline">{t("pois.createBtn")}</span>
         </button>
+        {isSearchingPois && (
+          <div className="flex items-center justify-center py-2">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-amber-500 border-t-transparent" />
+          </div>
+        )}
       </div>
 
       {poiSearchResults.length > 0 && (
@@ -135,8 +141,29 @@ export function LocationFormRouteFields({
         <div className="space-y-2">
           {formData.poiLinks.map((link, idx) => {
             const poi = allPois.find((p) => p.id === link.poiId);
+            const handleDragStart = (e: React.DragEvent) => {
+              e.dataTransfer.setData("text/plain", String(idx));
+              e.dataTransfer.effectAllowed = "move";
+            };
+            const handleDragOver = (e: React.DragEvent) => {
+              e.preventDefault();
+              e.dataTransfer.dropEffect = "move";
+            };
+            const handleDrop = (e: React.DragEvent) => {
+              e.preventDefault();
+              const fromIdx = parseInt(e.dataTransfer.getData("text/plain"), 10);
+              if (fromIdx === idx) return;
+              const next = [...formData.poiLinks];
+              const [moved] = next.splice(fromIdx, 1);
+              const toIdx = fromIdx < idx ? idx - 1 : idx;
+              next.splice(toIdx, 0, moved);
+              // 重新生成 order 字段
+              updateField("poiLinks", next.map((l, i) => ({ ...l, order: i })));
+            };
             return (
-              <div key={link.poiId} className="px-3 py-2 rounded-xl bg-stone-50 dark:bg-stone-800 border border-stone-100 dark:border-stone-700">
+              <div key={link.poiId} draggable
+                onDragStart={handleDragStart} onDragOver={handleDragOver} onDrop={handleDrop}
+                className="px-3 py-2 rounded-xl bg-stone-50 dark:bg-stone-800 border border-stone-100 dark:border-stone-700 cursor-grab active:cursor-grabbing">
                 <div className="flex items-center gap-2">
                   <span className="w-5 h-5 rounded-full bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-400 text-[10px] font-bold flex items-center justify-center shrink-0">{idx + 1}</span>
                   <span className="flex-1 text-sm text-stone-700 dark:text-stone-300 truncate">{poi?.name ?? link.poiId}</span>

--- a/frontend/src/components/features/location-form/use-location-form.ts
+++ b/frontend/src/components/features/location-form/use-location-form.ts
@@ -64,6 +64,7 @@ interface UseLocationFormReturn {
   handleConfirmDeletePoi: () => Promise<void>;
   handlePoiSearch: (value: string) => void;
   clearPoiSearchResults: () => void;
+  isSearchingPois: boolean;
 }
 
 /* ================================================================
@@ -134,6 +135,7 @@ export function useLocationForm(locationId: string): UseLocationFormReturn {
   const [isDeletingPoi, setIsDeletingPoi] = React.useState(false);
   const [poiSearch, setPoiSearch] = React.useState("");
   const [poiSearchResults, setPoiSearchResults] = React.useState<typeof allPois>([]);
+  const [isSearchingPois, setIsSearchingPois] = React.useState(false);
 
   // Auth guard
   React.useEffect(() => {
@@ -398,12 +400,21 @@ export function useLocationForm(locationId: string): UseLocationFormReturn {
     finally { setIsDeletingPoi(false); }
   }, [deletingPoi]);
 
+  const poiSearchTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const handlePoiSearch = React.useCallback((value: string) => {
     setPoiSearch(value);
+    if (poiSearchTimer.current) clearTimeout(poiSearchTimer.current);
     if (!value.trim()) { setPoiSearchResults([]); return; }
-    const q = value.toLowerCase();
-    setPoiSearchResults(allPois.filter((p) => p.name.toLowerCase().includes(q)).slice(0, 8));
-  }, [allPois]);
+    setIsSearchingPois(true);
+    poiSearchTimer.current = setTimeout(() => {
+      fetchAPI(`/pois?search=${encodeURIComponent(value)}&limit=8`)
+        .then((r) => r.json())
+        .then((data) => setPoiSearchResults(data.pois ?? []))
+        .catch(() => setPoiSearchResults([]))
+        .finally(() => setIsSearchingPois(false));
+    }, 350);
+  }, []);
 
   return {
     location, cities, allTags, allPois, formData, errors, isSaving, isDirty, saveMessage,
@@ -414,5 +425,6 @@ export function useLocationForm(locationId: string): UseLocationFormReturn {
     handleOpenCreatePoi, handleOpenEditPoi, handlePoiModalSuccess,
     handleOpenDeletePoi, handleConfirmDeletePoi, handlePoiSearch,
     clearPoiSearchResults: () => setPoiSearchResults([]),
+    isSearchingPois,
   };
 }

--- a/frontend/src/components/features/location-form/use-location-form.ts
+++ b/frontend/src/components/features/location-form/use-location-form.ts
@@ -402,6 +402,11 @@ export function useLocationForm(locationId: string): UseLocationFormReturn {
 
   const poiSearchTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // cleanup timer on unmount
+  React.useEffect(() => {
+    return () => { if (poiSearchTimer.current) clearTimeout(poiSearchTimer.current); };
+  }, []);
+
   const handlePoiSearch = React.useCallback((value: string) => {
     setPoiSearch(value);
     if (poiSearchTimer.current) clearTimeout(poiSearchTimer.current);


### PR DESCRIPTION
## 任务 #78：关联打卡点 P1

### 改动

**use-location-form.ts**
- `handlePoiSearch` 改为调服务端 API `/pois?search=xxx&limit=8`（debounce 350ms）
- 新增 `isSearchingPois` 状态和 `useRef` 定时器
- 导出 `isSearchingPois`

**location-form-route-fields.tsx**
- 搜索框旁添加 loading spinner（`isSearchingPois` 时显示）
- POI link 列表支持 HTML5 Drag API 拖拽排序：`draggable` + drag handlers
- 拖拽后 `order` 字段同步更新

**location-edit-client.tsx**
- 传递 `isSearchingPois={form.isSearchingPois}`

### 验证
- `pnpm --filter @gomate/frontend build` → 通过
- 不新增 npm 依赖

🤖 Generated with [Claude Code](https://claude.com/claude-code)