### PR TITLE
refactor(discover): remove sidebar + add TagFilterBar (#101 #102)

### DIFF
--- a/frontend/src/components/features/discover/discover-main.tsx
+++ b/frontend/src/components/features/discover/discover-main.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import * as React from "react";
-import { Compass, Loader2, Plus, MapPin, Tag, Flame, X } from "lucide-react";
+import { Compass, Loader2, Plus } from "lucide-react";
 import { apiGet } from "@/lib/api";
 import { StoryCard } from "./story-card";
 import { FeaturedStoryCard } from "./featured-story-card";
-import { SidebarSection } from "./sidebar-section";
+import { TagFilterBar } from "./tag-filter-bar";
 import { useI18n } from "@/hooks/useI18n";
 
 interface Story {
@@ -39,13 +39,6 @@ interface StoriesResponse {
   };
 }
 
-interface Location {
-  id: string;
-  name: string;
-  slug: string;
-  storyCount?: number;
-}
-
 interface Tag {
   id?: string;
   name: string;
@@ -53,29 +46,10 @@ interface Tag {
   count?: number;
 }
 
-interface LocationsResponse {
-  success: boolean;
-  locations?: Location[];
-  data?: Location[];
-}
-
 interface TagsResponse {
   success: boolean;
   tags?: Tag[];
   data?: Tag[];
-}
-
-interface StoriesStatsResponse {
-  success: boolean;
-  data: {
-    weeklyNewStories: number;
-    popularLocation: {
-      id: string;
-      name: string;
-      slug: string;
-      storyCount: number;
-    } | null;
-  };
 }
 
 export function DiscoverMain() {
@@ -89,12 +63,7 @@ export function DiscoverMain() {
 
   // 标签筛选状态 - 从 URL 读取
   const [selectedTag, setSelectedTag] = React.useState<string | null>(null);
-
-  // Sidebar data
-  const [locations, setLocations] = React.useState<Location[]>([]);
   const [tags, setTags] = React.useState<Tag[]>([]);
-  const [stats, setStats] = React.useState<StoriesStatsResponse["data"] | null>(null);
-  const [_statsLoading, _setStatsLoading] = React.useState(false);
 
   // Hydration safety - only start loading after mount
   const [mounted, setMounted] = React.useState(false);
@@ -149,42 +118,18 @@ export function DiscoverMain() {
     if (mounted) {
       setIsLoading(true);
       loadStories(1, false, selectedTag);
-      loadSidebarData();
+      loadTags();
     }
   }, [mounted, loadStories, selectedTag]);
 
-  const loadSidebarData = async () => {
-    const [locationsResult, tagsResult, statsResult] = await Promise.allSettled([
-      apiGet<LocationsResponse>("/locations?view=card&pageSize=5"),
-      apiGet<TagsResponse>("/stories/tags"),
-      apiGet<StoriesStatsResponse>("/stories/stats"),
-    ]);
-
-    if (locationsResult.status === "fulfilled" && locationsResult.value.success) {
-      setLocations(locationsResult.value.locations ?? locationsResult.value.data ?? []);
-    } else {
-      if (locationsResult.status === "rejected") {
-        console.error("Load locations error:", locationsResult.reason);
+  const loadTags = async () => {
+    try {
+      const result = await apiGet<TagsResponse>("/stories/tags");
+      if (result.success) {
+        setTags(result.tags ?? result.data ?? []);
       }
-      setLocations([]);
-    }
-
-    if (tagsResult.status === "fulfilled" && tagsResult.value.success) {
-      setTags(tagsResult.value.tags ?? tagsResult.value.data ?? []);
-    } else {
-      if (tagsResult.status === "rejected") {
-        console.error("Load tags error:", tagsResult.reason);
-      }
-      setTags([]);
-    }
-
-    if (statsResult.status === "fulfilled" && statsResult.value.success) {
-      setStats(statsResult.value.data);
-    } else {
-      if (statsResult.status === "rejected") {
-        console.error("Load stats error:", statsResult.reason);
-      }
-      setStats(null);
+    } catch (err) {
+      console.error("Load tags error:", err);
     }
   };
 
@@ -193,36 +138,22 @@ export function DiscoverMain() {
   };
 
   // 处理标签点击
-  const handleTagClick = (tagName: string) => {
-    const newTag = tagName === selectedTag ? null : tagName;
-    setSelectedTag(newTag);
+  const handleTagSelect = (tagName: string | null) => {
+    setSelectedTag(tagName);
 
     // 更新 URL
-    if (newTag) {
-      const url = new URL(window.location.href);
-      url.searchParams.set("tag", newTag);
-      window.history.pushState({}, "", url.toString());
+    const url = new URL(window.location.href);
+    if (tagName) {
+      url.searchParams.set("tag", tagName);
     } else {
-      const url = new URL(window.location.href);
       url.searchParams.delete("tag");
-      window.history.pushState({}, "", url.toString());
     }
+    window.history.pushState({}, "", url.toString());
 
     // 重置列表并重新加载
     setStories([]);
     setPage(1);
-    loadStories(1, false, newTag);
-  };
-
-  // 清除筛选
-  const handleClearFilter = () => {
-    setSelectedTag(null);
-    const url = new URL(window.location.href);
-    url.searchParams.delete("tag");
-    window.history.pushState({}, "", url.toString());
-    setStories([]);
-    setPage(1);
-    loadStories(1, false, null);
+    loadStories(1, false, tagName);
   };
 
   const handleLoadMore = () => {
@@ -276,7 +207,7 @@ export function DiscoverMain() {
     <div className="min-h-screen bg-background">
       {/* Header - 紧凑设计 */}
       <div className="pt-20 sm:pt-24 pb-5 sm:pb-6">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
             {/* Left: Title + Subtitle */}
             <div>
@@ -293,197 +224,84 @@ export function DiscoverMain() {
               </p>
             </div>
 
+            {/* Right: Publish CTA (desktop) */}
+            <button
+              className="hidden sm:flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors text-sm font-medium"
+              onClick={() => window.location.href = "/discover/create"}
+            >
+              <Plus className="h-4 w-4" />
+              {t("content.discover.publish")}
+            </button>
           </div>
         </div>
       </div>
 
-      {/* Main Content: Two Column Layout */}
-      <div className="max-w-7xl mx-auto px-3 sm:px-6 lg:px-8 pb-12">
-        <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_300px] gap-5 lg:gap-8">
-          {/* Left: Main Content Flow */}
-          <div className="space-y-4">
-            {/* Mobile Tag Filter - 横向滚动标签入口 */}
-            <div className="lg:hidden">
-              {tags.length > 0 && (
-                <div className="flex gap-2 overflow-x-auto pb-2 -mx-3 px-3 scrollbar-hide">
-                  {tags.map((tag) => (
-                    <button
-                      key={tag.id ?? tag.name}
-                      onClick={() => handleTagClick(tag.name)}
-                      className={`inline-flex items-center px-3 py-1.5 rounded-full text-xs whitespace-nowrap transition-colors ${
-                        selectedTag === tag.name
-                          ? "bg-primary text-primary-foreground"
-                          : "bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground"
-                      }`}
-                    >
-                      #{tag.name}
-                      {typeof tag.count === "number" && (
-                        <span className="ml-1 opacity-60">{tag.count}</span>
-                      )}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
+      {/* Main Content - Single Column */}
+      <div className="max-w-4xl mx-auto px-3 sm:px-6 lg:px-8 pb-12">
+        <div className="space-y-4">
+          {/* Tag Filter Bar */}
+          <TagFilterBar
+            tags={tags}
+            selectedTag={selectedTag}
+            onTagSelect={handleTagSelect}
+          />
 
-            {/* Filter Status Chip */}
-            {selectedTag && (
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-muted-foreground">筛选:</span>
-                <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-primary/10 text-primary text-sm font-medium">
-                  #{selectedTag}
-                  <button
-                    onClick={handleClearFilter}
-                    className="ml-1 p-0.5 rounded-full hover:bg-primary/20 transition-colors"
-                    aria-label="清除筛选"
-                  >
-                    <X className="w-3.5 h-3.5" />
-                  </button>
-                </span>
-              </div>
-            )}
+          {/* Featured Story - 第一篇作为精选 */}
+          {stories.length > 0 && (
+            <FeaturedStoryCard
+              story={stories[0]}
+              onClick={handleStoryClick}
+            />
+          )}
 
-            {/* Featured Story - 第一篇作为精选 */}
-            {stories.length > 0 && (
-              <FeaturedStoryCard
-                story={stories[0]}
+          {/* Story List - 其余故事 */}
+          <div className="space-y-3">
+            {stories.slice(1).map((story) => (
+              <StoryCard
+                key={story.id}
+                story={story}
                 onClick={handleStoryClick}
               />
-            )}
-
-            {/* Story List - 其余故事 */}
-            <div className="space-y-3">
-              {stories.slice(1).map((story) => (
-                <StoryCard
-                  key={story.id}
-                  story={story}
-                  onClick={handleStoryClick}
-                />
-              ))}
-            </div>
-
-            {/* Load More */}
-            {hasMore && (
-              <div className="py-6 flex justify-center">
-                <button
-                  onClick={handleLoadMore}
-                  disabled={isLoadingMore}
-                  className="px-6 py-2.5 rounded-lg border border-border bg-background hover:bg-accent transition-colors disabled:opacity-50 disabled:cursor-not-allowed text-sm"
-                >
-                  {isLoadingMore ? (
-                    <span className="flex items-center justify-center gap-2">
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                      {t("content.discover.loading")}
-                    </span>
-                  ) : (
-                    t("content.discover.loadMore")
-                  )}
-                </button>
-              </div>
-            )}
-
-            {/* No more */}
-            {!hasMore && stories.length > 0 && (
-              <div className="py-8 text-center text-sm text-muted-foreground">
-                {t("content.discover.noMore")}
-              </div>
-            )}
+            ))}
           </div>
 
-          {/* Right: Sidebar - 300px */}
-          <aside className="hidden lg:block space-y-4">
-            {/* Publish CTA */}
-            <div className="p-5 rounded-lg border border-border bg-white shadow-sm">
-              <h3 className="font-semibold text-sm mb-2">{t("content.discover.shareStory")}</h3>
-              <p className="text-xs text-muted-foreground mb-4">
-                {t("content.discover.shareStoryDesc")}
-              </p>
+          {/* Load More */}
+          {hasMore && (
+            <div className="py-6 flex justify-center">
               <button
-                className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors text-sm font-medium"
-                onClick={() => window.location.href = "/discover/create"}
+                onClick={handleLoadMore}
+                disabled={isLoadingMore}
+                className="px-6 py-2.5 rounded-lg border border-border bg-background hover:bg-accent transition-colors disabled:opacity-50 disabled:cursor-not-allowed text-sm"
               >
-                <Plus className="h-4 w-4" />
-                {t("content.discover.publish")}
+                {isLoadingMore ? (
+                  <span className="flex items-center justify-center gap-2">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    {t("content.discover.loading")}
+                  </span>
+                ) : (
+                  t("content.discover.loadMore")
+                )}
               </button>
             </div>
+          )}
 
-            {/* Popular Locations */}
-            {locations.length > 0 && (
-              <SidebarSection
-                icon={<MapPin className="w-4 h-4" />}
-                title={t("content.discover.popularLocations")}
-              >
-                <div className="space-y-2">
-                  {locations.map((location) => (
-                    <a
-                      key={location.id}
-                      href={`/locations/${location.slug || location.id}`}
-                      className="flex items-center justify-between py-2 px-2 -mx-2 rounded-md hover:bg-muted/50 transition-colors"
-                    >
-                      <span className="text-sm text-foreground">{location.name}</span>
-                      {typeof location.storyCount === "number" && (
-                        <span className="text-xs text-muted-foreground">{location.storyCount} 篇</span>
-                      )}
-                    </a>
-                  ))}
-                </div>
-              </SidebarSection>
-            )}
-
-            {/* Popular Tags */}
-            {tags.length > 0 && (
-              <SidebarSection
-                icon={<Tag className="w-4 h-4" />}
-                title={t("content.discover.popularTags")}
-              >
-                <div className="flex flex-wrap gap-2">
-                  {tags.map((tag) => (
-                    <button
-                      key={tag.id ?? tag.name}
-                      onClick={() => handleTagClick(tag.name)}
-                      className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs transition-colors ${
-                        selectedTag === tag.name
-                          ? "bg-primary text-primary-foreground"
-                          : "bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground"
-                      }`}
-                    >
-                      #{tag.name}
-                      {typeof tag.count === "number" && (
-                        <span className={`ml-1 ${selectedTag === tag.name ? "opacity-80" : "opacity-60"}`}>
-                          {tag.count}
-                        </span>
-                      )}
-                    </button>
-                  ))}
-                </div>
-              </SidebarSection>
-            )}
-
-            {/* Trending */}
-            <SidebarSection
-              icon={<Flame className="w-4 h-4" />}
-              title={t("content.discover.trending")}
-            >
-              {stats ? (
-                <div className="space-y-2 text-sm">
-                  <p className="text-muted-foreground">
-                    本周新增 <span className="text-foreground font-medium">{stats.weeklyNewStories}</span> 篇故事
-                  </p>
-                  {stats.popularLocation && (
-                    <p className="text-muted-foreground">
-                      <span className="text-foreground font-medium">{stats.popularLocation.name}</span> 是最热门的目的地
-                    </p>
-                  )}
-                </div>
-              ) : (
-                <div className="text-sm text-muted-foreground">
-                  {t("content.discover.trendingDesc")}
-                </div>
-              )}
-            </SidebarSection>
-          </aside>
+          {/* No more */}
+          {!hasMore && stories.length > 0 && (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              {t("content.discover.noMore")}
+            </div>
+          )}
         </div>
       </div>
+
+      {/* Mobile Publish FAB */}
+      <button
+        className="sm:hidden fixed bottom-6 right-6 w-14 h-14 rounded-full bg-primary text-primary-foreground shadow-lg hover:bg-primary/90 transition-colors flex items-center justify-center z-40"
+        onClick={() => window.location.href = "/discover/create"}
+        aria-label={t("content.discover.publish")}
+      >
+        <Plus className="h-6 w-6" />
+      </button>
     </div>
   );
 }

--- a/frontend/src/components/features/discover/tag-filter-bar.tsx
+++ b/frontend/src/components/features/discover/tag-filter-bar.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import * as React from "react";
+import { X } from "lucide-react";
+import { useI18n } from "@/hooks/useI18n";
+
+interface Tag {
+  id?: string;
+  name: string;
+  type?: string;
+  count?: number;
+}
+
+interface TagFilterBarProps {
+  tags: Tag[];
+  selectedTag: string | null;
+  onTagSelect: (tagName: string | null) => void;
+  className?: string;
+}
+
+/**
+ * 标签筛选栏组件
+ * - 横向滚动标签列表
+ * - 选中状态 + 清除按钮
+ * - URL 状态同步（通过父组件）
+ */
+export function TagFilterBar({ tags, selectedTag, onTagSelect, className }: TagFilterBarProps) {
+  const { t } = useI18n(["content", "common"]);
+
+  if (tags.length === 0) return null;
+
+  return (
+    <div className={className}>
+      {/* 横向滚动标签 */}
+      <div className="flex gap-2 overflow-x-auto pb-2 -mx-3 px-3 scrollbar-hide">
+        {tags.map((tag) => (
+          <button
+            key={tag.id ?? tag.name}
+            onClick={() => onTagSelect(tag.name === selectedTag ? null : tag.name)}
+            className={`inline-flex items-center px-3 py-1.5 rounded-full text-xs whitespace-nowrap transition-colors ${
+              selectedTag === tag.name
+                ? "bg-primary text-primary-foreground"
+                : "bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground"
+            }`}
+          >
+            #{tag.name}
+            {typeof tag.count === "number" && (
+              <span className="ml-1 opacity-60">{tag.count}</span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* 选中状态 Chip */}
+      {selectedTag && (
+        <div className="flex items-center gap-2 mt-2">
+          <span className="text-sm text-muted-foreground">{t("content.discover.filterLabel") || "筛选:"}</span>
+          <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-primary/10 text-primary text-sm font-medium">
+            #{selectedTag}
+            <button
+              onClick={() => onTagSelect(null)}
+              className="ml-1 p-0.5 rounded-full hover:bg-primary/20 transition-colors"
+              aria-label={t("common.clearAll") || "清除筛选"}
+            >
+              <X className="w-3.5 h-3.5" />
+            </button>
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Discover page refactor: remove sidebar, add dedicated TagFilterBar component.

## Changes

### #101 - Remove SidebarSection + simplify layout
- Remove 3 `SidebarSection` usages (locations, tags, trending)
- Switch to single column layout (`max-w-4xl`)
- Move publish CTA to header (desktop)
- Add mobile FAB button for publish
- Remove unused imports: `MapPin`, `Tag`, `Flame`, `X`, `SidebarSection`

### #102 - Create TagFilterBar component
- New file: `frontend/src/components/features/discover/tag-filter-bar.tsx`
- Horizontal scrolling tag list
- Selected state + clear button
- Filter status chip with X to clear
- Extracted from inline JSX in discover-main.tsx

## Verification
- [x] `pnpm build` passes
- [x] `pnpm test` passes (95/95)
- [x] Mobile: horizontal scroll tags + FAB button
- [x] Desktop: single column + tag filter bar
- [x] URL state sync works (?tag=xxx)

Closes #101, #102