### PR TITLE
perf(frontend): add Vite manual chunks for code splitting

### DIFF
--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -40,5 +40,16 @@ export default defineConfig({
         env.PUBLIC_AMAP_KEY || ""
       ),
     },
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            // 将大型依赖拆分为独立 chunk
+            'vendor-lucide': ['lucide-react'],
+            'vendor-markdown': ['react-markdown', 'remark-gfm'],
+          },
+        },
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
Add Vite manual chunks to split large dependencies into separate bundles.

## Changes

### astro.config.mjs
Add `build.rollupOptions.output.manualChunks`:
- `vendor-lucide`: lucide-react icons (~100KB)
- `vendor-markdown`: react-markdown + remark-gfm (~80KB)

## Impact
- Smaller main bundle
- Better browser caching (vendor chunks rarely change)
- Faster initial page load

## Verification
- [x] `pnpm build` passes

Phase 3 of frontend performance optimization.