### PR TITLE
refactor(api): generateStoryImage returns null + content hash uses createdAt (#98 #99)

### DIFF
--- a/api/src/routes/share-image.ts
+++ b/api/src/routes/share-image.ts
@@ -155,7 +155,14 @@ shareImageRoute.get("/story/:storyId", async (c) => {
       }
     }
 
-    const { png, cacheKey } = await generateStoryImage(c.env, storyId);
+    const result = await generateStoryImage(c.env, storyId);
+
+    // 故事不存在或未发布 → 404
+    if (!result) {
+      return c.json(APIErrors.notFound("Story not found or not published"), 404);
+    }
+
+    const { png, cacheKey } = result;
 
     const headers: Record<string, string> = {
       "Content-Type": "image/png",
@@ -171,9 +178,6 @@ shareImageRoute.get("/story/:storyId", async (c) => {
   } catch (error) {
     console.error("[ShareImage] Story image generation failed:", error);
     const errorMessage = error instanceof Error ? error.message : String(error);
-    if (errorMessage === "Story not published" || errorMessage.includes("not found")) {
-      return c.json({ error: errorMessage, details: errorMessage }, 404);
-    }
     return c.json(
       { error: "Failed to generate story image", details: errorMessage },
       500

--- a/api/src/services/share-image/generate-share-image.ts
+++ b/api/src/services/share-image/generate-share-image.ts
@@ -450,11 +450,12 @@ function formatTeamDate(timestamp: number | Date): string {
 /**
  * Phase 5: 生成故事分享图片
  * 查询故事数据，生成分享海报
+ * @returns 图片数据，或 null（故事不存在/未发布）
  */
 export async function generateStoryImage(
   env: Env,
   storyId: string
-): Promise<{ png: Uint8Array; cacheKey: string }> {
+): Promise<{ png: Uint8Array; cacheKey: string } | null> {
   const db = createDb(env.DB);
 
   // 1. 查询故事数据
@@ -463,14 +464,16 @@ export async function generateStoryImage(
     with: { author: true, location: true },
   });
 
+  // 故事不存在或未发布 → 返回 null，由 route 层处理 404
   if (!story || story.status !== "published") {
-    throw new Error(story ? "Story not published" : `Story not found: ${storyId}`);
+    return null;
   }
 
-  // 2. 生成内容哈希
+  // 2. 生成内容哈希（用 createdAt 替代 updatedAt，更稳定）
   const contentData = {
     title: story.title, summary: story.summary, coverImage: story.coverImage,
-    authorId: story.authorId, locationId: story.locationId, updatedAt: story.updatedAt,
+    authorId: story.authorId, locationId: story.locationId,
+    createdAt: story.createdAt,  // 故事创建时间，比 updatedAt 稳定
   };
   const contentHash = (await generateMD5(JSON.stringify(contentData))).slice(0, 12);
   const cacheKey = `share/story/${storyId}-${contentHash}.png`;


### PR DESCRIPTION
## Summary
PR #242 follow-up: cleaner error handling + more stable cache key.

## Changes

### #98 - generateStoryImage returns null instead of throwing
**Before:**
```ts
if (!story || story.status !== "published") {
  throw new Error(story ? "Story not published" : `Story not found: ${storyId}`);
}
```

**After:**
```ts
if (!story || story.status !== "published") {
  return null;  // Route handles null → 404
}
```

Route now checks for null and returns 404 explicitly, removed string matching in catch block.

### #99 - Content hash uses createdAt instead of updatedAt
- `stories` table has no `publishedAt` field
- `createdAt` is more stable than `updatedAt` for caching (viewCount updates won't invalidate cache)

**Note:** Already-cached posters will be regenerated once (one-time cost).

## Verification
- [x] `pnpm build` passes (API)
- [x] `pnpm test` passes (178/178)
- [x] Route returns 404 for non-existent/unpublished stories
- [x] Content hash uses `createdAt`

Closes #98, #99