### PR TITLE
refactor(frontend): import CSS utility classes (#113 Phase 3)

### DIFF
--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
+@import "./icon-sizes.css";
 
 /* ============================================================
    GoMate Design System v2.0 — globals.css


### PR DESCRIPTION
## Summary
Import CSS utility classes into globals.css for use across components.

## Changes

### globals.css
- Import `icon-sizes.css` at top level
- Makes utility classes available globally

### Available Classes

#### Icon Sizes
- `.icon-xs` (h-3 w-3)
- `.icon-sm` (h-3.5 w-3.5)
- `.icon-md` (h-4 w-4)
- `.icon-lg` (h-5 w-5)
- `.icon-xl` (h-6 w-6)

#### Spacing
- `.gap-xs` through `.gap-lg`

#### Text
- `.text-caption` (text-xs text-muted-foreground)
- `.text-body-sm` (text-sm text-muted-foreground)

#### Layout
- `.container-narrow` (max-w-7xl mx-auto px-4 sm:px-6 lg:px-8)
- `.grid-responsive` (grid grid-cols-1 sm:grid-cols-2 gap-4)

## Verification
- [x] `pnpm build` passes

Closes #113 (Phase 3)