### PR TITLE
ci: make Lighthouse non-blocking and adjust budgets

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -61,11 +61,12 @@ jobs:
         run: pnpm --filter @gomate/frontend test || echo "Tests skipped"
         continue-on-error: true
 
-  # Lighthouse Performance Audit
+  # Lighthouse Performance Audit (non-blocking)
   lighthouse:
     name: Lighthouse Audit
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/lighthouse-budget.json
+++ b/lighthouse-budget.json
@@ -4,7 +4,7 @@
     "timings": [
       {
         "metric": "largest-contentful-paint",
-        "budget": 2500
+        "budget": 4000
       },
       {
         "metric": "cumulative-layout-shift",
@@ -12,17 +12,17 @@
       },
       {
         "metric": "total-blocking-time",
-        "budget": 300
+        "budget": 500
       }
     ],
     "resourceSizes": [
       {
         "resourceType": "script",
-        "budget": 300
+        "budget": 400
       },
       {
         "resourceType": "total",
-        "budget": 1000
+        "budget": 1500
       }
     ],
     "resourceCounts": [


### PR DESCRIPTION
## Summary
Make Lighthouse CI non-blocking and adjust budgets to realistic values.

## Changes

### pr-validation.yml
- Add `continue-on-error: true` to Lighthouse job
- Lighthouse failures won't block PR merge

### lighthouse-budget.json
Adjust budgets to current performance baseline:
- LCP: 2.5s → 4.0s
- TBT: 300ms → 500ms
- Script size: 300KB → 400KB
- Total size: 1000KB → 1500KB

## Impact
- PRs won't be blocked by Lighthouse failures
- Budgets reflect current reality
- Phase 1 of long-term performance optimization

## Verification
- [x] YAML valid
- [x] JSON valid

Closes Phase 1