### PR TITLE
feat(story): OG 标签 + Twitter Card（任务 #86）

### DIFF
--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -195,6 +195,12 @@ function getHreflangUrl(loc: Locale) {
     {ogImage && <meta property="og:image:width" content="1200" />}
     {ogImage && <meta property="og:image:height" content="630" />}
 
+    {/* Twitter Card meta tags */}
+    <meta name="twitter:card" content={ogImage ? "summary_large_image" : "summary"} />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    {ogImage && <meta name="twitter:image" content={ogImage} />}
+
     {/* ═══════════════════════════════════════════════════════════════
        Phase 3 Task 2: Critical CSS 内联优化
 


### PR DESCRIPTION
## 任务 #86

### 改动
- Layout.astro 添加 Twitter Card meta 标签
  - twitter:card（带图 → summary_large_image，无图 → summary）
  - twitter:title / twitter:description / twitter:image
- OG 标签在 Layout.astro 中已完整（og:title/description/image/url/type）
- Story detail SSR 注水数据（title/summary/coverImage）通过 API_BASE fetch 获取

### 验证
- frontend build → 通过
