### PR TITLE
fix: cleanup unused imports and dead code (#96 #97)

### DIFF
--- a/frontend/src/components/features/share-poster-modal.tsx
+++ b/frontend/src/components/features/share-poster-modal.tsx
@@ -89,7 +89,7 @@ export function SharePosterModal({
     }
   }, [imageUrl, generateImage]);
 
-  // 关闭时清理
+  // imageUrl 变化时 revoke 旧的 blob URL，组件卸载时也 revoke
   useEffect(() => {
     return () => {
       if (imageUrl) {

--- a/frontend/src/components/shared/route-preloader.tsx
+++ b/frontend/src/components/shared/route-preloader.tsx
@@ -23,13 +23,6 @@ const CRITICAL_ROUTES = [
   "/register",
 ];
 
-// 用户可能访问的次关键路由
-const _SECONDARY_ROUTES = [
-  "/about",
-  "/help",
-  "/contact",
-];
-
 /**
  * 创建预加载链接
  * @param href - 目标路由
@@ -46,22 +39,6 @@ function prefetchRoute(href: string) {
   link.rel = "prefetch";
   link.href = href;
   link.as = "document";
-  document.head.appendChild(link);
-}
-
-/**
- * 创建 DNS 预解析
- * @param url - 预解析的域名
- */
-function _prefetchDNS(url: string) {
-  if (typeof window === "undefined") return;
-
-  const existingLink = document.querySelector(`link[rel="dns-prefetch"][href="${url}"]`);
-  if (existingLink) return;
-
-  const link = document.createElement("link");
-  link.rel = "dns-prefetch";
-  link.href = url;
   document.head.appendChild(link);
 }
 

--- a/frontend/src/components/ui/search-input.tsx
+++ b/frontend/src/components/ui/search-input.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { fetchAPI } from "@/lib/api";
 import { SearchResultItem, SearchSuggestions } from "./search";
 

--- a/frontend/src/components/ui/search.tsx
+++ b/frontend/src/components/ui/search.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 interface HighlightedTextProps {
   text: string;
   keyword: string;

--- a/frontend/src/components/ui/status-badge.tsx
+++ b/frontend/src/components/ui/status-badge.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { cn } from "@/lib/utils";
 import { useI18n } from "@/hooks/useI18n";
 

--- a/frontend/src/pages/blog/index.astro
+++ b/frontend/src/pages/blog/index.astro
@@ -3,7 +3,7 @@ import Layout from "@/layouts/Layout.astro";
 import { getCollection } from "astro:content";
 import { declareI18nNs } from "../../middleware";
 import { loadLocaleData } from "../../i18n/ssr-loader.server";
-import { getLocaleFromCookie, type Locale, DEFAULT_LOCALE, SUPPORTED_LOCALES } from "../../i18n";
+import { type Locale, DEFAULT_LOCALE, SUPPORTED_LOCALES } from "../../i18n";
 
 declareI18nNs(Astro.locals, ['blog', 'content']);
 


### PR DESCRIPTION
## Summary
Clean up unused imports and dead code from previous PRs.

## Changes

### #96 - Blob URL Memory Leak
- `share-poster-modal.tsx`: Clarify comment for blob URL cleanup (existing logic was already correct)

### #97 - Unused Imports/Variables
| File | Removed |
|------|---------|
| `blog/index.astro` | `getLocaleFromCookie` |
| `search-input.tsx` | `React` import |
| `search.tsx` | `React` import |
| `status-badge.tsx` | `* as React` import |
| `route-preloader.tsx` | `_SECONDARY_ROUTES` const, `_prefetchDNS` function |

## Verification
- [x] `pnpm build` passes
- [x] `pnpm test` passes (95/95)
- [x] No unused import warnings

Closes #96, #97