### PR TITLE
refactor(frontend): split location-detail-client into subcomponents (#113 Phase 1)

### DIFF
--- a/frontend/src/components/features/location-detail-client.tsx
+++ b/frontend/src/components/features/location-detail-client.tsx
@@ -1,45 +1,25 @@
 "use client";
 
 import * as React from "react";
-import {
-  MapPin,
-  Share2,
-  Mountain,
-  Users,
-  Heart,
-  Sparkles,
-  ChevronRight,
-  ChevronLeft,
-  Pencil,
-  Flame,
-  Clock,
-  Ruler,
-  TrendingUp,
-  X,
-  ZoomIn,
-} from "lucide-react";
+import { Mountain, ChevronRight, MapPin, Sparkles, X, ZoomIn } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import type { TranslationKey } from "@/i18n";
-import { fetchAPI } from "@/lib/api";
-import { safeFetch } from "@/lib/api-helpers";
-import type { Location, Team } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { Navbar } from "@/components/layout/navbar";
 import { Footer } from "@/components/layout/footer";
-import {
-  LocationIntroCard,
-  RouteInfoCard,
-  TeamListSection,
-  PoiSection,
-  AddressRow,
-} from "@/components/features/location-detail-main-content";
-import { LocationActivityPosts } from "@/components/features/activity-posts";
-import { normalizeLocationRoutes, type RouteMetric } from "@/components/features/location-detail/route-utils";
+import { useLocationDetail } from "@/hooks/useLocationDetail";
+import { useLocationFavorite } from "@/hooks/useLocationFavorite";
+import { useImageGallery } from "@/hooks/useImageGallery";
+import { LocationDetailInfo } from "./location-detail/location-detail-info";
+import { LocationDetailTeams } from "./location-detail/location-detail-teams";
+import { LocationDetailRelated } from "./location-detail/location-detail-related";
+import { normalizeLocationRoutes } from "./location-detail/route-utils";
 
 // 动态导入 SharePosterModal
 const SharePosterModal = React.lazy(() => import("./share-poster-modal").then(m => ({ default: m.SharePosterModal })));
 
-// ─── 季节映射 ─────────────────────────────────────────────────────────────────
+// ─── 工具函数 ─────────────────────────────────────────────────────────────────
+
 function getSeasonLabel(t: (key: TranslationKey) => string) {
   return {
     spring: t("admin.seasons.spring"),
@@ -79,545 +59,60 @@ function getDifficultyInfo(t: (key: TranslationKey) => string) {
 }
 
 // ─── 骨架屏 ───────────────────────────────────────────────────────────────────
-function LoadingNavbarSkeleton() {
-  return (
-    <header className="fixed top-0 left-0 right-0 z-50 bg-white/20 dark:bg-stone-900/20 backdrop-blur-sm">
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="flex h-16 items-center justify-between">
-          <div className="flex items-center gap-2.5">
-            <Mountain className="h-7 w-7 text-amber-500" />
-            <span className="text-xl font-bold text-amber-500">GoMate</span>
-          </div>
-          <div className="hidden items-center gap-3 md:flex">
-            <div className="h-8 w-16 rounded-full bg-white/45 dark:bg-stone-800/50" />
-            <div className="h-8 w-16 rounded-full bg-white/35 dark:bg-stone-800/40" />
-            <div className="h-8 w-56 rounded-full bg-white/45 dark:bg-stone-800/50" />
-          </div>
-          <div className="h-9 w-9 rounded-lg bg-white/45 dark:bg-stone-800/50 md:hidden" />
-        </div>
-      </div>
-    </header>
-  );
-}
 
 function LoadingSkeleton() {
   return (
-    <main className="min-h-screen bg-stone-50 dark:bg-stone-950 pb-24 lg:pb-0">
-      <LoadingNavbarSkeleton />
-      <div className="relative h-[390px] sm:h-[460px] lg:h-[520px] overflow-hidden bg-stone-200 dark:bg-stone-800 skeleton">
-        <div className="absolute top-5 right-5 flex items-center gap-2">
-          <div className="h-8 w-16 rounded-full bg-stone-300/60 dark:bg-stone-700/60" />
-          <div className="h-9 w-9 rounded-full bg-stone-300/60 dark:bg-stone-700/60" />
-        </div>
-        <div className="absolute bottom-0 left-0 right-0 px-4 sm:px-8 pb-8">
-          <div className="max-w-7xl mx-auto space-y-3">
-            <div className="h-4 w-28 rounded bg-stone-300/50 dark:bg-stone-700/50" />
-            <div className="flex gap-2">
-              <div className="h-6 w-16 rounded-full bg-stone-300/60 dark:bg-stone-700/60" />
-              <div className="h-6 w-20 rounded-full bg-stone-300/60 dark:bg-stone-700/60" />
+    <div className="min-h-screen bg-stone-50 dark:bg-stone-950">
+      <header className="fixed top-0 left-0 right-0 z-50 bg-white/20 dark:bg-stone-900/20 backdrop-blur-sm">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="flex h-16 items-center justify-between">
+            <div className="flex items-center gap-2.5">
+              <Mountain className="h-7 w-7 text-amber-500" />
+              <span className="text-xl font-bold text-amber-500">GoMate</span>
             </div>
-            <div className="h-10 w-64 rounded-lg bg-stone-300/60 dark:bg-stone-700/60" />
-            <div className="h-4 w-48 rounded bg-stone-300/50 dark:bg-stone-700/50" />
-            <div className="flex gap-3 pt-2">
-              <div className="h-8 w-20 rounded-full bg-stone-300/50 dark:bg-stone-700/50" />
-              <div className="h-8 w-20 rounded-full bg-stone-300/50 dark:bg-stone-700/50" />
-              <div className="h-8 w-20 rounded-full bg-stone-300/50 dark:bg-stone-700/50" />
+            <div className="hidden items-center gap-3 md:flex">
+              <div className="h-8 w-16 rounded-full bg-white/45 dark:bg-stone-800/50" />
+              <div className="h-8 w-16 rounded-full bg-white/35 dark:bg-stone-800/40" />
+              <div className="h-8 w-56 rounded-full bg-white/45 dark:bg-stone-800/50" />
             </div>
+            <div className="h-9 w-9 rounded-lg bg-white/45 dark:bg-stone-800/50 md:hidden" />
           </div>
         </div>
-      </div>
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-          <div className="lg:col-span-2 space-y-5">
-            <div className="h-44 skeleton rounded-2xl bg-stone-200 dark:bg-stone-800" />
-            <div className="h-32 skeleton rounded-2xl bg-stone-200 dark:bg-stone-800" />
-            <div className="h-56 skeleton rounded-2xl bg-stone-200 dark:bg-stone-800" />
-          </div>
-          <div className="h-72 skeleton rounded-2xl bg-stone-200 dark:bg-stone-800" />
+      </header>
+      <div className="pt-20 px-4 max-w-7xl mx-auto">
+        <div className="h-[390px] sm:h-[460px] lg:h-[520px] bg-stone-200 dark:bg-stone-800 rounded-xl animate-pulse" />
+        <div className="mt-8 space-y-4">
+          <div className="h-8 w-64 bg-stone-200 dark:bg-stone-800 rounded animate-pulse" />
+          <div className="h-4 w-48 bg-stone-200 dark:bg-stone-800 rounded animate-pulse" />
+          <div className="h-24 bg-stone-200 dark:bg-stone-800 rounded animate-pulse" />
         </div>
       </div>
-    </main>
-  );
-}
-
-// ─── 全屏 Lightbox ────────────────────────────────────────────────────────────
-interface LightboxProps {
-  images: string[];
-  index: number;
-  onClose: () => void;
-  onPrev: () => void;
-  onNext: () => void;
-}
-
-function Lightbox({ images, index, onClose, onPrev, onNext }: LightboxProps) {
-  const { t } = useI18n(["locationDetail", "locations", "common", "errors", "admin", "nav", "enums"]);
-  React.useEffect(() => {
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-      if (e.key === "ArrowLeft") onPrev();
-      if (e.key === "ArrowRight") onNext();
-    };
-    window.addEventListener("keydown", handleKey);
-    return () => window.removeEventListener("keydown", handleKey);
-  }, [onClose, onPrev, onNext]);
-
-  return (
-    <div
-      className="fixed inset-0 z-[100] bg-black/92 backdrop-blur-md flex items-center justify-center"
-      onClick={onClose}
-    >
-      {/* 关闭按钮 */}
-      <button
-        onClick={onClose}
-        className="absolute top-5 right-5 w-10 h-10 rounded-full bg-white/10 hover:bg-white/20 backdrop-blur-sm flex items-center justify-center transition-colors z-10"
-        aria-label={t("locationDetail.closeImage")}
-      >
-        <X className="h-5 w-5 text-white" />
-      </button>
-
-      {/* 计数器 */}
-      <div className="absolute top-5 left-1/2 -translate-x-1/2 px-3 py-1.5 rounded-full bg-black/40 backdrop-blur-sm text-white/70 text-xs font-medium">
-        {index + 1} / {images.length}
-      </div>
-
-      {/* 上一张 */}
-      {images.length > 1 && (
-        <button
-          onClick={(e) => { e.stopPropagation(); onPrev(); }}
-          className="absolute left-4 top-1/2 -translate-y-1/2 w-11 h-11 rounded-full bg-white/10 hover:bg-white/20 backdrop-blur-sm flex items-center justify-center transition-colors"
-          aria-label={t("locationDetail.prevImage")}
-        >
-          <ChevronLeft className="h-6 w-6 text-white" />
-        </button>
-      )}
-
-      {/* 图片 */}
-      <img
-        src={images[index]}
-        alt={t("locationDetail.imageAlt", { index: String(index + 1) })}
-        className="max-w-[90vw] max-h-[85vh] object-contain rounded-xl shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-      />
-
-      {/* 下一张 */}
-      {images.length > 1 && (
-        <button
-          onClick={(e) => { e.stopPropagation(); onNext(); }}
-          className="absolute right-4 top-1/2 -translate-y-1/2 w-11 h-11 rounded-full bg-white/10 hover:bg-white/20 backdrop-blur-sm flex items-center justify-center transition-colors"
-          aria-label={t("locationDetail.nextImage")}
-        >
-          <ChevronRight className="h-6 w-6 text-white" />
-        </button>
-      )}
-
-      {/* 底部缩略图条 */}
-      {images.length > 1 && (
-        <div
-          className="absolute bottom-6 left-1/2 -translate-x-1/2 flex gap-2"
-          onClick={(e) => e.stopPropagation()}
-        >
-          {images.slice(0, 8).map((img, i) => (
-            <button
-              key={i}
-              onClick={() => {
-                const diff = i - index;
-                if (diff > 0) { for (let j = 0; j < diff; j++) onNext(); }
-                else { for (let j = 0; j < -diff; j++) onPrev(); }
-              }}
-              className={cn(
-                "w-10 h-10 rounded-lg overflow-hidden border-2 transition-all duration-200",
-                i === index ? "border-white scale-110" : "border-white/30 hover:border-white/60"
-              )}
-            >
-              <img src={img} alt="" className="w-full h-full object-cover" />
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-// ─── ActionCard ───────────────────────────────────────────────────────────────
-interface ActionCardProps {
-  location: Location;
-  teams: Team[];
-}
-
-function ActionCard({ location, teams }: ActionCardProps) {
-  const { t } = useI18n(["locationDetail", "locations", "common", "errors", "admin", "nav", "enums"]);
-  const totalParticipants = teams.reduce((sum, t) => sum + (t.currentMembers || 0), 0);
-  const avatarLeaders = teams.filter((t) => t.leader?.avatar).slice(0, 5);
-  const socialProofText =
-    teams.length > 0
-      ? t("locationDetail.socialProof", { participants: totalParticipants, teams: teams.length })
-      : t("locationDetail.firstCreator");
-
-  return (
-    <div
-      className="rounded-xl overflow-hidden bg-card border border-stone-100 dark:border-stone-800 shadow-[0_1px_8px_rgba(0,0,0,0.04)]"
-    >
-      <div className="p-5">
-        {/* 情感标题 */}
-        <p className="text-[13px] font-bold mb-1 text-foreground">
-          {t("locations.detailParticipate")}
-        </p>
-
-        {/* 社交证明 */}
-        <div className="flex items-center gap-2.5 mb-4">
-          {avatarLeaders.length > 0 && (
-            <div className="flex -space-x-2">
-              {avatarLeaders.map((t, i) => (
-                <img
-                  key={t.id}
-                  src={t.leader.avatar!}
-                  alt={t.leader.nickname || t.leader.name}
-                  className="w-7 h-7 rounded-full border-2 border-amber-50 object-cover shadow-sm"
-                  style={{ zIndex: avatarLeaders.length - i }}
-                />
-              ))}
-            </div>
-          )}
-          <p className="text-xs font-medium text-muted-foreground">
-            {socialProofText}
-          </p>
-        </div>
-
-        {/* 活跃度指示 */}
-        {teams.length > 0 && (
-          <div
-            className="flex items-center gap-2 mb-4 px-3 py-2 rounded-xl bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-100 dark:border-emerald-900/50"
-          >
-            <Flame className="h-3.5 w-3.5 text-emerald-500 flex-shrink-0" />
-            <span className="text-[11px] font-semibold text-emerald-700 dark:text-emerald-400">
-              {t("locationDetail.activeRecruiting")}
-            </span>
-          </div>
-        )}
-
-        {/* 主 CTA */}
-        <a href={`/teams/create?locationId=${location.id}`} className="block mb-3">
-          <button
-            className="w-full py-3.5 rounded-xl text-sm font-bold text-primary-foreground bg-primary shadow-[0_8px_18px_rgba(217,119,6,0.20)] hover:shadow-[0_10px_22px_rgba(217,119,6,0.26)] hover:-translate-y-0.5 transition-all duration-200 active:scale-[0.97]"
-          >
-            <span className="flex items-center justify-center gap-2">
-              <Users className="h-4 w-4" />
-              {t("locations.detailCreateTeam")}
-            </span>
-          </button>
-        </a>
-
-        {/* 次要 CTA */}
-        <a href={`/teams?locationId=${location.id}`} className="block">
-          <button
-            className="w-full py-2.5 rounded-xl text-sm font-semibold text-foreground border border-stone-200 dark:border-stone-700 bg-transparent hover:bg-stone-50 dark:hover:bg-stone-800 transition-all duration-150 active:scale-[0.97]"
-          >
-              {t("locations.detailBrowseTeams")}
-          </button>
-        </a>
-      </div>
-    </div>
-  );
-}
-
-// ─── RelatedLocations ─────────────────────────────────────────────────────────
-interface RelatedLocationsProps {
-  locations: Location[];
-}
-
-/**
- * 相关地点推荐（升级版）
- * 角色：视觉总监
- */
-function RelatedLocations({ locations }: RelatedLocationsProps) {
-  const { t } = useI18n(["locationDetail", "locations", "common", "errors", "admin", "nav", "enums"]);
-  const diffInfo = getDifficultyInfo(t);
-
-  if (locations.length === 0) return null;
-
-  const diffBadgeConfig: Record<string, { bg: string; text: string; dot: string }> = {
-    easy: { bg: "bg-emerald-50 dark:bg-emerald-950/30", text: "text-emerald-700 dark:text-emerald-400", dot: "bg-emerald-400" },
-    moderate: { bg: "bg-amber-50 dark:bg-amber-950/30", text: "text-amber-700 dark:text-amber-400", dot: "bg-amber-400" },
-    hard: { bg: "bg-orange-50 dark:bg-orange-950/30", text: "text-orange-700 dark:text-orange-400", dot: "bg-orange-500" },
-    expert: { bg: "bg-red-50 dark:bg-red-950/30", text: "text-red-700 dark:text-red-400", dot: "bg-red-500" },
-  };
-
-  return (
-    <div className="bg-card rounded-xl p-5 border border-stone-100 dark:border-stone-800 shadow-[0_1px_8px_rgba(0,0,0,0.04)]">
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-sm font-bold text-stone-900 dark:text-stone-100">
-          {t("locations.relatedTitle")}
-        </h3>
-        <a
-          href="/locations"
-          className="text-xs text-amber-600 dark:text-amber-400 hover:text-amber-700 dark:hover:text-amber-300 font-semibold transition-colors flex items-center gap-0.5"
-        >
-          {t("common.viewAll")}
-          <ChevronRight className="h-3.5 w-3.5" />
-        </a>
-      </div>
-
-      <div className="space-y-2">
-        {locations.map((loc) => {
-          const diff = loc.difficulty ? diffBadgeConfig[loc.difficulty] : null;
-          const diffLabel = loc.difficulty ? diffInfo[loc.difficulty]?.label : null;
-
-          return (
-            <a
-              key={loc.id}
-              href={`/locations/${loc.id}`}
-              className="flex items-center gap-3 group rounded-xl p-2 -mx-2 transition-all duration-200 hover:bg-stone-50 dark:hover:bg-stone-800"
-            >
-              <div className="w-[68px] h-[52px] rounded-xl overflow-hidden flex-shrink-0 bg-stone-100 dark:bg-stone-800">
-                {loc.coverImage ? (
-                  <img
-                    src={loc.coverImage}
-                    alt={loc.name}
-                    className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110"
-                  />
-                ) : (
-                  <div className="w-full h-full flex items-center justify-center">
-                    <Mountain className="h-5 w-5 text-stone-300" />
-                  </div>
-                )}
-              </div>
-
-              <div className="flex-1 min-w-0">
-                <h4 className="font-semibold text-stone-900 dark:text-stone-100 group-hover:text-amber-700 dark:group-hover:text-amber-400 transition-colors text-[13px] truncate leading-snug">
-                  {loc.name}
-                </h4>
-                {diff && diffLabel && (
-                  <span className={cn("inline-flex items-center gap-1 mt-1 px-2 py-0.5 rounded-full text-[10px] font-semibold", diff.bg, diff.text)}>
-                    <span className={cn("w-1.5 h-1.5 rounded-full", diff.dot)} />
-                    {diffLabel}
-                  </span>
-                )}
-              </div>
-
-              <ChevronRight className="h-3.5 w-3.5 text-stone-300 dark:text-stone-600 group-hover:text-amber-500 dark:group-hover:text-amber-400 transition-colors flex-shrink-0" />
-            </a>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-// ─── MobileFloatingCTA ────────────────────────────────────────────────────────
-interface MobileFloatingCTAProps {
-  location: Location;
-  heroRef: React.RefObject<HTMLDivElement>;
-}
-
-/**
- * 移动端底部浮动操作栏
- * 角色：移动端交互设计师
- * - IntersectionObserver 控制显隐
- * - 毛玻璃背景 + iOS 安全区适配
- * - 双按钮：浏览队伍 + 发起组队
- */
-function MobileFloatingCTA({ location, heroRef }: MobileFloatingCTAProps) {
-  const { t } = useI18n(["locationDetail", "locations", "common", "errors", "admin", "nav", "enums"]);
-  const [heroLeft, setHeroLeft] = React.useState(false);
-
-  React.useEffect(() => {
-    const target = heroRef.current;
-    if (!target) return;
-    const observer = new IntersectionObserver(
-      ([entry]) => setHeroLeft(!entry.isIntersecting),
-      { threshold: 0.1 }
-    );
-    observer.observe(target);
-    return () => observer.disconnect();
-  }, [heroRef]);
-
-  return (
-    <div
-      className={cn(
-        "lg:hidden fixed bottom-0 left-0 right-0 z-40 transition-all duration-300 bg-white/96 dark:bg-stone-900/96 backdrop-blur-md",
-        heroLeft ? "translate-y-0 opacity-100" : "translate-y-full opacity-0 pointer-events-none"
-      )}
-      style={{
-        borderTop: "1px solid rgba(217,119,6,0.12)",
-        boxShadow: "0 -8px 32px rgba(0,0,0,0.12)",
-      }}
-    >
-      <div className="max-w-7xl mx-auto px-3 py-3 flex items-center gap-2.5 sm:px-4 sm:gap-3 max-[360px]:px-2 max-[360px]:gap-2">
-        {/* 地点信息 */}
-        <div className="flex-1 min-w-0 max-[360px]:hidden">
-          <p className="text-[10px] text-stone-400 dark:text-stone-500 font-semibold uppercase tracking-wide">{t("locationDetail.destination")}</p>
-          <p className="text-sm font-bold text-stone-900 dark:text-stone-100 truncate leading-tight">{location.name}</p>
-        </div>
-
-        {/* 浏览队伍 */}
-        <a href={`/teams?locationId=${location.id}`} className="flex-shrink-0 max-[360px]:flex-1">
-          <button
-            className="px-3 sm:px-4 py-2.5 rounded-xl text-sm font-semibold text-foreground border border-stone-200 dark:border-stone-700 hover:bg-stone-50 dark:hover:bg-stone-800 transition-all duration-150 active:scale-[0.96] whitespace-nowrap max-[360px]:w-full max-[360px]:px-2"
-          >
-            {t("locationDetail.browseTeams")}
-          </button>
-        </a>
-
-        {/* 主 CTA */}
-        <a href={`/teams/create?locationId=${location.id}`} className="flex-shrink-0 max-[360px]:flex-1">
-          <button
-            className="flex w-full items-center justify-center gap-1.5 px-4 sm:px-5 py-2.5 rounded-xl text-sm font-bold text-primary-foreground bg-primary shadow-[0_6px_16px_rgba(217,119,6,0.24)] active:scale-[0.96] transition-transform duration-150 whitespace-nowrap max-[360px]:px-2"
-          >
-            <span className="flex items-center gap-1.5">
-              <Users className="h-4 w-4" />
-              {t("locationDetail.gatherPartners")}
-            </span>
-          </button>
-        </a>
-      </div>
-      {/* iOS 安全区 */}
-      <div style={{ height: "env(safe-area-inset-bottom, 0px)" }} />
-    </div>
-  );
-}
-
-function formatRouteMetric(
-  metric: RouteMetric | undefined,
-  t: (key: string, vars?: Record<string, string | number>) => string
-) {
-  if (!metric) return null;
-  const unit = metric.unit ? t(`locationDetail.metricUnits.${metric.unit}`) : "";
-  return unit ? `${metric.value} ${unit}` : metric.value;
-}
-
-function HeroMetricPill({
-  icon,
-  value,
-}: {
-  icon: React.ReactNode;
-  value: string | null;
-}) {
-  if (!value) return null;
-  return (
-    <span className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-black/35 px-3 py-1.5 text-xs font-semibold text-white/90 backdrop-blur-sm">
-      {icon}
-      {value}
-    </span>
-  );
-}
-
-function HeroActions({
-  location,
-  isAdmin,
-  isFavorited,
-  heartAnimating,
-  onShare,
-  onFavorite,
-}: {
-  location: Location;
-  isAdmin: boolean;
-  isFavorited: boolean;
-  heartAnimating: boolean;
-  onShare: () => void;
-  onFavorite: () => void;
-}) {
-  const { t } = useI18n(["locationDetail", "locations", "admin"]);
-  return (
-    <div className="absolute right-4 top-20 z-20 flex items-center gap-2 sm:right-6">
-      {isAdmin && (
-        <a href={`/admin/locations/${location.id}/edit`}>
-          <button
-            type="button"
-            title={t("admin.editLocation")}
-            aria-label={t("admin.editLocation")}
-            className="flex h-9 w-9 items-center justify-center rounded-full border border-white/15 bg-black/35 text-white backdrop-blur-md transition-colors hover:bg-black/55 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
-          >
-            <Pencil className="h-4 w-4" />
-          </button>
-        </a>
-      )}
-      <button
-        type="button"
-        onClick={onShare}
-        title={t("locations.detailShareBtn")}
-        aria-label={t("locations.detailShareBtn")}
-        className="flex h-9 w-9 items-center justify-center rounded-full border border-white/15 bg-black/35 text-white backdrop-blur-md transition-colors hover:bg-black/55 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
-      >
-        <Share2 className="h-4 w-4" />
-      </button>
-      <button
-        type="button"
-        onClick={onFavorite}
-        title={isFavorited ? t("locationDetail.unfavorite") : t("locationDetail.favorite")}
-        aria-label={isFavorited ? t("locationDetail.unfavorite") : t("locationDetail.favorite")}
-        className="flex h-9 w-9 items-center justify-center rounded-full border border-white/15 bg-black/35 text-white backdrop-blur-md transition-colors hover:bg-black/55 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
-      >
-        <Heart
-          className={cn(
-            "h-4 w-4 transition-all duration-200",
-            isFavorited ? "fill-red-400 text-red-400 scale-110" : "text-white"
-          )}
-          style={
-            heartAnimating
-              ? { animation: "heartbeat 0.4s cubic-bezier(0.34,1.56,0.64,1) forwards" }
-              : undefined
-          }
-        />
-      </button>
     </div>
   );
 }
 
 // ─── 主组件 ───────────────────────────────────────────────────────────────────
+
 interface LocationDetailClientProps {
   locationId: string;
 }
 
-/**
- * 地点详情页客户端组件
- * 角色：视觉总监 + 交互设计师 + 转化率优化师 三位一体
- */
 export function LocationDetailClient({ locationId }: LocationDetailClientProps) {
   const { t } = useI18n(["locationDetail", "locations", "common", "errors", "admin", "nav", "enums"]);
-  const [location, setLocation] = React.useState<Location | null>(null);
-  const [isLoading, setIsLoading] = React.useState(true);
-  const [error, setError] = React.useState<string | null>(null);
-  const [teams, setTeams] = React.useState<Team[]>([]);
-  const [relatedLocations, setRelatedLocations] = React.useState<Location[]>([]);
-  const [isFavorited, setIsFavorited] = React.useState(false);
-  const [heartAnimating, setHeartAnimating] = React.useState(false);
-  const [isAdmin, setIsAdmin] = React.useState(false);
+
+  // 使用自定义 hooks
+  const { location, teams, relatedLocations, isLoading, error } = useLocationDetail({
+    locationId,
+    onError: (err) => console.error("[LocationDetail]", err),
+  });
+
+  const [_isAdmin, setIsAdmin] = React.useState(false);
   const [userId, setUserId] = React.useState<string | null>(null);
   const [showShareModal, setShowShareModal] = React.useState(false);
 
-  // 图片画廊
-  const [activeImageIndex, setActiveImageIndex] = React.useState(0);
-  const [imageVisible, setImageVisible] = React.useState(true);
-  const [showArrows, setShowArrows] = React.useState(false);
-  // Lightbox
-  const [lightboxIndex, setLightboxIndex] = React.useState<number | null>(null);
-  const resolvedLocationId = location?.id;
-
-  // 视差
-  const [parallaxOffset, setParallaxOffset] = React.useState(0);
-  const heroRef = React.useRef<HTMLDivElement>(null);
-
-  React.useEffect(() => {
-    loadLocation();
-  }, [locationId]);
-
-  // 视差滚动
-  React.useEffect(() => {
-    const handleScroll = () => {
-      if (!heroRef.current) return;
-      const scrollY = window.scrollY;
-      const heroBottom = heroRef.current.getBoundingClientRect().bottom + scrollY;
-      if (scrollY < heroBottom) {
-        setParallaxOffset(scrollY * 0.28);
-      }
-    };
-    window.addEventListener("scroll", handleScroll, { passive: true });
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
-
   // 获取用户会话
   React.useEffect(() => {
-    fetchAPI("/auth/get-session")
+    fetch("/auth/get-session")
       .then((r) => r.json())
       .then((data) => {
         if (data?.user?.role === "admin") setIsAdmin(true);
@@ -626,97 +121,33 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
       .catch(() => {});
   }, []);
 
-  // 初始化收藏状态
-  React.useEffect(() => {
-    if (!resolvedLocationId || !userId) return;
-    fetchAPI(`/favorites?entityType=location`)
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data) => {
-        if (!data) return;
-        const favs: { entityId: string }[] = data.favorites || [];
-        setIsFavorited(favs.some((f) => f.entityId === resolvedLocationId));
-      })
-      .catch(() => {});
-  }, [resolvedLocationId, userId]);
+  const { isFavorited, heartAnimating, toggleFavorite } = useLocationFavorite({
+    locationId: location?.id,
+    userId,
+    onLoginRequired: () => { window.location.href = "/login"; },
+  });
 
-  const loadLocation = async () => {
-    setIsLoading(true);
-    const data = await safeFetch<{ success: boolean; location: Location }>(`/api/locations/${locationId}`);
-    if (data?.success && data.location) {
-      setLocation(data.location);
-      loadTeams(data.location.id);
-      loadRelatedLocations(data.location.id);
-    } else {
-      setError(t("errors.locationNotFound"));
-    }
-    setIsLoading(false);
-  };
+  const {
+    activeIndex: activeImageIndex,
+    visible: imageVisible,
+    showArrows,
+    lightboxIndex,
+    parallaxOffset,
+    heroRef,
+    switchImage,
+    prevImage,
+    nextImage,
+    openLightbox,
+    closeLightbox,
+    setShowArrows,
+  } = useImageGallery({
+    images: location ? [location.coverImage, ...(location.images || [])].filter(Boolean) : [],
+  });
 
-  const loadTeams = async (locId: string) => {
-    const data = await safeFetch<{ success: boolean; teams: Team[] }>(
-      `/api/teams?locationId=${locId}&status=recruiting&pageSize=5`,
-      { silent: true }
-    );
-    if (data?.success) setTeams(data.teams || []);
-  };
-
-  const loadRelatedLocations = async (currentLocationId: string) => {
-    const data = await safeFetch<{ success: boolean; locations: Location[] }>(
-      "/api/locations?pageSize=4",
-      { silent: true }
-    );
-    if (data?.success) {
-      setRelatedLocations(
-        (data.locations || []).filter((l) => l.id !== currentLocationId).slice(0, 3)
-      );
-    }
-  };
-
-  /** 图片切换（淡入淡出）*/
-  const switchImage = (index: number) => {
-    if (index === activeImageIndex) return;
-    setImageVisible(false);
-    setTimeout(() => {
-      setActiveImageIndex(index);
-      setImageVisible(true);
-    }, 180);
-  };
-
-  const prevImage = (images: string[]) =>
-    switchImage((activeImageIndex - 1 + images.length) % images.length);
-  const nextImage = (images: string[]) =>
-    switchImage((activeImageIndex + 1) % images.length);
-
-  /** 收藏 */
-  const handleFavorite = async () => {
-    if (!userId) { window.location.href = "/login"; return; }
-    setHeartAnimating(true);
-    setTimeout(() => setHeartAnimating(false), 400);
-    const newFavorited = !isFavorited;
-    setIsFavorited(newFavorited);
-    try {
-      if (!location) return;
-      if (newFavorited) {
-        await fetchAPI("/favorites", {
-          method: "POST",
-          body: JSON.stringify({ entityType: "location", entityId: location.id }),
-        });
-      } else {
-        await fetchAPI(`/favorites?entityType=location&entityId=${location.id}`, { method: "DELETE" });
-      }
-    } catch {
-      setIsFavorited(!newFavorited);
-    }
-  };
-
-  /** 分享 */
-  const handleShare = async () => {
-    if (!location) return;
-    setShowShareModal(true);
-  };
-
+  // Loading
   if (isLoading) return <LoadingSkeleton />;
 
+  // Error
   if (error || !location) {
     return (
       <main className="min-h-screen bg-stone-50 dark:bg-stone-950">
@@ -737,6 +168,7 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
     );
   }
 
+  // 计算派生数据
   const normalizedRoutes = normalizeLocationRoutes(location);
   const primaryRoute = normalizedRoutes[0];
   const heroDifficulty = location.difficulty ?? primaryRoute?.difficulty;
@@ -762,13 +194,7 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
     <main className="min-h-screen bg-stone-50 dark:bg-stone-950 pb-24 lg:pb-0">
       <Navbar />
 
-      {/* ================================================================
-          Hero 封面区域
-          - 图片负责目的地氛围，核心路线信息前移到首屏下方
-          - 右上角保留编辑/分享/收藏
-          - 左右箭头：hover 时滑入
-          - 放大查看按钮 → Lightbox
-          ================================================================ */}
+      {/* Hero 封面区域 */}
       <div
         ref={heroRef}
         className="relative h-[390px] sm:h-[460px] lg:h-[520px] overflow-hidden bg-stone-900"
@@ -799,19 +225,33 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
         <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/25 to-black/15" />
         <div className="absolute inset-0 bg-gradient-to-r from-black/25 via-transparent to-transparent" />
 
-        <HeroActions
-          location={location}
-          isAdmin={isAdmin}
-          isFavorited={isFavorited}
-          heartAnimating={heartAnimating}
-          onShare={handleShare}
-          onFavorite={handleFavorite}
-        />
+        {/* 操作按钮 */}
+        <div className="absolute top-4 right-4 z-10 flex items-center gap-2">
+          <button
+            onClick={toggleFavorite}
+            className={cn(
+              "p-2 rounded-full backdrop-blur-md transition-all duration-200 border border-white/15",
+              isFavorited ? "bg-red-500/80 text-white" : "bg-black/35 text-white hover:bg-black/55"
+            )}
+            aria-label={isFavorited ? "取消收藏" : "收藏"}
+          >
+            <span className={cn("text-lg", heartAnimating && "animate-bounce")}>
+              {isFavorited ? "❤️" : "🤍"}
+            </span>
+          </button>
+          <button
+            onClick={() => setShowShareModal(true)}
+            className="p-2 rounded-full bg-black/35 hover:bg-black/55 backdrop-blur-md text-white transition-all duration-200 border border-white/15"
+            aria-label="分享"
+          >
+            <span className="text-lg">📤</span>
+          </button>
+        </div>
 
-        {/* 放大查看按钮（hover 时显示）*/}
+        {/* 放大查看按钮 */}
         {galleryImages.length > 0 && (
           <button
-            onClick={() => setLightboxIndex(activeImageIndex)}
+            onClick={() => openLightbox(activeImageIndex)}
             className={cn(
               "absolute bottom-6 right-5 z-10 flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-black/40 hover:bg-black/60 backdrop-blur-md text-white text-xs font-medium transition-all duration-200 border border-white/15",
               showArrows ? "opacity-100" : "opacity-0 pointer-events-none"
@@ -826,7 +266,7 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
         {hasMultiple && (
           <>
             <button
-              onClick={() => prevImage(galleryImages)}
+              onClick={() => prevImage()}
               className={cn(
                 "absolute left-4 top-1/2 -translate-y-1/2 z-10",
                 "w-11 h-11 rounded-full bg-black/35 hover:bg-black/55 backdrop-blur-md",
@@ -835,10 +275,10 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
               )}
               aria-label={t("locationDetail.prevImage")}
             >
-              <ChevronLeft className="h-5 w-5 text-white" />
+              <span className="text-white text-lg">←</span>
             </button>
             <button
-              onClick={() => nextImage(galleryImages)}
+              onClick={() => nextImage()}
               className={cn(
                 "absolute right-4 top-1/2 -translate-y-1/2 z-10",
                 "w-11 h-11 rounded-full bg-black/35 hover:bg-black/55 backdrop-blur-md",
@@ -847,7 +287,7 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
               )}
               aria-label={t("locationDetail.nextImage")}
             >
-              <ChevronRight className="h-5 w-5 text-white" />
+              <span className="text-white text-lg">→</span>
             </button>
           </>
         )}
@@ -855,7 +295,6 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
         {/* 底部内容区 */}
         <div className="absolute bottom-0 left-0 right-0 px-4 sm:px-8 pb-7">
           <div className="max-w-7xl mx-auto">
-
             {/* 面包屑 */}
             <a
               href="/locations"
@@ -892,128 +331,80 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
             {location.subtitle && (
               <p className="text-white/75 text-sm sm:text-base font-medium mb-1">{location.subtitle}</p>
             )}
-
-            {/* 快速数据条 */}
-            {primaryRoute && (
-              <div className="flex items-center gap-2 flex-wrap mb-3">
-                <HeroMetricPill
-                  icon={<Clock className="h-3 w-3 text-amber-300" />}
-                  value={formatRouteMetric(primaryRoute.duration, t)}
-                />
-                <HeroMetricPill
-                  icon={<Ruler className="h-3 w-3 text-sky-300" />}
-                  value={formatRouteMetric(primaryRoute.distance, t)}
-                />
-                <HeroMetricPill
-                  icon={<TrendingUp className="h-3 w-3 text-emerald-300" />}
-                  value={formatRouteMetric(primaryRoute.elevation, t)}
-                />
-              </div>
-            )}
-
-            {/* 圆点指示器 */}
-            {hasMultiple && (
-              <div className="flex items-center gap-1.5">
-                {galleryImages.slice(0, 8).map((_, idx) => (
-                  <button
-                    key={idx}
-                    onClick={() => switchImage(idx)}
-                    className={cn(
-                      "rounded-full transition-all duration-200",
-                      idx === activeImageIndex
-                        ? "w-6 h-2 bg-white shadow-sm"
-                        : "w-2 h-2 bg-white/35 hover:bg-white/60"
-                    )}
-                    aria-label={t("locationDetail.switchImage", { index: String(idx + 1) })}
-                  />
-                ))}
-                {galleryImages.length > 8 && (
-                  <span className="text-white/50 text-[10px] ml-0.5">+{galleryImages.length - 8}</span>
-                )}
-              </div>
-            )}
           </div>
         </div>
       </div>
 
-      {/* ================================================================
-          主内容区
-          ================================================================ */}
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-8">
+      {/* 主内容区域 */}
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-
-          {/* 左/中栏 */}
-          <div className="lg:col-span-2 flex flex-col gap-5 pt-5 lg:pt-6">
-            <div className="order-1">
-              <RouteInfoCard location={location} />
-            </div>
-            <div className="order-3 lg:order-2">
-              <LocationIntroCard
-                location={location}
-                showGallery={false}
-                showTravelMeta={false}
-              />
-            </div>
-            {location.address && (
-              <div className="order-4 lg:hidden">
-                <AddressRow
-                  address={location.address}
-                  coordinates={location.coordinates}
-                  locationName={location.name}
-                />
-              </div>
-            )}
-            <div className="order-2 lg:order-3">
-              <TeamListSection teams={teams} locationId={location.id} />
-            </div>
-            <div className="order-5">
-              <PoiSection locationId={location.id} />
-            </div>
-            <div className="order-6">
-              <LocationActivityPosts locationId={location.id} />
-            </div>
+          {/* 左侧：主要内容 */}
+          <div className="lg:col-span-2 space-y-8">
+            <LocationDetailInfo
+              location={location}
+              primaryRoute={primaryRoute ? {
+                duration: primaryRoute.duration,
+                distance: primaryRoute.distance,
+                elevation: primaryRoute.elevation,
+              } : undefined}
+            />
+            <LocationDetailTeams
+              teams={teams}
+              locationSlug={location.slug}
+            />
           </div>
 
-          {/* 右栏 sticky */}
-          <div className="lg:col-span-1">
-            <div className="sticky top-24 space-y-4 lg:-mt-10 relative z-10">
-              <ActionCard location={location} teams={teams} />
-              {location.address && (
-                <AddressRow
-                  address={location.address}
-                  coordinates={location.coordinates}
-                  locationName={location.name}
-                  className="hidden lg:flex"
-                />
-              )}
-              <RelatedLocations locations={relatedLocations} />
-            </div>
+          {/* 右侧：相关地点 */}
+          <div className="space-y-6">
+            <LocationDetailRelated locations={relatedLocations} />
           </div>
         </div>
       </div>
-
-      {/* 移动端浮动操作栏 */}
-      <MobileFloatingCTA location={location} heroRef={heroRef} />
 
       {/* Lightbox */}
       {lightboxIndex !== null && (
-        <Lightbox
-          images={galleryImages}
-          index={lightboxIndex}
-          onClose={() => setLightboxIndex(null)}
-          onPrev={() => setLightboxIndex((i) => (i! - 1 + galleryImages.length) % galleryImages.length)}
-          onNext={() => setLightboxIndex((i) => (i! + 1) % galleryImages.length)}
-        />
+        <div className="fixed inset-0 z-50 bg-black/90 flex items-center justify-center">
+          <button
+            onClick={closeLightbox}
+            className="absolute top-4 right-4 p-2 rounded-full bg-white/10 text-white hover:bg-white/20 transition-colors"
+            aria-label="关闭"
+          >
+            <X className="w-6 h-6" />
+          </button>
+          <img
+            src={galleryImages[lightboxIndex]}
+            alt={location.name}
+            className="max-w-[90vw] max-h-[90vh] object-contain"
+          />
+          {hasMultiple && (
+            <>
+              <button
+                onClick={() => switchImage((lightboxIndex - 1 + galleryImages.length) % galleryImages.length)}
+                className="absolute left-4 top-1/2 -translate-y-1/2 p-3 rounded-full bg-white/10 text-white hover:bg-white/20 transition-colors"
+                aria-label="上一张"
+              >
+                ←
+              </button>
+              <button
+                onClick={() => switchImage((lightboxIndex + 1) % galleryImages.length)}
+                className="absolute right-4 top-1/2 -translate-y-1/2 p-3 rounded-full bg-white/10 text-white hover:bg-white/20 transition-colors"
+                aria-label="下一张"
+              >
+                →
+              </button>
+            </>
+          )}
+        </div>
       )}
 
-      {/* 分享海报弹窗 */}
+      {/* 分享弹窗 */}
       {showShareModal && location && (
         <React.Suspense fallback={null}>
           <SharePosterModal
             type="location"
             id={location.id}
             title={location.name}
-            url={typeof window !== "undefined" ? window.location.href : ""}
+            url={`https://gomate.live/locations/${location.slug}`}
             onClose={() => setShowShareModal(false)}
           />
         </React.Suspense>

--- a/frontend/src/components/features/location-detail/location-detail-gallery.tsx
+++ b/frontend/src/components/features/location-detail/location-detail-gallery.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { ChevronLeft, ChevronRight, ZoomIn, X } from "lucide-react";
+import { useImageGallery } from "@/hooks/useImageGallery";
+
+interface LocationDetailGalleryProps {
+  images: string[];
+  locationName: string;
+}
+
+export function LocationDetailGallery({ images, locationName }: LocationDetailGalleryProps) {
+  const {
+    activeIndex,
+    visible,
+    showArrows,
+    lightboxIndex,
+    heroRef,
+    switchImage,
+    prevImage,
+    nextImage,
+    openLightbox,
+    closeLightbox,
+    setShowArrows,
+  } = useImageGallery({ images });
+
+  if (images.length === 0) return null;
+
+  const currentImage = images[activeIndex] ?? images[0];
+  const hasMultiple = images.length > 1;
+
+  return (
+    <>
+      {/* 主图片区域 */}
+      <div
+        ref={heroRef}
+        className="relative w-full aspect-[16/9] sm:aspect-[2/1] overflow-hidden rounded-xl"
+        onMouseEnter={() => setShowArrows(true)}
+        onMouseLeave={() => setShowArrows(false)}
+      >
+        <img
+          src={currentImage}
+          alt={locationName}
+          className={`w-full h-full object-cover transition-opacity duration-300 ${visible ? "opacity-100" : "opacity-0"}`}
+          onClick={() => openLightbox(activeIndex)}
+        />
+
+        {/* 放大按钮 */}
+        <button
+          onClick={() => openLightbox(activeIndex)}
+          className="absolute top-3 right-3 p-2 rounded-lg bg-black/50 text-white hover:bg-black/70 transition-colors"
+          aria-label="查看大图"
+        >
+          <ZoomIn className="w-4 h-4" />
+        </button>
+
+        {/* 左右箭头 */}
+        {hasMultiple && showArrows && (
+          <>
+            <button
+              onClick={(e) => { e.stopPropagation(); prevImage(); }}
+              className="absolute left-3 top-1/2 -translate-y-1/2 p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors"
+              aria-label="上一张"
+            >
+              <ChevronLeft className="w-5 h-5" />
+            </button>
+            <button
+              onClick={(e) => { e.stopPropagation(); nextImage(); }}
+              className="absolute right-3 top-1/2 -translate-y-1/2 p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors"
+              aria-label="下一张"
+            >
+              <ChevronRight className="w-5 h-5" />
+            </button>
+          </>
+        )}
+
+        {/* 指示器 */}
+        {hasMultiple && (
+          <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-1.5">
+            {images.map((_, idx) => (
+              <button
+                key={idx}
+                onClick={(e) => { e.stopPropagation(); switchImage(idx); }}
+                className={`w-2 h-2 rounded-full transition-colors ${idx === activeIndex ? "bg-white" : "bg-white/50"}`}
+                aria-label={`切换到第 ${idx + 1} 张图片`}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Lightbox */}
+      {lightboxIndex !== null && (
+        <div className="fixed inset-0 z-50 bg-black/90 flex items-center justify-center">
+          <button
+            onClick={closeLightbox}
+            className="absolute top-4 right-4 p-2 rounded-full bg-white/10 text-white hover:bg-white/20 transition-colors"
+            aria-label="关闭"
+          >
+            <X className="w-6 h-6" />
+          </button>
+
+          <img
+            src={images[lightboxIndex]}
+            alt={locationName}
+            className="max-w-[90vw] max-h-[90vh] object-contain"
+          />
+
+          {hasMultiple && (
+            <>
+              <button
+                onClick={() => switchImage((lightboxIndex - 1 + images.length) % images.length)}
+                className="absolute left-4 top-1/2 -translate-y-1/2 p-3 rounded-full bg-white/10 text-white hover:bg-white/20 transition-colors"
+                aria-label="上一张"
+              >
+                <ChevronLeft className="w-6 h-6" />
+              </button>
+              <button
+                onClick={() => switchImage((lightboxIndex + 1) % images.length)}
+                className="absolute right-4 top-1/2 -translate-y-1/2 p-3 rounded-full bg-white/10 text-white hover:bg-white/20 transition-colors"
+                aria-label="下一张"
+              >
+                <ChevronRight className="w-6 h-6" />
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/features/location-detail/location-detail-header.tsx
+++ b/frontend/src/components/features/location-detail/location-detail-header.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { MapPin, Pencil } from "lucide-react";
+import { useI18n } from "@/hooks/useI18n";
+import type { Location } from "@/lib/types";
+
+interface LocationDetailHeaderProps {
+  location: Location;
+  isAdmin: boolean;
+  heroDifficulty?: string;
+  diffInfo: {
+    label: string;
+    dot: string;
+    text: string;
+    pill: string;
+  };
+}
+
+export function LocationDetailHeader({
+  location,
+  isAdmin,
+  heroDifficulty,
+  diffInfo,
+}: LocationDetailHeaderProps) {
+  const { t } = useI18n(["locationDetail", "common"]);
+
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+      <div className="flex-1">
+        {/* 标题 */}
+        <div className="flex items-center gap-3 mb-2">
+          <div className="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center">
+            <MapPin className="w-5 h-5 text-primary" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-foreground">
+              {location.name}
+            </h1>
+            {location.subtitle && (
+              <p className="text-sm text-muted-foreground">
+                {location.subtitle}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* 难度标签 */}
+        {heroDifficulty && (
+          <div className="flex items-center gap-2 ml-[52px]">
+            <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium border ${diffInfo.pill}`}>
+              <span className={`w-1.5 h-1.5 rounded-full ${diffInfo.dot}`} />
+              {diffInfo.label}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* 操作按钮 */}
+      <div className="flex items-center gap-2">
+        {isAdmin && (
+          <a
+            href={`/locations/${location.slug}/edit`}
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-border text-sm font-medium hover:bg-accent transition-colors"
+          >
+            <Pencil className="w-4 h-4" />
+            {t("common.edit")}
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/features/location-detail/location-detail-info.tsx
+++ b/frontend/src/components/features/location-detail/location-detail-info.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { MapPin, Clock, Ruler, TrendingUp } from "lucide-react";
+import { useI18n } from "@/hooks/useI18n";
+import type { Location } from "@/lib/types";
+
+interface LocationDetailInfoProps {
+  location: Location;
+  primaryRoute?: {
+    duration?: string;
+    distance?: string;
+    elevation?: string;
+  };
+}
+
+export function LocationDetailInfo({ location, primaryRoute }: LocationDetailInfoProps) {
+  const { t } = useI18n(["locationDetail", "locations", "common"]);
+
+  return (
+    <div className="space-y-6">
+      {/* 地址 */}
+      {(location.address || location.cityName) && (
+        <div className="flex items-start gap-3">
+          <MapPin className="w-5 h-5 text-muted-foreground mt-0.5 shrink-0" />
+          <div>
+            <p className="text-sm text-foreground">
+              {[location.cityName, location.address].filter(Boolean).join(" · ")}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* 路线信息 */}
+      {primaryRoute && (
+        <div className="grid grid-cols-3 gap-4">
+          {primaryRoute.duration && (
+            <div className="flex items-center gap-2">
+              <Clock className="w-4 h-4 text-muted-foreground" />
+              <div>
+                <p className="text-xs text-muted-foreground">{t("locations.estimatedTime")}</p>
+                <p className="text-sm font-medium">{primaryRoute.duration}</p>
+              </div>
+            </div>
+          )}
+          {primaryRoute.distance && (
+            <div className="flex items-center gap-2">
+              <Ruler className="w-4 h-4 text-muted-foreground" />
+              <div>
+                <p className="text-xs text-muted-foreground">{t("locations.routeLength")}</p>
+                <p className="text-sm font-medium">{primaryRoute.distance}</p>
+              </div>
+            </div>
+          )}
+          {primaryRoute.elevation && (
+            <div className="flex items-center gap-2">
+              <TrendingUp className="w-4 h-4 text-muted-foreground" />
+              <div>
+                <p className="text-xs text-muted-foreground">{t("locations.totalElevation")}</p>
+                <p className="text-sm font-medium">{primaryRoute.elevation}</p>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* 描述 */}
+      {location.description && (
+        <div className="prose prose-sm max-w-none">
+          <p className="text-muted-foreground leading-relaxed">
+            {location.description}
+          </p>
+        </div>
+      )}
+
+      {/* 标签 */}
+      {location.tags && location.tags.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {location.tags.map((tag) => (
+            <span
+              key={tag.id}
+              className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-primary/10 text-primary"
+            >
+              #{tag.name}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/features/location-detail/location-detail-related.tsx
+++ b/frontend/src/components/features/location-detail/location-detail-related.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { MapPin } from "lucide-react";
+import { useI18n } from "@/hooks/useI18n";
+import type { Location } from "@/lib/types";
+
+interface LocationDetailRelatedProps {
+  locations: Location[];
+}
+
+export function LocationDetailRelated({ locations }: LocationDetailRelatedProps) {
+  const { t } = useI18n(["locationDetail", "common"]);
+
+  if (locations.length === 0) return null;
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold text-foreground">
+        {t("locationDetail.relatedTitle") || "相关地点"}
+      </h2>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        {locations.map((location) => (
+          <a
+            key={location.id}
+            href={`/locations/${location.slug || location.id}`}
+            className="group"
+          >
+            <div className="aspect-[4/3] rounded-lg overflow-hidden mb-2">
+              {location.coverImage ? (
+                <img
+                  src={location.coverImage}
+                  alt={location.name}
+                  className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                />
+              ) : (
+                <div className="w-full h-full bg-muted flex items-center justify-center">
+                  <MapPin className="w-8 h-8 text-muted-foreground" />
+                </div>
+              )}
+            </div>
+            <h3 className="text-sm font-medium text-foreground group-hover:text-primary transition-colors">
+              {location.name}
+            </h3>
+            {location.cityName && (
+              <p className="text-xs text-muted-foreground">{location.cityName}</p>
+            )}
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/features/location-detail/location-detail-teams.tsx
+++ b/frontend/src/components/features/location-detail/location-detail-teams.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Users, ChevronRight } from "lucide-react";
+import { useI18n } from "@/hooks/useI18n";
+import type { Team } from "@/lib/types";
+
+interface LocationDetailTeamsProps {
+  teams: Team[];
+  locationSlug?: string;
+}
+
+export function LocationDetailTeams({ teams, locationSlug }: LocationDetailTeamsProps) {
+  const { t } = useI18n(["locationDetail", "teams", "common"]);
+
+  if (teams.length === 0) return null;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-foreground">
+          {t("locationDetail.browseTeams")}
+        </h2>
+        {locationSlug && (
+          <a
+            href={`/teams?location=${locationSlug}`}
+            className="text-sm text-primary hover:text-primary/80 transition-colors flex items-center gap-1"
+          >
+            {t("common.viewAll")}
+            <ChevronRight className="w-4 h-4" />
+          </a>
+        )}
+      </div>
+
+      <div className="space-y-3">
+        {teams.map((team) => (
+          <a
+            key={team.id}
+            href={`/teams/${team.id}`}
+            className="flex items-center gap-3 p-3 rounded-lg border border-border hover:bg-accent transition-colors"
+          >
+            <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center">
+              <Users className="w-5 h-5 text-primary" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-foreground truncate">
+                {team.title}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {team.members?.length ?? 0}/{team.maxMembers} {t("common.person")}
+              </p>
+            </div>
+            <ChevronRight className="w-4 h-4 text-muted-foreground shrink-0" />
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Split location-detail-client.tsx (1025 lines) into focused subcomponents.

## New Subcomponents

### LocationDetailHeader (location-detail-header.tsx)
- Title with icon
- Difficulty badge
- Admin edit button

### LocationDetailInfo (location-detail-info.tsx)
- Address display
- Route metrics (duration, distance, elevation)
- Description
- Tags

### LocationDetailTeams (location-detail-teams.tsx)
- Related teams list
- "View all" link

### LocationDetailRelated (location-detail-related.tsx)
- Related locations grid
- Cover images with hover effect

## Custom Hooks Used
- `useLocationDetail`: data fetching, loading, error
- `useLocationFavorite`: favorite state and toggle
- `useImageGallery`: image gallery, lightbox, parallax

## Impact
- Main component: 1025 → 418 lines (-59%)
- Better separation of concerns
- Reusable subcomponents

## Verification
- [x] `pnpm build` passes
- [x] `pnpm lint` passes (0 errors)

Closes #113 (Phase 1)