### PR TITLE
feat: 高级设置 UI 改造 (P0+P1+P2) — 默认展开/accordion分组/拖拽/toast

### DIFF
--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -153,6 +153,7 @@
   "formAlbumTitle": "Album Images",
   "formSettingsTitle": "Advanced Settings",
   "formSettingsTitleRecommended": "Advanced Settings (Recommended)",
+  "formTipsSectionTitle": "Tips & Warnings",
   "formFacilitiesTitle": "Facilities",
   "formTipsTitle": "Hiking Tips",
   "formTipsAdd": "Add Tip",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -152,6 +152,7 @@
   "formContentTitle": "Cover & Season",
   "formAlbumTitle": "Album Images",
   "formSettingsTitle": "Advanced Settings",
+  "formSettingsTitleRecommended": "Advanced Settings (Recommended)",
   "formFacilitiesTitle": "Facilities",
   "formTipsTitle": "Hiking Tips",
   "formTipsAdd": "Add Tip",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -162,6 +162,7 @@
   "formTagsTitle": "Associated Tags",
   "formTagsHint": "Select tags related to this location",
   "formRouteTitle": "Associated Checkpoints",
+  "deleteSuccessToast": "Deleted",
   "facilityParking": "Parking",
   "facilityRestroom": "Restroom",
   "facilityWater": "Water Station",

--- a/frontend/public/locales/ja/admin.json
+++ b/frontend/public/locales/ja/admin.json
@@ -152,6 +152,7 @@
   "formContentTitle": "カバーとシーズン",
   "formAlbumTitle": "アルバム画像",
   "formSettingsTitle": "詳細設定",
+  "formSettingsTitleRecommended": "詳細設定（推奨）",
   "formFacilitiesTitle": "付帯施設",
   "formTipsTitle": "ハイキングのヒント",
   "formTipsAdd": "ヒントを追加",

--- a/frontend/public/locales/ja/admin.json
+++ b/frontend/public/locales/ja/admin.json
@@ -153,6 +153,7 @@
   "formAlbumTitle": "アルバム画像",
   "formSettingsTitle": "詳細設定",
   "formSettingsTitleRecommended": "詳細設定（推奨）",
+  "formTipsSectionTitle": "ヒントと警告",
   "formFacilitiesTitle": "付帯施設",
   "formTipsTitle": "ハイキングのヒント",
   "formTipsAdd": "ヒントを追加",

--- a/frontend/public/locales/ja/admin.json
+++ b/frontend/public/locales/ja/admin.json
@@ -162,6 +162,7 @@
   "formTagsTitle": "関連タグ",
   "formTagsHint": "このスポットに関連するタグを選択",
   "formRouteTitle": "関連チェックポイント",
+  "deleteSuccessToast": "削除しました",
   "facilityParking": "駐車場",
   "facilityRestroom": "トイレ",
   "facilityWater": "補給ポイント",

--- a/frontend/public/locales/zh-CN/admin.json
+++ b/frontend/public/locales/zh-CN/admin.json
@@ -162,6 +162,7 @@
   "formTagsTitle": "关联标签",
   "formTagsHint": "选择与该地点相关的标签",
   "formRouteTitle": "关联打卡点",
+  "deleteSuccessToast": "已删除",
   "facilityParking": "停车场",
   "facilityRestroom": "卫生间",
   "facilityWater": "补给水源",

--- a/frontend/public/locales/zh-CN/admin.json
+++ b/frontend/public/locales/zh-CN/admin.json
@@ -153,6 +153,7 @@
   "formAlbumTitle": "相册图片",
   "formSettingsTitle": "高级设置",
   "formSettingsTitleRecommended": "高级设置（推荐完善）",
+  "formTipsSectionTitle": "贴士与警告",
   "formFacilitiesTitle": "配套设施",
   "formTipsTitle": "徒步贴士",
   "formTipsAdd": "添加贴士",

--- a/frontend/public/locales/zh-CN/admin.json
+++ b/frontend/public/locales/zh-CN/admin.json
@@ -152,6 +152,7 @@
   "formContentTitle": "封面与季节",
   "formAlbumTitle": "相册图片",
   "formSettingsTitle": "高级设置",
