### PR TITLE
refactor(frontend): use safeFetch in favorites-client (#113 Phase 4)

### DIFF
--- a/frontend/src/components/features/favorites-client.tsx
+++ b/frontend/src/components/features/favorites-client.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { Heart, MapPin, ArrowLeft, Mountain } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import { fetchAPI, fetchCurrentUser } from "@/lib/api";
+import { safeFetch } from "@/lib/api-helpers";
 import { Navbar } from "@/components/layout/navbar";
 import { Footer } from "@/components/layout/footer";
 
@@ -46,7 +47,7 @@ export function FavoritesClient() {
   const loadFavorites = async () => {
     setIsLoading(true);
     setError(null);
-    const data = await safeFetch<{ favorites: { entityId: string }[] }>("/favorites?entityType=location");
+    const data = await safeFetch<{ favorites: FavoriteLocation[] }>("/favorites?entityType=location");
     if (data?.favorites) {
       setFavorites(data.favorites);
     } else {

--- a/frontend/src/components/features/favorites-client.tsx
+++ b/frontend/src/components/features/favorites-client.tsx
@@ -46,17 +46,14 @@ export function FavoritesClient() {
   const loadFavorites = async () => {
     setIsLoading(true);
     setError(null);
-    try {
-      const res = await fetchAPI("/favorites?entityType=location");
-      if (!res.ok) throw new Error("failed");
-      const data = await res.json();
-      setFavorites(data.favorites || []);
-    } catch {
+    const data = await safeFetch<{ favorites: { entityId: string }[] }>("/favorites?entityType=location");
+    if (data?.favorites) {
+      setFavorites(data.favorites);
+    } else {
       setError(t("favorites.loadFailed") || "加载失败");
       setFavorites([]);
-    } finally {
-      setIsLoading(false);
     }
+    setIsLoading(false);
   };
 
   const handleRemove = async (entityId: string) => {


### PR DESCRIPTION
## Summary
Simplify error handling in favorites-client.tsx using safeFetch.

## Changes

### favorites-client.tsx
- Replace try-catch in `loadFavorites` with `safeFetch`
- Add type annotation for API response
- Remove manual error checking (`if (!res.ok) throw`)

## Impact
- Simpler error handling
- Consistent with other components using safeFetch
- Reduced code by 3 lines

## Verification
- [x] `pnpm build` passes

Closes #113 (Phase 4)