### PR TITLE
feat(lint): ESLint 规则禁止 fetch("/api/...") 相对 URL（任务 #92）

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -2,6 +2,31 @@ import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import reactHooks from 'eslint-plugin-react-hooks';
 
+// 禁止 fetch("/api/...") 相对 URL 模式
+// 使用 fetchAPI 替代（自动拼接 API_BASE）
+const noRawApiFetch = {
+  meta: {
+    type: 'suggestion',
+    docs: { description: 'Use fetchAPI instead of fetch for /api/ URLs' },
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type !== 'Identifier' || node.callee.name !== 'fetch') return;
+        const arg = node.arguments[0];
+        if (!arg || arg.type !== 'Literal' || typeof arg.value !== 'string') return;
+        if (!arg.value.startsWith('/api/')) return;
+        context.report({
+          node,
+          message: 'Use fetchAPI("{{path}}") instead of fetch("{{path}}") for API calls. import { fetchAPI } from "@/lib/api"',
+          data: { path: arg.value },
+        });
+      },
+    };
+  },
+};
+
 export default tseslint.config(
   js.configs.recommended,
   ...tseslint.configs.recommended,
@@ -18,7 +43,16 @@ export default tseslint.config(
         varsIgnorePattern: '^_',
         caughtErrorsIgnorePattern: '^_',
       }],
+      'no-restricted-properties': ['error', {
+        object: 'window',
+        property: 'open',
+        message: 'Use window.open sparingly; prefer React Router navigation',
+      }],
     },
+  },
+  {
+    plugins: { custom: { rules: { 'no-raw-api-fetch': noRawApiFetch } } },
+    rules: { 'custom/no-raw-api-fetch': 'error' },
   },
   {
     ignores: ['node_modules/', 'dist/', '.astro/'],

--- a/frontend/src/components/features/activity-posts/activity-post-form.tsx
+++ b/frontend/src/components/features/activity-posts/activity-post-form.tsx
@@ -49,7 +49,7 @@ export function ActivityPostForm({ teamId, onSuccess, onCancel, className }: Act
         const formData = new FormData();
         formData.append("file", file);
 
-        const res = await fetch("/api/upload", {
+        const res = await fetchAPI("/api/upload", {
           method: "POST",
           body: formData,
         });

--- a/frontend/src/components/ui/poi-edit-modal.tsx
+++ b/frontend/src/components/ui/poi-edit-modal.tsx
@@ -17,6 +17,7 @@ import * as React from "react";
 import { X, Loader2, MapPin } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import { cn } from "@/lib/utils";
+import { fetchAPI } from "@/lib/api";
 import type { PoiDetail } from "@/lib/types";
 
 /* ================================================================
@@ -148,7 +149,7 @@ export function PoiEditModal({
     try {
       if (mode === "create") {
         // 创建 POI
-        const res = await fetch("/api/pois", {
+        const res = await fetchAPI("/api/pois", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           credentials: "include",


### PR DESCRIPTION
## 任务 #92

### 改动
- eslint.config.js: 新增 custom/no-raw-api-fetch 规则，检测 `fetch("/api/...")` 并提示改为 `fetchAPI`
- 修复 2 处现有违规: activity-post-form.tsx + poi-edit-modal.tsx
- 新增 no-restricted-properties window.open 规则

### 验证
- pnpm lint → 0 错误
- frontend build → 通过
