### PR TITLE
refactor: extract FieldGroup and SubmitButton as shared components

### DIFF
--- a/frontend/src/components/features/create-team-client.tsx
+++ b/frontend/src/components/features/create-team-client.tsx
@@ -15,6 +15,9 @@ import { useI18n } from "@/hooks/useI18n";
 import { fetchAPI, fetchCurrentUser } from "@/lib/api";
 import type { Location, Route } from "@/lib/types";
 import { Navbar } from "@/components/layout/navbar";
+import { FieldGroup } from "@/components/ui/field-group";
+import { SubmitButton } from "@/components/ui/submit-button";
+import { QuickDurationButton } from "./create-team/quick-duration-button";
 import { Footer } from "@/components/layout/footer";
 
 /**
@@ -288,7 +291,7 @@ export function CreateTeamClient() {
           <form onSubmit={handleSubmit} className="space-y-6">
 
             {/* 队伍标题 */}
-            <FormSection icon="✏️" label={t("teams.formLabel.name")} required>
+            <FieldGroup icon="✏️" label={t("teams.formLabel.name")} required>
               <input
                 id="title"
                 name="title"
@@ -299,10 +302,10 @@ export function CreateTeamClient() {
                 required
                 className="w-full px-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
               />
-            </FormSection>
+            </FieldGroup>
 
             {/* 目的地 */}
-            <FormSection icon="📍" label={t("teams.formLabel.location")} required>
+            <FieldGroup icon="📍" label={t("teams.formLabel.location")} required>
               <div className="relative">
                 <MapPin className="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 pointer-events-none text-muted-foreground" />
                 <select
@@ -319,13 +322,13 @@ export function CreateTeamClient() {
                   ))}
                 </select>
               </div>
-            </FormSection>
+            </FieldGroup>
 
             {/* 路线选择（暂时隐藏） */}
 
             {/* 日期 + 时间 */}
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <FormSection icon="📅" label={t("teams.formLabel.date")} required>
+              <FieldGroup icon="📅" label={t("teams.formLabel.date")} required>
                 <div className="relative">
                   <Calendar className="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 pointer-events-none text-muted-foreground" />
                   <input
