### PR TITLE
fix(discover): 移除重复的「发布故事」按钮（任务 #83）

### DIFF
--- a/frontend/src/components/features/discover/discover-main.tsx
+++ b/frontend/src/components/features/discover/discover-main.tsx
@@ -293,14 +293,6 @@ export function DiscoverMain() {
               </p>
             </div>
 
-            {/* Right: Publish Button */}
-            <button
-              className="flex w-full sm:w-auto items-center justify-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors text-sm font-medium"
-              onClick={() => window.location.href = "/discover/create"}
-            >
-              <Plus className="h-4 w-4" />
-              {t("content.discover.publish")}
-            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 任务 #83

移除 header 中重复的「发布故事」按钮（sidebar 已有该功能）。

验证：frontend build 通过
