### PR TITLE
feat(story): 海报生成（任务 #87）

### DIFF
--- a/api/src/routes/share-image.ts
+++ b/api/src/routes/share-image.ts
@@ -1,7 +1,7 @@
 import { APIErrors } from "../lib/api-errors";
 import { Hono } from "hono";
 import type { Env } from "../lib/auth";
-import { generatePreviewImage, generateLocationImage, generateTeamImage } from "../services/share-image/generate-share-image";
+import { generatePreviewImage, generateLocationImage, generateTeamImage, generateStoryImage } from "../services/share-image/generate-share-image";
 
 const shareImageRoute = new Hono<{ Bindings: Env }>();
 
@@ -124,6 +124,55 @@ shareImageRoute.get("/team/:teamId", async (c) => {
     const errorMessage = error instanceof Error ? error.message : String(error);
     return c.json(
       { error: "Failed to generate team image", details: errorMessage },
+      500
+    );
+  }
+});
+
+/**
+ * Phase 5: 故事分享图片
+ * GET /share-image/story/:storyId
+ */
+shareImageRoute.get("/story/:storyId", async (c) => {
+  try {
+    const storyId = c.req.param("storyId");
+    const download = c.req.query("download") === "1";
+    const refresh = c.req.query("refresh") === "1";
+
+    if (!storyId) {
+      return c.json(APIErrors.badRequest("Story ID is required"), 400);
+    }
+
+    if (refresh && c.env.R2) {
+      try {
+        const prefix = `share/story/${storyId}-`;
+        const list = await c.env.R2.list({ prefix });
+        for (const object of list.objects) {
+          await c.env.R2.delete(object.key);
+        }
+      } catch (e) {
+        console.error("[ShareImage] Cache clear failed:", e);
+      }
+    }
+
+    const { png, cacheKey } = await generateStoryImage(c.env, storyId);
+
+    const headers: Record<string, string> = {
+      "Content-Type": "image/png",
+      "Cache-Control": "public, max-age=86400",
+      "X-Cache-Key": cacheKey,
+    };
+
+    if (download) {
+      headers["Content-Disposition"] = `attachment; filename="story-${storyId}.png"`;
+    }
+
+    return new Response(png, { headers });
+  } catch (error) {
+    console.error("[ShareImage] Story image generation failed:", error);
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return c.json(
+      { error: "Failed to generate story image", details: errorMessage },
       500
     );
   }

--- a/api/src/routes/share-image.ts
+++ b/api/src/routes/share-image.ts
@@ -171,6 +171,9 @@ shareImageRoute.get("/story/:storyId", async (c) => {
   } catch (error) {
     console.error("[ShareImage] Story image generation failed:", error);
     const errorMessage = error instanceof Error ? error.message : String(error);
+    if (errorMessage === "Story not published" || errorMessage.includes("not found")) {
+      return c.json({ error: errorMessage, details: errorMessage }, 404);
+    }
     return c.json(
       { error: "Failed to generate story image", details: errorMessage },
       500

--- a/api/src/services/share-image/generate-share-image.ts
+++ b/api/src/services/share-image/generate-share-image.ts
@@ -6,6 +6,7 @@ import { loadFonts } from "./load-fonts";
 import { renderTestTemplate } from "../../templates/share-image/test-poster";
 import { renderLocationPoster } from "../../templates/share-image/location-poster";
 import { renderTeamPoster } from "../../templates/share-image/team-poster";
+import { renderStoryPoster } from "../../templates/share-image/story-poster";
 import { createDb } from "../../db";
 import * as schema from "../../db/schema";
 import { eq, and, sql } from "drizzle-orm";
@@ -444,6 +445,86 @@ function formatTeamDate(timestamp: number | Date): string {
   const weekday = weekdays[date.getDay()];
 
   return `${month}${day}日 ${weekday}`;
+}
+
+/**
+ * Phase 5: 生成故事分享图片
+ * 查询故事数据，生成分享海报
+ */
+export async function generateStoryImage(
+  env: Env,
+  storyId: string
+): Promise<{ png: Uint8Array; cacheKey: string }> {
+  const db = createDb(env.DB);
+
+  // 1. 查询故事数据
+  const story = await db.query.stories.findFirst({
+    where: eq(schema.stories.id, storyId),
+    with: { author: true, location: true },
+  });
+
+  if (!story || story.status !== "published") {
+    throw new Error(story ? "Story not published" : `Story not found: ${storyId}`);
+  }
+
+  // 2. 生成内容哈希
+  const contentData = {
+    title: story.title, summary: story.summary, coverImage: story.coverImage,
+    authorId: story.authorId, locationId: story.locationId, updatedAt: story.updatedAt,
+  };
+  const contentHash = (await generateMD5(JSON.stringify(contentData))).slice(0, 12);
+  const cacheKey = `share/story/${storyId}-${contentHash}.png`;
+
+  // 3. 检查 R2 缓存
+  if (env.R2) {
+    try {
+      const cached = await env.R2.get(cacheKey);
+      if (cached) {
+        const png = new Uint8Array(await cached.arrayBuffer());
+        return { png, cacheKey };
+      }
+    } catch (e) { console.error("[ShareImage] Cache check failed:", e); }
+  }
+
+  // 4. 初始化 WASM + 加载字体
+  await initResvgWasm();
+  const fonts = await loadFonts(env);
+
+  // 5. 并行加载图片
+  const [coverImageBase64, authorAvatarBase64] = await Promise.all([
+    story.coverImage ? loadImageAsBase64(story.coverImage, env, 3000) : Promise.resolve(null),
+    story.author?.image ? loadImageAsBase64(story.author.image, env, 3000) : Promise.resolve(null),
+  ]);
+
+  // 6. 生成二维码
+  const storyUrl = `https://gomate.live/discover/${storyId}`;
+  const qrCodeDataUrl = await generateQRCode(storyUrl);
+
+  // 7. 渲染 SVG
+  const svg = await renderStoryPoster({
+    title: story.title,
+    summary: story.summary,
+    coverImage: coverImageBase64 ?? undefined,
+    authorName: (story.author?.name || story.author?.nickname) ?? undefined,
+    authorAvatar: authorAvatarBase64 ?? undefined,
+    locationName: story.location?.name ?? undefined,
+    qrCodeDataUrl,
+    fonts,
+  });
+
+  // 8. SVG 转 PNG
+  const png = await renderSvgToPng(svg);
+
+  // 9. 保存到 R2
+  if (env.R2) {
+    try {
+      await env.R2.put(cacheKey, png, {
+        httpMetadata: { contentType: "image/png", cacheControl: "public, max-age=86400" },
+      });
+    } catch (e) { console.error("[ShareImage] Cache save failed:", e); }
+  }
+
+  return { png, cacheKey };
 }
 
 /**

--- a/api/src/templates/share-image/story-poster.tsx
+++ b/api/src/templates/share-image/story-poster.tsx
@@ -1,0 +1,61 @@
+import satori from "satori";
+
+interface StoryPosterData {
+  title: string;
+  summary: string;
+  coverImage?: string | null;
+  authorName?: string;
+  authorAvatar?: string | null;
+  locationName?: string;
+  qrCodeDataUrl?: string | null;
+  fonts: Array<{ name: string; data: ArrayBuffer; weight: number; style: string }>;
+}
+
+export async function renderStoryPoster(data: StoryPosterData): Promise<string> {
+  const { title, summary, coverImage, authorName, authorAvatar, locationName, qrCodeDataUrl, fonts } = data;
+  const fontFamily = fonts.length > 0 ? fonts[0].name : "system-ui";
+  const cleanSummary = summary.length > 100 ? summary.slice(0, 97) + "..." : summary;
+
+  const coverImageElement = coverImage ? {
+    type: "div", props: {
+      style: { display: "flex", marginHorizontal: 16, marginTop: 16, borderRadius: 12, overflow: "hidden" },
+      children: { type: "img", props: { src: coverImage, style: { display: "flex", width: 343, height: 180, objectFit: "cover" } } },
+    },
+  } : null;
+
+  const svg = await satori(
+    // @ts-expect-error
+    {
+      type: "div",
+      props: {
+        style: { display: "flex", flexDirection: "column", width: 375, backgroundColor: "#faf8f5", fontFamily },
+        children: [
+          ...(coverImageElement ? [coverImageElement] : []),
+          {
+            type: "div", props: {
+              style: { display: "flex", flexDirection: "column", margin: 16, padding: 20, backgroundColor: "rgba(255,255,255,0.85)", border: "1px solid #e8e0d7", borderRadius: 12 },
+              children: [
+                { type: "h1", props: { style: { fontSize: 18, lineHeight: "28px", fontWeight: 700, color: "#1e1812", marginBottom: 8 }, children: title } },
+                { type: "p", props: { style: { fontSize: 13, lineHeight: "20px", color: "#6b5e53", marginBottom: 12 }, children: cleanSummary } },
+                { type: "div", props: { style: { display: "flex", alignItems: "center", gap: 8, marginBottom: locationName ? 8 : 0 }, children: [
+                  authorAvatar ? { type: "img", props: { src: authorAvatar, style: { width: 24, height: 24, borderRadius: 12 } } } :
+                  { type: "div", props: { style: { width: 24, height: 24, borderRadius: 12, backgroundColor: "#D97706", display: "flex", alignItems: "center", justifyContent: "center" }, children: { type: "span", props: { style: { fontSize: 10, color: "white" } }, children: authorName?.[0] || "?" } } },
+                  { type: "span", props: { style: { fontSize: 12, color: "#1e1812", fontWeight: 500 }, children: authorName || "匿名" } },
+                ] } },
+                locationName ? { type: "div", props: { style: { display: "flex", gap: 4, marginBottom: 8 }, children: [
+                  { type: "span", props: { style: { fontSize: 11, color: "#D97706" } }, children: "📍" },
+                  { type: "span", props: { style: { fontSize: 11, color: "#6b5e53" } }, children: locationName },
+                ] } } : null,
+                qrCodeDataUrl ? { type: "img", props: { src: qrCodeDataUrl, style: { width: 64, height: 64, marginTop: 8, alignSelf: "center" } } } : null,
+              ].filter(Boolean),
+            },
+          },
+          { type: "div", props: { style: { display: "flex", justifyContent: "center", padding: 8, fontSize: 10, color: "#6b5e53" }, children: "GoMate - 发现趣处，组队同行" } },
+        ].filter(Boolean),
+      },
+    },
+    { width: 375, fonts }
+  );
+
+  return svg;
+}

--- a/api/src/templates/share-image/story-poster.tsx
+++ b/api/src/templates/share-image/story-poster.tsx
@@ -24,7 +24,7 @@ export async function renderStoryPoster(data: StoryPosterData): Promise<string> 
   } : null;
 
   const svg = await satori(
-    // @ts-expect-error
+    // @ts-expect-error - Satori accepts plain object format
     {
       type: "div",
       props: {


### PR DESCRIPTION
## 任务 #87：故事分享 P2 - 海报生成

### 后端（+200 行）
- **story-poster.tsx**：海报模板（封面 + 标题 + 摘要 + 作者头像/昵称 + 关联地点 + QR 码）
- **generateStoryImage**：复用分享图片基础设施（R2 缓存、resvg-wasm、QR 码、封面图/头像加载）
- **GET /share-image/story/:storyId**：支持 ?download 和 ?refresh 参数
- 草稿/隐藏状态返回 404

### 前端
- share-story-sheet.tsx 新增「生成海报」按钮

### 验证
- api build → 通过
- api test → 178 全过
- frontend build → 通过