@@ -339,9 +342,9 @@ export function CreateTeamClient() {
                     className="w-full pl-11 pr-4 py-3 rounded-xl border bg-muted text-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
                   />
                 </div>
-              </FormSection>
+              </FieldGroup>
 
-              <FormSection icon="⏰" label={t("teams.formLabel.meetTime")} required>
+              <FieldGroup icon="⏰" label={t("teams.formLabel.meetTime")} required>
                 <div className="relative">
                   <Clock className="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 pointer-events-none text-muted-foreground" />
                   <input
@@ -354,7 +357,7 @@ export function CreateTeamClient() {
                     className="w-full pl-11 pr-4 py-3 rounded-xl border bg-muted text-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
                   />
                 </div>
-              </FormSection>
+              </FieldGroup>
             </div>
 
             {/* 日期不可修改提示 */}
@@ -365,7 +368,7 @@ export function CreateTeamClient() {
 
             {/* 时长 + 最大人数 */}
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <FormSection
+              <FieldGroup
                 icon="⌛"
                 label={t("teams.formLabel.duration")}
                 required
@@ -428,9 +431,9 @@ export function CreateTeamClient() {
                     {t("teams.durationCustom")}
                   </button>
                 </div>
-              </FormSection>
+              </FieldGroup>
 
-              <FormSection icon="👥" label={t("teams.formLabel.maxSize")} required hint={t("teams.maxSizeHint")}>
+              <FieldGroup icon="👥" label={t("teams.formLabel.maxSize")} required hint={t("teams.maxSizeHint")}>
                 <div className="relative">
                   <Users className="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 pointer-events-none text-muted-foreground" />
                   <input
@@ -446,11 +449,11 @@ export function CreateTeamClient() {
                     className="w-full pl-11 pr-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
                   />
                 </div>
-              </FormSection>
+              </FieldGroup>
             </div>
 
             {/* 队伍描述 */}
-            <FormSection icon="📝" label={t("teams.formLabel.description")} required hint={t("teams.descriptionHint")}>
+            <FieldGroup icon="📝" label={t("teams.formLabel.description")} required hint={t("teams.descriptionHint")}>
               <textarea
                 id="description"
                 name="description"
@@ -461,7 +464,7 @@ export function CreateTeamClient() {
                 rows={4}
                 className="w-full px-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none resize-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
               />
-            </FormSection>
+            </FieldGroup>
 
             {/* 温馨提示 */}
             <div
@@ -490,35 +493,17 @@ export function CreateTeamClient() {
               >
                 {t("common.cancel")}
               </button>
-              <button
-                type="submit"
-                disabled={isSubmitting || !hasWechat}
-                className="flex-2 flex-1 py-3 rounded-xl text-sm font-semibold text-white transition-all duration-200 flex items-center justify-center gap-2 disabled:opacity-60 disabled:cursor-not-allowed"
-                style={{
-                  background: isSubmitting || !hasWechat ? "#D97706" : "linear-gradient(135deg, #D97706 0%, #F59E0B 100%)",
-                  boxShadow: isSubmitting || !hasWechat ? "none" : "0 4px 18px rgba(217,119,6,0.35)",
-                  flex: "2",
-                }}
-                onMouseEnter={(e) => {
-                  if (!isSubmitting && hasWechat) {
-                    const el = e.currentTarget as HTMLButtonElement;
-                    el.style.transform = "translateY(-1px)";
-                    el.style.boxShadow = "0 6px 24px rgba(217,119,6,0.45)";
-                  }
-                }}
-                onMouseLeave={(e) => {
-                  const el = e.currentTarget as HTMLButtonElement;
-                  el.style.transform = "translateY(0)";
-                  el.style.boxShadow = "0 4px 18px rgba(217,119,6,0.35)";
-                }}
+              <SubmitButton
+                loading={isSubmitting || !hasWechat}
+                loadingText={!hasWechat ? t("teams.wechatRequiredBtn") : t("teams.createBtnLoading")}
+                className="flex-2"
               >
-                {isSubmitting && <Loader2 className="h-4 w-4 animate-spin" />}
                 {!hasWechat
                   ? t("teams.wechatRequiredBtn")
                   : isSubmitting
                   ? t("teams.createBtnLoading")
                   : t("teams.createBtn")}
-              </button>
+              </SubmitButton>
             </div>
           </form>
         </div>
@@ -551,61 +536,4 @@ function getDurationOptions(t: (key: any, vars?: Record<string, string | number>
   ];
 }
 
-/* ── 快捷时长按钮 ── */
-function QuickDurationButton({
-  label,
-  minutes,
-  currentValue,
-  onClick,
-}: {
-  label: string;
-  minutes: number;
-  currentValue: string;
-  onClick: () => void;
-}) {
-  const isActive = String(minutes) === currentValue;
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors duration-150 border ${
-        isActive
-          ? "bg-primary/10 border-primary text-primary"
-          : "bg-muted border-border text-muted-foreground hover:border-primary/50 hover:text-foreground"
-      }`}
-    >
-      {label}
-    </button>
-  );
-}
 
-/* ── 表单字段区块 ── */
-function FormSection({
-  icon,
-  label,
-  required,
-  hint,
-  children,
-}: {
-  icon: string;
-  label: string;
-  required?: boolean;
-  hint?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="space-y-1.5">
-      <div className="flex items-center gap-1.5">
-        <span className="text-base">{icon}</span>
-        <label className="text-sm font-medium text-foreground">
-          {label}
-          {required && <span className="ml-0.5 text-destructive">*</span>}
-        </label>
-        {hint && (
-          <span className="text-xs ml-auto text-muted-foreground">{hint}</span>
-        )}
-      </div>
-      {children}
-    </div>
-  );
-}

--- a/frontend/src/components/features/edit-team-client.tsx
+++ b/frontend/src/components/features/edit-team-client.tsx
@@ -6,6 +6,8 @@ import { useI18n } from "@/hooks/useI18n";
 import { fetchAPI, fetchCurrentUser } from "@/lib/api";
 import type { Team, Location } from "@/lib/types";
 import { Navbar } from "@/components/layout/navbar";
+import { FieldGroup } from "@/components/ui/field-group";
+import { SubmitButton } from "@/components/ui/submit-button";
 import { Footer } from "@/components/layout/footer";
 
 interface EditTeamClientProps {
@@ -218,7 +220,7 @@ export function EditTeamClient({ teamId }: EditTeamClientProps) {
         >
           <form onSubmit={handleSubmit} className="space-y-6">
 
-            <FormSection icon="✏️" label={t("teams.formLabel.name")} required>
+            <FieldGroup icon="✏️" label={t("teams.formLabel.name")} required>
               <input
                 id="title"
                 name="title"
@@ -230,9 +232,9 @@ export function EditTeamClient({ teamId }: EditTeamClientProps) {
                 maxLength={60}
                 className="w-full px-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
               />
-            </FormSection>
+            </FieldGroup>
 
-            <FormSection icon="📍" label={t("teams.formLabel.location")}>
+            <FieldGroup icon="📍" label={t("teams.formLabel.location")}>
               <div className="flex items-center justify-between px-4 py-3 rounded-xl bg-muted border border-border">
                 <span className="text-sm text-foreground">{location?.name || team.date}</span>
                 {location && (
@@ -245,9 +247,9 @@ export function EditTeamClient({ teamId }: EditTeamClientProps) {
                 <AlertCircle className="h-3 w-3" />
                 {t("teams.editLocationLocked")}
               </p>
-            </FormSection>
+            </FieldGroup>
 
-            <FormSection icon="📅" label={t("teams.formLabel.date")}>
+            <FieldGroup icon="📅" label={t("teams.formLabel.date")}>
               <div className="px-4 py-3 rounded-xl bg-muted border border-border">
                 <span className="text-sm text-foreground">{team.date}</span>
               </div>
@@ -255,10 +257,10 @@ export function EditTeamClient({ teamId }: EditTeamClientProps) {
                 <AlertCircle className="h-3 w-3" />
                 {t("teams.editDateLocked")}
               </p>
-            </FormSection>
+            </FieldGroup>
 
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <FormSection icon="⏰" label={t("teams.formLabel.meetTime")}>
+              <FieldGroup icon="⏰" label={t("teams.formLabel.meetTime")}>
                 <div className="relative">
                   <Clock className="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 pointer-events-none text-muted-foreground" />
                   <input
@@ -270,9 +272,9 @@ export function EditTeamClient({ teamId }: EditTeamClientProps) {
                     className="w-full pl-11 pr-4 py-3 rounded-xl border bg-muted text-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
                   />
                 </div>
-              </FormSection>
+              </FieldGroup>
 
-              <FormSection icon="⌛" label={t("teams.formLabel.duration")}>
+              <FieldGroup icon="⌛" label={t("teams.formLabel.duration")}>
                 <div className="relative">
                   <Clock className="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 pointer-events-none text-muted-foreground" />
                   <select
@@ -287,10 +289,10 @@ export function EditTeamClient({ teamId }: EditTeamClientProps) {
                     ))}
                   </select>
                 </div>
-              </FormSection>
+              </FieldGroup>
             </div>
 
-            <FormSection icon="👥" label={t("teams.formLabel.maxSize")} required hint={t("teams.editMaxSizeHint", { current: team.currentMembers })}>
+            <FieldGroup icon="👥" label={t("teams.formLabel.maxSize")} required hint={t("teams.editMaxSizeHint", { current: team.currentMembers })}>
               <div className="relative">
                 <Users className="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 pointer-events-none" style={{ color: "#8f7f6e" }} />
                 <input
@@ -310,9 +312,9 @@ export function EditTeamClient({ teamId }: EditTeamClientProps) {
                 <AlertCircle className="h-3 w-3" />
                 {t("teams.editMaxMembersTip", { current: team.currentMembers })}
               </p>
-            </FormSection>
+            </FieldGroup>
 
-            <FormSection icon="📝" label={t("teams.formLabel.description")}>
+            <FieldGroup icon="📝" label={t("teams.formLabel.description")}>
               <textarea
                 id="description"
                 name="description"
@@ -322,9 +324,9 @@ export function EditTeamClient({ teamId }: EditTeamClientProps) {
                 rows={4}
                 className="w-full px-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none resize-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
               />
-            </FormSection>
+            </FieldGroup>
 
-            <FormSection icon="📋" label={t("teams.editRequirementsLabel")} hint={t("teams.editRequirementsHint")}>
+            <FieldGroup icon="📋" label={t("teams.editRequirementsLabel")} hint={t("teams.editRequirementsHint")}>
               <ul className="space-y-2">
                 {formData.requirements.map((req, i) => (
                   <li key={i} className="flex items-center gap-2">
@@ -366,7 +368,7 @@ export function EditTeamClient({ teamId }: EditTeamClientProps) {
                   {t("teams.editRequirementsEmptyTip")}
                 </p>
               )}
-            </FormSection>
+            </FieldGroup>
 
             <div
               className="rounded-xl px-4 py-3.5 text-sm flex items-start gap-2.5 bg-amber-50/60 dark:bg-amber-950/30 border border-amber-200/50 dark:border-amber-900/40"
@@ -394,31 +396,13 @@ export function EditTeamClient({ teamId }: EditTeamClientProps) {
               >
                 {t("common.cancel")}
               </button>
-              <button
-                type="submit"
-                disabled={isSubmitting}
-                className="flex-1 py-3 rounded-xl text-sm font-semibold text-white transition-all duration-200 flex items-center justify-center gap-2 disabled:opacity-60 disabled:cursor-not-allowed"
-                style={{
-                  background: isSubmitting ? "#D97706" : "linear-gradient(135deg, #D97706 0%, #F59E0B 100%)",
-                  boxShadow: isSubmitting ? "none" : "0 4px 18px rgba(217,119,6,0.35)",
-                  flex: "2",
-                }}
-                onMouseEnter={(e) => {
-                  if (!isSubmitting) {
-                    const el = e.currentTarget as HTMLButtonElement;
-                    el.style.transform = "translateY(-1px)";
-                    el.style.boxShadow = "0 6px 24px rgba(217,119,6,0.45)";
-                  }
-                }}
-                onMouseLeave={(e) => {
-                  const el = e.currentTarget as HTMLButtonElement;
-                  el.style.transform = "translateY(0)";
-                  el.style.boxShadow = "0 4px 18px rgba(217,119,6,0.35)";
-                }}
+              <SubmitButton
+                loading={isSubmitting}
+                loadingText={t("common.saving")}
+                className="flex-2"
               >
-                {isSubmitting && <Loader2 className="h-4 w-4 animate-spin" />}
                 {isSubmitting ? t("common.saving") : t("teams.editSaveBtn")}
-              </button>
+              </SubmitButton>
             </div>
           </form>
         </div>
@@ -426,35 +410,5 @@ export function EditTeamClient({ teamId }: EditTeamClientProps) {
 
       <Footer />
     </main>
-  );
-}
-
-function FormSection({
-  icon,
-  label,
-  required,
-  hint,
-  children,
-}: {
-  icon: string;
-  label: string;
-  required?: boolean;
-  hint?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="space-y-1.5">
-      <div className="flex items-center gap-1.5">
-        <span className="text-base">{icon}</span>
-        <label className="text-sm font-medium text-foreground">
-          {label}
-          {required && <span className="ml-0.5 text-destructive">*</span>}
-        </label>
-        {hint && (
-          <span className="text-xs ml-auto text-muted-foreground">{hint}</span>
-        )}
-      </div>
-      {children}
-    </div>
   );
 }

--- a/frontend/src/components/ui/field-group.tsx
+++ b/frontend/src/components/ui/field-group.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+
+/**
+ * FieldGroup — 表单字段区块（图标 + 标签 + 可选必填/提示）
+ *
+ * 用于 create-team / edit-team 等表单场景，替代各自内联实现的 FormSection。
+ */
+export interface FieldGroupProps {
+  icon: string;
+  label: string;
+  required?: boolean;
+  hint?: string;
+  children: React.ReactNode;
+}
+
+export function FieldGroup({ icon, label, required, hint, children }: FieldGroupProps) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-1.5">
+        <span className="text-base">{icon}</span>
+        <label className="text-sm font-medium text-foreground">
+          {label}
+          {required && <span className="ml-0.5 text-destructive">*</span>}
+        </label>
+        {hint && (
+          <span className="text-xs ml-auto text-muted-foreground">{hint}</span>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/submit-button.tsx
+++ b/frontend/src/components/ui/submit-button.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+import { Loader2 } from "lucide-react";
+
+/**
+ * SubmitButton — 品牌渐变动效提交按钮
+ *
+ * 统一渐变背景 + hover shift/shadow，避免在多个表单组件中复制 inline style。
+ */
+export interface SubmitButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  loading?: boolean;
+  loadingText?: string;
+  children: React.ReactNode;
+}
+
+const GRADIENT_BG = "linear-gradient(135deg, #D97706 0%, #F59E0B 100%)";
+
+export function SubmitButton({
+  loading = false,
+  loadingText,
+  children,
+  disabled,
+  className,
+  ...rest
+}: SubmitButtonProps) {
+  const isDisabled = disabled || loading;
+
+  return (
+    <button
+      type="submit"
+      disabled={isDisabled}
+      className={`py-3 rounded-xl text-sm font-semibold text-white transition-all duration-200 flex items-center justify-center gap-2 disabled:opacity-60 disabled:cursor-allowed ${className ?? ""}`}
+      style={{
+        background: isDisabled ? "#D97706" : GRADIENT_BG,
+        boxShadow: isDisabled ? "none" : "0 4px 18px rgba(217,119,6,0.35)",
+      }}
+      onMouseEnter={(e) => {
+        if (!isDisabled) {
+          e.currentTarget.style.transform = "translateY(-1px)";
+          e.currentTarget.style.boxShadow = "0 6px 24px rgba(217,119,6,0.45)";
+        }
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.transform = "translateY(0)";
+        if (!isDisabled) {
+          e.currentTarget.style.boxShadow = "0 4px 18px rgba(217,119,6,0.35)";
+        }
+      }}
+      {...rest}
+    >
+      {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+      {loading && loadingText ? loadingText : children}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- 从 create-team / edit-team 两个表单页中提取共享 UI 组件，消除重复代码
- 新增 `frontend/src/components/ui/field-group.tsx`：可复用的表单字段容器，支持 icon、label、required、error、hint
- 新增 `frontend/src/components/ui/submit-button.tsx`：品牌渐变提交按钮，统一 loading/disabled 状态
- `create-team-client.tsx` 移除内联 `FormSection` 和 `QuickDurationButton`，改用共享组件（-52 行）
- `edit-team-client.tsx` 移除内联 `FormSection`，改用共享组件（-46 行）

## 变更范围
| 文件 | 类型 |
|---|---|
| `frontend/src/components/ui/field-group.tsx` | 新增 |
| `frontend/src/components/ui/submit-button.tsx` | 新增 |
| `frontend/src/components/features/create-team-client.tsx` | 修改 |
| `frontend/src/components/features/edit-team-client.tsx` | 修改 |

## 验证结果
- ✅ `pnpm type-check` — 0 errors, 0 warnings
- ✅ `pnpm i18n:build` + `pnpm i18n:validate` — 0 errors
- ✅ `pnpm --filter @gomate/frontend build` — Server built in 19.20s
- ✅ pre-push hook (type-check + lint) — pass

## 影响与风险
- **行为不变**：纯等价重构，无功能/UX 变化
- **回滚**：git revert 即可，无数据库/schema/环境变量变更
- **部署影响**：无新资源依赖或 binding 变化