### PR TITLE
feat(api): PUT /stories/:id 支持 tags 更新（任务 #81）

### DIFF
--- a/api/src/lib/validation.ts
+++ b/api/src/lib/validation.ts
@@ -65,6 +65,7 @@ export const createStorySchema = z.object({
 export const updateStorySchema = createStorySchema.partial().extend({
   id: z.string().min(1, "故事ID不能为空"),
   status: z.enum(["draft", "published", "hidden"], { message: "状态必须是 draft、published 或 hidden" }).optional(),
+  tags: z.array(z.string()).max(10, "最多10个标签").optional(),
 });
 
 /**

--- a/api/src/routes/stories.ts
+++ b/api/src/routes/stories.ts
@@ -491,46 +491,49 @@ stories.put("/:id", async (c) => {
 
     await db.update(schema.stories).set(updateData).where(eq(schema.stories.id, id));
 
-    // 如果传了 tags，更新标签关联
+    // 如果传了 tags，在事务内更新标签关联
     if (data.tags !== undefined) {
-      // 先删除旧关联
-      await db
-        .delete(schema.entityToTags)
-        .where(
-          and(
-            eq(schema.entityToTags.entityId, id),
-            eq(schema.entityToTags.entityType, "story")
-          )
-        );
+      const newTags = data.tags;
+      await db.transaction(async (tx) => {
+        // 先删除旧关联
+        await tx
+          .delete(schema.entityToTags)
+          .where(
+            and(
+              eq(schema.entityToTags.entityId, id),
+              eq(schema.entityToTags.entityType, "story")
+            )
+          );
 
-      // 插入新关联（空数组则清除所有）
-      if (data.tags.length > 0) {
-        const tagEntries: (typeof schema.entityToTags.$inferInsert)[] = [];
-        for (const tagName of data.tags) {
-          let tag = await db.query.tags.findFirst({
-            where: eq(schema.tags.name, tagName),
-          });
-          if (!tag) {
-            const tagId = generateId();
-            await db.insert(schema.tags).values({
-              id: tagId,
-              name: tagName,
-              type: "activity",
-              createdAt: new Date(),
+        // 插入新关联（空数组则清除所有）
+        if (newTags.length > 0) {
+          const tagEntries: (typeof schema.entityToTags.$inferInsert)[] = [];
+          for (const tagName of newTags) {
+            let tag = await tx.query.tags.findFirst({
+              where: eq(schema.tags.name, tagName),
             });
-            tag = { id: tagId, name: tagName, type: "activity", createdAt: new Date() };
+            if (!tag) {
+              const tagId = generateId();
+              await tx.insert(schema.tags).values({
+                id: tagId,
+                name: tagName,
+                type: "activity",
+                createdAt: new Date(),
+              });
+              tag = { id: tagId, name: tagName, type: "activity", createdAt: new Date() };
+            }
+            tagEntries.push({
+              id: generateId(),
+              entityId: id,
+              entityType: "story",
+              tagId: tag.id,
+            });
           }
-          tagEntries.push({
-            id: generateId(),
-            entityId: id,
-            entityType: "story",
-            tagId: tag.id,
-          });
+          if (tagEntries.length > 0) {
+            await tx.insert(schema.entityToTags).values(tagEntries);
+          }
         }
-        if (tagEntries.length > 0) {
-          await db.insert(schema.entityToTags).values(tagEntries);
-        }
-      }
+      });
     }
 
     return c.json({

--- a/api/src/routes/stories.ts
+++ b/api/src/routes/stories.ts
@@ -491,6 +491,48 @@ stories.put("/:id", async (c) => {
 
     await db.update(schema.stories).set(updateData).where(eq(schema.stories.id, id));
 
+    // 如果传了 tags，更新标签关联
+    if (data.tags !== undefined) {
+      // 先删除旧关联
+      await db
+        .delete(schema.entityToTags)
+        .where(
+          and(
+            eq(schema.entityToTags.entityId, id),
+            eq(schema.entityToTags.entityType, "story")
+          )
+        );
+
+      // 插入新关联（空数组则清除所有）
+      if (data.tags.length > 0) {
+        const tagEntries: (typeof schema.entityToTags.$inferInsert)[] = [];
+        for (const tagName of data.tags) {
+          let tag = await db.query.tags.findFirst({
+            where: eq(schema.tags.name, tagName),
+          });
+          if (!tag) {
+            const tagId = generateId();
+            await db.insert(schema.tags).values({
+              id: tagId,
+              name: tagName,
+              type: "activity",
+              createdAt: new Date(),
+            });
+            tag = { id: tagId, name: tagName, type: "activity", createdAt: new Date() };
+          }
+          tagEntries.push({
+            id: generateId(),
+            entityId: id,
+            entityType: "story",
+            tagId: tag.id,
+          });
+        }
+        if (tagEntries.length > 0) {
+          await db.insert(schema.entityToTags).values(tagEntries);
+        }
+      }
+    }
+
     return c.json({
       success: true,
       message: "更新成功",


### PR DESCRIPTION
## 任务 #81：故事编辑 - 后端 tags 更新

### 改动（2 文件）
- **validation.ts**: updateStorySchema 增加 `tags: z.array(z.string()).max(10).optional()`
- **stories.ts PUT /:id handler**:
  · 传 tags → 删除旧关联 + 插入新关联
  · 空 tags → 清除所有关联
  · 不传 tags → 不改变（向后兼容）
  · 新 tag 名称自动创建

### 本地验证
- `pnpm --filter @gomate/api build` → 通过
- `pnpm --filter @gomate/api lint` → 0 错误
- `pnpm --filter @gomate/api test` → 178 全过