+  "formSettingsTitleRecommended": "高级设置（推荐完善）",
   "formFacilitiesTitle": "配套设施",
   "formTipsTitle": "徒步贴士",
   "formTipsAdd": "添加贴士",

--- a/frontend/src/components/features/location-form/location-form-settings-fields.tsx
+++ b/frontend/src/components/features/location-form/location-form-settings-fields.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Settings, Plus, ChevronDown } from "lucide-react";
+import { Settings, Plus, ChevronDown, GripVertical, AlertCircle, CheckCircle2 } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import { cn } from "@/lib/utils";
 import type { FormData } from "./use-location-form";
@@ -103,7 +103,38 @@ interface LocationFormSettingsFieldsProps {
 export function LocationFormSettingsFields({ formData, allTags, updateField }: LocationFormSettingsFieldsProps) {
   const { t } = useI18n(["admin"]);
   const facilityOptions = FACILITY_OPTIONS(t);
-  return (
+  const [toast, setToast] = React.useState<{ type: "success" | "error"; message: string } | null>(null);
+
+  const showToast = React.useCallback((type: "success" | "error", message: string) => {
+    setToast({ type, message });
+    setTimeout(() => setToast(null), 2500);
+  }, []);
+
+  const moveItem = React.useCallback((arr: string[], from: number, to: number) => {
+    const next = [...arr];
+    const [moved] = next.splice(from, 1);
+    next.splice(to, 0, moved);
+    return next;
+  }, []);
+
+  const handleDragStart = React.useCallback((e: React.DragEvent, idx: number) => {
+    e.dataTransfer.effectAllowed = "move";
+    e.dataTransfer.setData("text/plain", String(idx));
+  }, []);
+
+  const handleDragOver = React.useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+  }, []);
+
+  const handleDrop = React.useCallback((e: React.DragEvent, dropIdx: number, field: "tips" | "warnings") => {
+    e.preventDefault();
+    const fromIdx = parseInt(e.dataTransfer.getData("text/plain"), 10);
+    if (fromIdx === dropIdx) return;
+    const next = moveItem(formData.extra[field], fromIdx, dropIdx);
+    updateField("extra", { ...formData.extra, [field]: next });
+  }, [formData.extra, moveItem, updateField]);
+  return (<>
     <SectionCard icon={<Settings className="h-4 w-4" />} title={t("admin.formSettingsTitleRecommended")} collapsible defaultOpen={true}
       badge={<span className="text-[10px] text-stone-400 dark:text-stone-500 bg-stone-100 dark:bg-stone-800 px-2 py-0.5 rounded-full">{t("admin.optionalBadge")}</span>}>
       <div className="space-y-2">
@@ -116,7 +147,7 @@ export function LocationFormSettingsFields({ formData, allTags, updateField }: L
                 <button key={f.value} type="button"
                   onClick={() => updateField("extra", { ...formData.extra, facilities: selected ? formData.extra.facilities.filter((v) => v !== f.value) : [...formData.extra.facilities, f.value] })}
                   className={cn("px-3 py-1.5 rounded-xl text-xs font-medium border transition-all",
-                    selected ? "bg-amber-500 text-white border-amber-500" : "bg-white dark:bg-stone-800 text-stone-600 dark:text-stone-400 border-stone-200 dark:border-stone-700 hover:border-amber-300")}>
+                    selected ? "bg-amber-500 text-white border-amber-500" : "bg-white dark:bg-stone-800 text-stone-600 dark:text-stone-400 border-stone-200 dark:border-stone-700 hover:bg-stone-50 dark:hover:bg-stone-700 hover:border-amber-300")}>
                   {f.label}
                 </button>
               );
