### PR TITLE
perf(frontend): add lazy loading for discover page

### DIFF
--- a/frontend/src/components/features/lazy-discover-client.tsx
+++ b/frontend/src/components/features/lazy-discover-client.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import * as React from "react";
+
+const DiscoverMain = React.lazy(
+  () => import("@/components/features/discover-client").then((m) => ({
+    default: m.DiscoverMain,
+  }))
+);
+
+const StoryDetail = React.lazy(
+  () => import("@/components/features/discover-client").then((m) => ({
+    default: m.StoryDetail,
+  }))
+);
+
+interface LazyDiscoverMainProps {
+  [key: string]: unknown;
+}
+
+export function LazyDiscoverMain(props: LazyDiscoverMainProps) {
+  return (
+    <React.Suspense fallback={<DiscoverLoadingSkeleton />}>
+      <DiscoverMain {...props} />
+    </React.Suspense>
+  );
+}
+
+interface LazyStoryDetailProps {
+  [key: string]: unknown;
+}
+
+export function LazyStoryDetail(props: LazyStoryDetailProps) {
+  return (
+    <React.Suspense fallback={<StoryDetailLoadingSkeleton />}>
+      <StoryDetail {...props} />
+    </React.Suspense>
+  );
+}
+
+function DiscoverLoadingSkeleton() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="pt-20 sm:pt-24 pb-5 sm:pb-6">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center gap-3 mb-2">
+            <div className="w-8 h-8 rounded-lg bg-muted animate-pulse" />
+            <div className="h-8 w-48 bg-muted rounded animate-pulse" />
+          </div>
+          <div className="h-4 w-64 bg-muted rounded animate-pulse mt-2" />
+        </div>
+      </div>
+      <div className="max-w-4xl mx-auto px-3 sm:px-6 lg:px-8 pb-12">
+        <div className="space-y-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-32 bg-muted rounded-xl animate-pulse" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StoryDetailLoadingSkeleton() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="pt-20 pb-8">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="h-[400px] bg-muted rounded-xl animate-pulse mb-8" />
+          <div className="space-y-4">
+            <div className="h-8 w-64 bg-muted rounded animate-pulse" />
+            <div className="h-4 w-full bg-muted rounded animate-pulse" />
+            <div className="h-4 w-3/4 bg-muted rounded animate-pulse" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/features/lazy-discover-client.tsx
+++ b/frontend/src/components/features/lazy-discover-client.tsx
@@ -27,13 +27,13 @@ export function LazyDiscoverMain(props: LazyDiscoverMainProps) {
 }
 
 interface LazyStoryDetailProps {
-  [key: string]: unknown;
+  storyId: string;
 }
 
-export function LazyStoryDetail(props: LazyStoryDetailProps) {
+export function LazyStoryDetail({ storyId }: LazyStoryDetailProps) {
   return (
     <React.Suspense fallback={<StoryDetailLoadingSkeleton />}>
-      <StoryDetail {...props} />
+      <StoryDetail storyId={storyId} />
     </React.Suspense>
   );
 }

--- a/frontend/src/pages/discover/index.astro
+++ b/frontend/src/pages/discover/index.astro
@@ -3,12 +3,12 @@
  * 发现页 - 故事列表
  */
 import Layout from "../../layouts/Layout.astro";
-import { DiscoverMain } from "../../components/features/discover-client";
+import { LazyDiscoverMain } from "../../components/features/lazy-discover-client";
 import { declareI18nNs } from "../../middleware";
 
 declareI18nNs(Astro.locals, ["content", "common"]);
 ---
 
 <Layout title="发现 - GoMate" showNavbar={true} showFooter={true}>
-  <DiscoverMain client:visible />
+  <LazyDiscoverMain client:visible />
 </Layout>


### PR DESCRIPTION
## Summary
Add lazy loading for discover page to improve initial load performance.

## Changes

### lazy-discover-client.tsx
- `LazyDiscoverMain`: React.lazy + Suspense wrapper
- `LazyStoryDetail`: React.lazy + Suspense wrapper
- Loading skeletons for both components

### discover/index.astro
- Replace direct import with lazy component
- Reduces initial JavaScript bundle size

## Impact
- Smaller initial JS bundle
- Faster first contentful paint
- Better perceived performance with loading skeletons

## Verification
- [x] `pnpm build` passes

Phase 2 of long-term performance optimization.