### PR TITLE
fix(story): 编辑页标签 API URL 改为 fetchAPI（任务 #84）

### DIFF
--- a/frontend/src/components/features/discover/use-story-form.ts
+++ b/frontend/src/components/features/discover/use-story-form.ts
@@ -123,7 +123,7 @@ export function useStoryForm(storyId: string): UseStoryFormReturn {
         const [user, storyRes, tagsRes] = await Promise.all([
           fetchCurrentUser().catch(() => null),
           fetchAPI(`/stories/${storyId}`).then((r: Response) => r.ok ? r.json() : { success: false }).catch(() => ({ success: false })),
-          fetch("/api/stories/tags").then((r) => r.json()).catch(() => ({ tags: [] })),
+          fetchAPI("/stories/tags").then((r) => r.json()).catch(() => ({ tags: [] })),
         ]);
 
         if (cancelled) return;


### PR DESCRIPTION
## 任务 #84 P0

### Bug
`fetch("/api/stories/tags")` 使用相对路径 → 404 → allTags 永远为空

### 修复
`fetchAPI("/stories/tags")`，自动拼接 API_BASE

### 验证
- frontend build → 通过
- diff: +1 -1
