### PR TITLE
perf: tighten Lighthouse budget after optimizations

### DIFF
--- a/lighthouse-budget.json
+++ b/lighthouse-budget.json
@@ -4,7 +4,7 @@
     "timings": [
       {
         "metric": "largest-contentful-paint",
-        "budget": 4000
+        "budget": 3500
       },
       {
         "metric": "cumulative-layout-shift",
@@ -12,17 +12,17 @@
       },
       {
         "metric": "total-blocking-time",
-        "budget": 500
+        "budget": 400
       }
     ],
     "resourceSizes": [
       {
         "resourceType": "script",
-        "budget": 400
+        "budget": 350
       },
       {
         "resourceType": "total",
-        "budget": 1500
+        "budget": 1200
       }
     ],
     "resourceCounts": [


### PR DESCRIPTION
## Summary
Tighten Lighthouse performance budget after Phase 1-3 optimizations.

## Budget Changes

| Metric | Before | After | Target |
|--------|--------|-------|--------|
| LCP | 4.0s | 3.5s | 2.5s |
| TBT | 500ms | 400ms | 300ms |
| Script | 400KB | 350KB | 300KB |
| Total | 1500KB | 1200KB | 1000KB |

## Verification
- [x] JSON valid

Phase 4 of long-term performance optimization.