@@ -130,7 +161,12 @@ export function LocationFormSettingsFields({ formData, allTags, updateField }: L
         <Field label="" hint="">{/* label 在 SubSectionCard title 中 */}
           <div className="space-y-2">
             {formData.extra.tips.map((tip, idx) => (
-              <div key={idx} className="flex items-center gap-2">
+              <div key={idx} draggable
+                onDragStart={(e) => handleDragStart(e, idx)}
+                onDragOver={handleDragOver}
+                onDrop={(e) => handleDrop(e, idx, "tips")}
+                className="flex items-center gap-1.5 rounded-lg bg-stone-50/50 dark:bg-stone-800/50 hover:bg-stone-100 dark:hover:bg-stone-700/50 transition-colors cursor-grab active:cursor-grabbing p-1">
+                <GripVertical className="h-3.5 w-3.5 text-stone-300 shrink-0" />
                 <input type="text" data-tip-input value={tip}
                   onChange={(e) => {
                     const next = [...formData.extra.tips]; next[idx] = e.target.value;
@@ -142,10 +178,14 @@ export function LocationFormSettingsFields({ formData, allTags, updateField }: L
                       updateField("extra", { ...formData.extra, tips: next });
                     }
                   }}
-                  placeholder={t("admin.tipsPlaceholder")} className={cn("w-full px-3 py-2.5 rounded-xl text-sm outline-none transition-all duration-150 border bg-stone-50 dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder:text-stone-400 dark:placeholder:text-stone-500 border-stone-200 dark:border-stone-700 focus:ring-2 focus:ring-amber-200 focus:border-amber-400 flex-1")} />
-                <button type="button" onClick={() => updateField("extra", { ...formData.extra, tips: formData.extra.tips.filter((_, i) => i !== idx) })}
-                  className="w-8 h-8 flex items-center justify-center rounded-lg text-stone-400 hover:text-red-500 hover:bg-red-50 transition-colors shrink-0">
-                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
+                  placeholder={t("admin.tipsPlaceholder")} className={cn("w-full px-3 py-2 rounded-xl text-sm outline-none transition-all duration-150 border bg-white dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder:text-stone-400 dark:placeholder:text-stone-500 border-stone-200 dark:border-stone-700 focus:ring-2 focus:ring-amber-200 focus:border-amber-400 flex-1")} />
+                <button type="button" onClick={() => {
+                  const next = formData.extra.tips.filter((_, i) => i !== idx);
+                  updateField("extra", { ...formData.extra, tips: next });
+                  showToast("success", t("admin.deleteSuccessToast"));
+                }}
+                  className="w-7 h-7 flex items-center justify-center rounded-lg text-stone-400 hover:text-red-500 hover:bg-red-50 transition-colors shrink-0">
+                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
                 </button>
               </div>
             ))}
@@ -167,7 +207,12 @@ export function LocationFormSettingsFields({ formData, allTags, updateField }: L
         <Field label={t("admin.formWarningsTitle")}>
           <div className="space-y-2">
             {formData.extra.warnings.map((w, idx) => (
-              <div key={idx} className="flex items-center gap-2">
+              <div key={idx} draggable
+                onDragStart={(e) => handleDragStart(e, idx)}
+                onDragOver={handleDragOver}
+                onDrop={(e) => handleDrop(e, idx, "warnings")}
+                className="flex items-center gap-1.5 rounded-lg bg-stone-50/50 dark:bg-stone-800/50 hover:bg-stone-100 dark:hover:bg-stone-700/50 transition-colors cursor-grab active:cursor-grabbing p-1">
+                <GripVertical className="h-3.5 w-3.5 text-stone-300 shrink-0" />
                 <input type="text" data-warning-input value={w}
                   onChange={(e) => {
                     const next = [...formData.extra.warnings]; next[idx] = e.target.value;
@@ -179,10 +224,14 @@ export function LocationFormSettingsFields({ formData, allTags, updateField }: L
                       updateField("extra", { ...formData.extra, warnings: next });
                     }
                   }}
-                  placeholder={t("admin.warningsPlaceholder")} className={cn("w-full px-3 py-2.5 rounded-xl text-sm outline-none transition-all duration-150 border bg-stone-50 dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder:text-stone-400 dark:placeholder:text-stone-500 border-stone-200 dark:border-stone-700 focus:ring-2 focus:ring-amber-200 focus:border-amber-400 flex-1")} />
-                <button type="button" onClick={() => updateField("extra", { ...formData.extra, warnings: formData.extra.warnings.filter((_, i) => i !== idx) })}
-                  className="w-8 h-8 flex items-center justify-center rounded-lg text-stone-400 hover:text-red-500 hover:bg-red-50 transition-colors shrink-0">
-                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
+                  placeholder={t("admin.warningsPlaceholder")} className={cn("w-full px-3 py-2 rounded-xl text-sm outline-none transition-all duration-150 border bg-white dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder:text-stone-400 dark:placeholder:text-stone-500 border-stone-200 dark:border-stone-700 focus:ring-2 focus:ring-amber-200 focus:border-amber-400 flex-1")} />
+                <button type="button" onClick={() => {
+                  const next = formData.extra.warnings.filter((_, i) => i !== idx);
+                  updateField("extra", { ...formData.extra, warnings: next });
+                  showToast("success", t("admin.deleteSuccessToast"));
+                }}
+                  className="w-7 h-7 flex items-center justify-center rounded-lg text-stone-400 hover:text-red-500 hover:bg-red-50 transition-colors shrink-0">
+                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
                 </button>
               </div>
             ))}
@@ -225,5 +274,13 @@ export function LocationFormSettingsFields({ formData, allTags, updateField }: L
       </SubSectionCard>
       </div>
     </SectionCard>
-  );
+    {toast && (
+      <div className="fixed bottom-5 left-1/2 z-[60] w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 animate-[slide-up-toast_0.25s_ease-out_both]">
+        <div className="flex items-center gap-2 rounded-lg border border-primary/20 bg-card px-4 py-3 text-sm font-medium shadow-warm">
+          <CheckCircle2 className="h-4 w-4 shrink-0 text-green-500" />
+          <span>{toast.message}</span>
+        </div>
+      </div>
+    )}
+  </>);
 }

