### PR TITLE
feat(story): 分享 options sheet + 复制 toast 微调（任务 #85）

### DIFF
--- a/frontend/src/components/features/discover/share-story-sheet.tsx
+++ b/frontend/src/components/features/discover/share-story-sheet.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { Link2, Share2, X } from "lucide-react";
+import { useI18n } from "@/hooks/useI18n";
 
 interface ShareStorySheetProps {
   open: boolean;
@@ -11,7 +12,23 @@ interface ShareStorySheetProps {
 }
 
 export function ShareStorySheet({ open, onClose, title, onCopyLink }: ShareStorySheetProps) {
+  const { t } = useI18n(["common", "teams"]);
+
   if (!open) return null;
+
+  const handleCopyLink = () => {
+    onCopyLink();
+    onClose();
+  };
+
+  const handleSystemShare = async () => {
+    try {
+      await navigator.share({ title, url: window.location.href });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+    }
+    onClose();
+  };
 
   return (
     <>
@@ -19,19 +36,19 @@ export function ShareStorySheet({ open, onClose, title, onCopyLink }: ShareStory
       <div className="fixed bottom-0 left-0 right-0 bg-background z-50 rounded-t-2xl" style={{ paddingBottom: "env(safe-area-inset-bottom)", animation: "slideUp 0.2s ease" }}>
         <div className="p-4 space-y-3">
           <div className="flex items-center justify-between mb-2">
-            <span className="text-sm font-medium text-muted-foreground">分享故事</span>
+            <span className="text-sm font-medium text-muted-foreground">{t("teams.shareOptions")}</span>
             <button onClick={onClose} className="p-1 hover:bg-muted rounded-full transition-colors"><X className="w-4 h-4 text-muted-foreground" /></button>
           </div>
           <p className="text-sm font-medium text-foreground truncate">{title}</p>
 
           <div className="grid grid-cols-4 gap-4 py-4">
-            <button onClick={onCopyLink} className="flex flex-col items-center gap-2">
+            <button onClick={handleCopyLink} className="flex flex-col items-center gap-2">
               <div className="w-12 h-12 rounded-full bg-amber-100 flex items-center justify-center"><Link2 className="w-5 h-5 text-amber-600" /></div>
-              <span className="text-xs text-muted-foreground">复制链接</span>
+              <span className="text-xs text-muted-foreground">{t("teams.copyLink")}</span>
             </button>
-            <button onClick={() => { if (navigator.share) navigator.share({ title, url: window.location.href }); }} className="flex flex-col items-center gap-2">
+            <button onClick={handleSystemShare} className="flex flex-col items-center gap-2">
               <div className="w-12 h-12 rounded-full bg-blue-100 flex items-center justify-center"><Share2 className="w-5 h-5 text-blue-600" /></div>
-              <span className="text-xs text-muted-foreground">更多</span>
+              <span className="text-xs text-muted-foreground">{t("common.share")}</span>
             </button>
           </div>
         </div>

--- a/frontend/src/components/features/discover/share-story-sheet.tsx
+++ b/frontend/src/components/features/discover/share-story-sheet.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import * as React from "react";
+import { Link2, Share2, X } from "lucide-react";
+
+interface ShareStorySheetProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  onCopyLink: () => void;
+}
+
+export function ShareStorySheet({ open, onClose, title, onCopyLink }: ShareStorySheetProps) {
+  if (!open) return null;
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/40 z-50 transition-opacity" onClick={onClose} />
+      <div className="fixed bottom-0 left-0 right-0 bg-background z-50 rounded-t-2xl" style={{ paddingBottom: "env(safe-area-inset-bottom)", animation: "slideUp 0.2s ease" }}>
+        <div className="p-4 space-y-3">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-sm font-medium text-muted-foreground">分享故事</span>
+            <button onClick={onClose} className="p-1 hover:bg-muted rounded-full transition-colors"><X className="w-4 h-4 text-muted-foreground" /></button>
+          </div>
+          <p className="text-sm font-medium text-foreground truncate">{title}</p>
+
+          <div className="grid grid-cols-4 gap-4 py-4">
+            <button onClick={onCopyLink} className="flex flex-col items-center gap-2">
+              <div className="w-12 h-12 rounded-full bg-amber-100 flex items-center justify-center"><Link2 className="w-5 h-5 text-amber-600" /></div>
+              <span className="text-xs text-muted-foreground">复制链接</span>
+            </button>
+            <button onClick={() => { if (navigator.share) navigator.share({ title, url: window.location.href }); }} className="flex flex-col items-center gap-2">
+              <div className="w-12 h-12 rounded-full bg-blue-100 flex items-center justify-center"><Share2 className="w-5 h-5 text-blue-600" /></div>
+              <span className="text-xs text-muted-foreground">更多</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/features/discover/story-detail.tsx
+++ b/frontend/src/components/features/discover/story-detail.tsx
@@ -10,6 +10,7 @@ import { useToast } from "@/hooks/useToast";
 import { MarkdownContent } from "./markdown-content";
 import { StoryDetailSkeleton } from "./story-detail-skeleton";
 import { StoryToast } from "./story-detail-toast";
+import { ShareStorySheet } from "./share-story-sheet";
 import type { Story, StoryDetailProps, StoryDetailResponse } from "./story-detail-types";
 import {
   CONTENT_WIDTH,
@@ -44,6 +45,7 @@ export function StoryDetail({ storyId }: StoryDetailProps) {
   const [deleteConfirmOpen, setDeleteConfirmOpen] = React.useState(false);
   const [isDeleting, setIsDeleting] = React.useState(false);
   const [deleteError, setDeleteError] = React.useState("");
+  const [showShareSheet, setShowShareSheet] = React.useState(false);
 
   const loadStory = React.useCallback(async () => {
     try {
@@ -224,7 +226,7 @@ export function StoryDetail({ storyId }: StoryDetailProps) {
             )}
             <button
               type="button"
-              onClick={handleShare}
+              onClick={() => setShowShareSheet(true)}
               className="inline-flex min-h-10 items-center gap-2 rounded-lg border border-border bg-card px-3 text-sm font-medium text-muted-foreground shadow-sm transition-colors hover:border-primary/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               aria-label={t("content.discover.share")}
             >
@@ -293,6 +295,13 @@ export function StoryDetail({ storyId }: StoryDetailProps) {
           t={t}
         />
       )}
+
+      <ShareStorySheet
+        open={showShareSheet}
+        onClose={() => setShowShareSheet(false)}
+        title={story?.title || ""}
+        onCopyLink={copyCurrentUrl}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 任务 #85

### 改动
- share-story-sheet.tsx：底部 sheet（复制链接 + 系统分享按钮）
- story-detail.tsx：共享按钮改为打开 sheet
- i18n linkCopied 文案改为「链接已复制，快去分享给朋友吧！」（中英日）

### 验证
- frontend build → 通过
