### PR TITLE
perf(frontend): use client:visible for non-critical pages

### DIFF
--- a/frontend/src/pages/about.astro
+++ b/frontend/src/pages/about.astro
@@ -10,5 +10,5 @@ declareI18nNs(Astro.locals, ['nav', 'content']);
 ---
 
 <Layout title="关于我们 - GoMate">
-  <AboutClient client:load />
+  <AboutClient client:visible />
 </Layout>

--- a/frontend/src/pages/contact.astro
+++ b/frontend/src/pages/contact.astro
@@ -10,5 +10,5 @@ declareI18nNs(Astro.locals, ["feedback", "content"]);
 ---
 
 <Layout title="联系我们 - GoMate">
-  <ContactClient client:load />
+  <ContactClient client:visible />
 </Layout>

--- a/frontend/src/pages/feedback.astro
+++ b/frontend/src/pages/feedback.astro
@@ -10,5 +10,5 @@ declareI18nNs(Astro.locals, ["feedback", "content"]);
 ---
 
 <Layout title="反馈建议 - GoMate">
-  <FeedbackClient client:load />
+  <FeedbackClient client:visible />
 </Layout>

--- a/frontend/src/pages/help.astro
+++ b/frontend/src/pages/help.astro
@@ -10,5 +10,5 @@ declareI18nNs(Astro.locals, ['nav', 'content']);
 ---
 
 <Layout title="帮助中心 - GoMate">
-  <HelpClient client:load />
+  <HelpClient client:visible />
 </Layout>

--- a/frontend/src/pages/privacy.astro
+++ b/frontend/src/pages/privacy.astro
@@ -10,5 +10,5 @@ declareI18nNs(Astro.locals, ['nav', 'content']);
 ---
 
 <Layout title="隐私政策 - GoMate">
-  <PrivacyClient client:load />
+  <PrivacyClient client:visible />
 </Layout>

--- a/frontend/src/pages/terms.astro
+++ b/frontend/src/pages/terms.astro
@@ -6,5 +6,5 @@ import { declareI18nNs } from "../middleware";
 declareI18nNs(Astro.locals, ['nav', 'content']);
 ---
 <Layout title="服务条款 - GoMate">
-  <TermsClient client:load />
+  <TermsClient client:visible />
 </Layout>


### PR DESCRIPTION
## Summary
Defer hydration for non-critical pages using `client:visible`.

## Changes

### Pages Updated
- about.astro
- terms.astro
- privacy.astro
- help.astro
- contact.astro
- feedback.astro

All changed from `client:load` to `client:visible`.

## Impact
- Smaller initial JavaScript bundle
- Faster first contentful paint
- Components only hydrate when scrolled into view

## Verification
- [x] `pnpm build` passes

Phase 2b of long-term performance optimization.