--- a/frontend/src/components/features/location-form/location-form-settings-fields.tsx
+++ b/frontend/src/components/features/location-form/location-form-settings-fields.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Settings, Plus } from "lucide-react";
+import { Settings, Plus, ChevronDown } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import { cn } from "@/lib/utils";
 import type { FormData } from "./use-location-form";
@@ -39,6 +39,28 @@ interface FieldProps {
   label: string; required?: boolean; hint?: string; error?: string; children: React.ReactNode;
 }
 
+interface SubSectionCardProps {
+  title: string; children: React.ReactNode; defaultOpen?: boolean;
+}
+
+function SubSectionCard({ title, children, defaultOpen = false }: SubSectionCardProps) {
+  const [open, setOpen] = React.useState(defaultOpen);
+  return (
+    <div className="border border-stone-100 dark:border-stone-800 rounded-xl overflow-hidden">
+      <button type="button" onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center gap-2 px-4 py-3 text-left hover:bg-stone-50/60 dark:hover:bg-stone-800/60 transition-colors cursor-pointer">
+        <ChevronDown className={cn("h-3.5 w-3.5 text-stone-400 transition-transform duration-200", open && "rotate-0", !open && "-rotate-90")} />
+        <span className="text-xs font-semibold text-stone-700 dark:text-stone-300">{title}</span>
+      </button>
+      {open && (
+        <div className="px-4 pb-4 pt-2 border-t border-stone-50 dark:border-stone-800">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function Field({ label, required, hint, error, children }: FieldProps) {
   return (
     <div className="space-y-1.5">
@@ -49,6 +71,19 @@ function Field({ label, required, hint, error, children }: FieldProps) {
       {error && <p className="text-xs text-red-500">{error}</p>}
       {!error && hint && <p className="text-xs text-stone-400">{hint}</p>}
     </div>
+  );
+}
+
+interface AddButtonProps {
+  label: string; onAdd: () => void;
+}
+
+function AddButton({ label, onAdd }: AddButtonProps) {
+  return (
+    <button type="button" onClick={onAdd}
+      className="flex items-center gap-1.5 text-xs text-amber-600 hover:text-amber-700 transition-colors">
+      <Plus className="h-3.5 w-3.5" />{label}
+    </button>
   );
 }
 
@@ -69,95 +104,124 @@ export function LocationFormSettingsFields({ formData, allTags, updateField }: L
   return (
     <SectionCard icon={<Settings className="h-4 w-4" />} title={t("admin.formSettingsTitleRecommended")} collapsible defaultOpen={true}
       badge={<span className="text-[10px] text-stone-400 dark:text-stone-500 bg-stone-100 dark:bg-stone-800 px-2 py-0.5 rounded-full">{t("admin.optionalBadge")}</span>}>
-      {/* 配套设施 */}
-      <Field label={t("admin.formFacilitiesTitle")}>
-        <div className="flex flex-wrap gap-2">
-          {facilityOptions.map((f) => {
-            const selected = formData.extra.facilities.includes(f.value);
-            return (
-              <button key={f.value} type="button"
-                onClick={() => updateField("extra", { ...formData.extra, facilities: selected ? formData.extra.facilities.filter((v) => v !== f.value) : [...formData.extra.facilities, f.value] })}
-                className={cn("px-3 py-1.5 rounded-xl text-xs font-medium border transition-all",
-                  selected ? "bg-amber-500 text-white border-amber-500" : "bg-white dark:bg-stone-800 text-stone-600 dark:text-stone-400 border-stone-200 dark:border-stone-700 hover:border-amber-300")}>
-                {f.label}
-              </button>
-            );
-          })}
-        </div>
-      </Field>
-
-      {/* 徒步贴士 */}
-      <Field label={t("admin.formTipsTitle")}>
-        <div className="space-y-2">
-          {formData.extra.tips.map((tip, idx) => (
-            <div key={idx} className="flex items-center gap-2">
-              <input type="text" value={tip}
-                onChange={(e) => {
-                  const next = [...formData.extra.tips]; next[idx] = e.target.value;
-                  updateField("extra", { ...formData.extra, tips: next });
-                }}
-                placeholder={t("admin.tipsPlaceholder")} className={cn("w-full px-3 py-2.5 rounded-xl text-sm outline-none transition-all duration-150 border bg-stone-50 dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder:text-stone-400 dark:placeholder:text-stone-500 border-stone-200 dark:border-stone-700 focus:ring-2 focus:ring-amber-200 focus:border-amber-400 flex-1")} />
-              <button type="button" onClick={() => updateField("extra", { ...formData.extra, tips: formData.extra.tips.filter((_, i) => i !== idx) })}
-                className="w-8 h-8 flex items-center justify-center rounded-lg text-stone-400 hover:text-red-500 hover:bg-red-50 transition-colors shrink-0">
-                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
-              </button>
-            </div>
-          ))}
-          {formData.extra.tips.length < 10 && (
-            <button type="button" onClick={() => updateField("extra", { ...formData.extra, tips: [...formData.extra.tips, ""] })}
-              className="flex items-center gap-1.5 text-xs text-amber-600 hover:text-amber-700 transition-colors">
-              <Plus className="h-3.5 w-3.5" />{t("admin.formTipsAdd")}
-            </button>
-          )}
-        </div>
-      </Field>
-
-      {/* 安全警告 */}
-      <Field label={t("admin.formWarningsTitle")}>
-        <div className="space-y-2">
-          {formData.extra.warnings.map((w, idx) => (
-            <div key={idx} className="flex items-center gap-2">
-              <input type="text" value={w}
-                onChange={(e) => {
-                  const next = [...formData.extra.warnings]; next[idx] = e.target.value;
-                  updateField("extra", { ...formData.extra, warnings: next });
-                }}
-                placeholder={t("admin.warningsPlaceholder")} className={cn("w-full px-3 py-2.5 rounded-xl text-sm outline-none transition-all duration-150 border bg-stone-50 dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder:text-stone-400 dark:placeholder:text-stone-500 border-stone-200 dark:border-stone-700 focus:ring-2 focus:ring-amber-200 focus:border-amber-400 flex-1")} />
-              <button type="button" onClick={() => updateField("extra", { ...formData.extra, warnings: formData.extra.warnings.filter((_, i) => i !== idx) })}
-                className="w-8 h-8 flex items-center justify-center rounded-lg text-stone-400 hover:text-red-500 hover:bg-red-50 transition-colors shrink-0">
-                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
-              </button>
-            </div>
-          ))}
-          {formData.extra.warnings.length < 10 && (
-            <button type="button" onClick={() => updateField("extra", { ...formData.extra, warnings: [...formData.extra.warnings, ""] })}
-              className="flex items-center gap-1.5 text-xs text-amber-600 hover:text-amber-700 transition-colors">
-              <Plus className="h-3.5 w-3.5" />{t("admin.formWarningsAdd")}
-            </button>
-          )}
-        </div>
-      </Field>
-
-      {/* 关联标签 */}
-      <Field label={t("admin.formTagsTitle")} hint={t("admin.formTagsHint")}>
-        {allTags.length === 0 ? (
-          <p className="text-xs text-stone-400">{t("admin.noTagsAvailable")}</p>
-        ) : (
+      <div className="space-y-2">
+      <SubSectionCard title={t("admin.formFacilitiesTitle")} defaultOpen={true}>
+        <Field label={t("admin.formFacilitiesTitle")}>
           <div className="flex flex-wrap gap-2">
-            {allTags.map((tag) => {
-              const selected = formData.tagIds.includes(tag.id);
+            {facilityOptions.map((f) => {
+              const selected = formData.extra.facilities.includes(f.value);
               return (
-                <button key={tag.id} type="button"
-                  onClick={() => updateField("tagIds", selected ? formData.tagIds.filter((id) => id !== tag.id) : [...formData.tagIds, tag.id])}
-                  className={cn("px-3 py-1 rounded-full text-xs font-medium border transition-all",
-                    selected ? "bg-amber-500 text-white border-amber-500" : "bg-white text-stone-600 border-stone-200 hover:border-amber-300")}>
-                  {tag.name}
+                <button key={f.value} type="button"
+                  onClick={() => updateField("extra", { ...formData.extra, facilities: selected ? formData.extra.facilities.filter((v) => v !== f.value) : [...formData.extra.facilities, f.value] })}
+                  className={cn("px-3 py-1.5 rounded-xl text-xs font-medium border transition-all",
+                    selected ? "bg-amber-500 text-white border-amber-500" : "bg-white dark:bg-stone-800 text-stone-600 dark:text-stone-400 border-stone-200 dark:border-stone-700 hover:border-amber-300")}>
+                  {f.label}
                 </button>
               );
             })}
           </div>
-        )}
-      </Field>
+        </Field>
+      </SubSectionCard>
+
+      <SubSectionCard title={t("admin.formTipsSectionTitle")}>
+        {/* 徒步贴士 */}
+        <Field label={t("admin.formTipsTitle")}>
+          <div className="space-y-2">
+            {formData.extra.tips.map((tip, idx) => (
+              <div key={idx} className="flex items-center gap-2">
+                <input type="text" data-tip-input value={tip}
+                  onChange={(e) => {
+                    const next = [...formData.extra.tips]; next[idx] = e.target.value;
+                    updateField("extra", { ...formData.extra, tips: next });
+                  }}
+                  onBlur={() => {
+                    if (tip.trim() === "") {
+                      const next = formData.extra.tips.filter((_, i) => i !== idx);
+                      updateField("extra", { ...formData.extra, tips: next });
+                    }
+                  }}
+                  placeholder={t("admin.tipsPlaceholder")} className={cn("w-full px-3 py-2.5 rounded-xl text-sm outline-none transition-all duration-150 border bg-stone-50 dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder:text-stone-400 dark:placeholder:text-stone-500 border-stone-200 dark:border-stone-700 focus:ring-2 focus:ring-amber-200 focus:border-amber-400 flex-1")} />
+                <button type="button" onClick={() => updateField("extra", { ...formData.extra, tips: formData.extra.tips.filter((_, i) => i !== idx) })}
+                  className="w-8 h-8 flex items-center justify-center rounded-lg text-stone-400 hover:text-red-500 hover:bg-red-50 transition-colors shrink-0">
+                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
+                </button>
+              </div>
+            ))}
+            {formData.extra.tips.length < 10 && (
+              <AddButton label={t("admin.formTipsAdd")} onAdd={() => {
+                const next = [...formData.extra.tips, ""];
+                updateField("extra", { ...formData.extra, tips: next });
+                setTimeout(() => {
+                  const inputs = document.querySelectorAll<HTMLInputElement>('[data-tip-input]');
+                  const last = inputs[inputs.length - 1];
+                  last?.focus();
+                }, 0);
+              }} />
+            )}
+          </div>
+        </Field>
+
+        {/* 安全警告 */}
+        <Field label={t("admin.formWarningsTitle")}>
+          <div className="space-y-2">
+            {formData.extra.warnings.map((w, idx) => (
+              <div key={idx} className="flex items-center gap-2">
+                <input type="text" data-warning-input value={w}
+                  onChange={(e) => {
+                    const next = [...formData.extra.warnings]; next[idx] = e.target.value;
+                    updateField("extra", { ...formData.extra, warnings: next });
+                  }}
+                  onBlur={() => {
+                    if (w.trim() === "") {
+                      const next = formData.extra.warnings.filter((_, i) => i !== idx);
+                      updateField("extra", { ...formData.extra, warnings: next });
+                    }
+                  }}
+                  placeholder={t("admin.warningsPlaceholder")} className={cn("w-full px-3 py-2.5 rounded-xl text-sm outline-none transition-all duration-150 border bg-stone-50 dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder:text-stone-400 dark:placeholder:text-stone-500 border-stone-200 dark:border-stone-700 focus:ring-2 focus:ring-amber-200 focus:border-amber-400 flex-1")} />
+                <button type="button" onClick={() => updateField("extra", { ...formData.extra, warnings: formData.extra.warnings.filter((_, i) => i !== idx) })}
+                  className="w-8 h-8 flex items-center justify-center rounded-lg text-stone-400 hover:text-red-500 hover:bg-red-50 transition-colors shrink-0">
+                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
+                </button>
+              </div>
+            ))}
+            {formData.extra.warnings.length < 10 && (
+              <AddButton label={t("admin.formWarningsAdd")} onAdd={() => {
+                const next = [...formData.extra.warnings, ""];
+                updateField("extra", { ...formData.extra, warnings: next });
+                setTimeout(() => {
+                  const inputs = document.querySelectorAll<HTMLInputElement>('[data-warning-input]');
+                  const last = inputs[inputs.length - 1];
+                  last?.focus();
+                }, 0);
+              }} />
+            )}
+          </div>
+        </Field>
+      </SubSectionCard>
+
+      <SubSectionCard title={t("admin.formTagsTitle")}>
+        {/* 关联标签 */}
+        <Field label={t("admin.formTagsTitle")} hint={t("admin.formTagsHint")}>
+          {allTags.length === 0 ? (
+            <p className="text-xs text-stone-400">{t("admin.noTagsAvailable")}</p>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {allTags.map((tag) => {
+                const selected = formData.tagIds.includes(tag.id);
+                return (
+                  <button key={tag.id} type="button"
+                    onClick={() => updateField("tagIds", selected ? formData.tagIds.filter((id) => id !== tag.id) : [...formData.tagIds, tag.id])}
+                    className={cn("px-3 py-1 rounded-full text-xs font-medium border transition-all",
+                      selected ? "bg-amber-500 text-white border-amber-500" : "bg-white text-stone-600 border-stone-200 hover:border-amber-300")}>
+                    {tag.name}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </Field>
+      </SubSectionCard>
+      </div>
     </SectionCard>
   );
 }

--- a/frontend/src/components/features/location-form/location-form-settings-fields.tsx
+++ b/frontend/src/components/features/location-form/location-form-settings-fields.tsx
@@ -64,9 +64,11 @@ function SubSectionCard({ title, children, defaultOpen = false }: SubSectionCard
 function Field({ label, required, hint, error, children }: FieldProps) {
   return (
     <div className="space-y-1.5">
-      <label className="block text-xs font-semibold text-stone-700 dark:text-stone-300">
-        {label}{required && <span className="ml-1 text-red-400">*</span>}
-      </label>
+      {label && (
+        <label className="block text-xs font-semibold text-stone-700 dark:text-stone-300">
+          {label}{required && <span className="ml-1 text-red-400">*</span>}
+        </label>
+      )}
       {children}
       {error && <p className="text-xs text-red-500">{error}</p>}
       {!error && hint && <p className="text-xs text-stone-400">{hint}</p>}
@@ -106,7 +108,7 @@ export function LocationFormSettingsFields({ formData, allTags, updateField }: L
       badge={<span className="text-[10px] text-stone-400 dark:text-stone-500 bg-stone-100 dark:bg-stone-800 px-2 py-0.5 rounded-full">{t("admin.optionalBadge")}</span>}>
       <div className="space-y-2">
       <SubSectionCard title={t("admin.formFacilitiesTitle")} defaultOpen={true}>
-        <Field label={t("admin.formFacilitiesTitle")}>
+        <Field label="" hint="">{/* label 在 SubSectionCard title 中 */}
           <div className="flex flex-wrap gap-2">
             {facilityOptions.map((f) => {
               const selected = formData.extra.facilities.includes(f.value);
@@ -125,7 +127,7 @@ export function LocationFormSettingsFields({ formData, allTags, updateField }: L
 
       <SubSectionCard title={t("admin.formTipsSectionTitle")}>
         {/* 徒步贴士 */}
-        <Field label={t("admin.formTipsTitle")}>
+        <Field label="" hint="">{/* label 在 SubSectionCard title 中 */}
           <div className="space-y-2">
             {formData.extra.tips.map((tip, idx) => (
               <div key={idx} className="flex items-center gap-2">
@@ -201,7 +203,7 @@ export function LocationFormSettingsFields({ formData, allTags, updateField }: L
 
       <SubSectionCard title={t("admin.formTagsTitle")}>
         {/* 关联标签 */}
-        <Field label={t("admin.formTagsTitle")} hint={t("admin.formTagsHint")}>
+        <Field label="" hint={t("admin.formTagsHint")}>
           {allTags.length === 0 ? (
             <p className="text-xs text-stone-400">{t("admin.noTagsAvailable")}</p>
           ) : (

--- a/frontend/src/components/features/location-form/location-form-settings-fields.tsx
+++ b/frontend/src/components/features/location-form/location-form-settings-fields.tsx
@@ -67,7 +67,7 @@ export function LocationFormSettingsFields({ formData, allTags, updateField }: L
   const { t } = useI18n(["admin"]);
   const facilityOptions = FACILITY_OPTIONS(t);
   return (
-    <SectionCard icon={<Settings className="h-4 w-4" />} title={t("admin.formSettingsTitle")} collapsible defaultOpen={false}
+    <SectionCard icon={<Settings className="h-4 w-4" />} title={t("admin.formSettingsTitleRecommended")} collapsible defaultOpen={true}
       badge={<span className="text-[10px] text-stone-400 dark:text-stone-500 bg-stone-100 dark:bg-stone-800 px-2 py-0.5 rounded-full">{t("admin.optionalBadge")}</span>}>
       {/* 配套设施 */}
       <Field label={t("admin.formFacilitiesTitle")}>

--- a/frontend/src/components/features/location-form/location-form-settings-fields.tsx
+++ b/frontend/src/components/features/location-form/location-form-settings-fields.tsx
@@ -204,7 +204,7 @@ export function LocationFormSettingsFields({ formData, allTags, updateField }: L
         </Field>
 
         {/* 安全警告 */}
-        <Field label={t("admin.formWarningsTitle")}>
+        <Field label="" hint="">{/* label 在 SubSectionCard title 中 */}
           <div className="space-y-2">
             {formData.extra.warnings.map((w, idx) => (
               <div key={idx} draggable


### PR DESCRIPTION
## Tasks #1 + #2 + #3: 高级设置 UI 改造

### #1 - 默认展开 + 标题优化（P0）
- `defaultOpen={false}` → `defaultOpen={true}`
- 标题 key 改为 `formSettingsTitleRecommended`

### #2 - 子区块 accordion 分组 + 空条目自动清理（P1）
- 新增 `SubSectionCard` 组件
- 三个子区块：配套设施（展开）、贴士与警告（折叠）、关联标签（折叠）
- 空 tip/warning onBlur 自动删除，添加自动聚焦

### #3 - 拖拽排序 + hover 态优化 + 删除 toast（P2）
- HTML5 Drag API 拖拽排序（GripVertical 手柄）
- 配套设施未选中态 hover 增加背景色
- 删除 tip/warning 时 toast 反馈
- 新增 i18n key `deleteSuccessToast`（三语言）

### 验证
- `npm run build`: ✅ 构建成功

@Martin 请 CR