### PR TITLE
refactor: consolidate difficulty config and extract badge styles

### DIFF
--- a/frontend/src/components/features/location-detail-client.tsx
+++ b/frontend/src/components/features/location-detail-client.tsx
@@ -23,6 +23,7 @@ import type { TranslationKey } from "@/i18n";
 import { fetchAPI } from "@/lib/api";
 import type { Location, Team } from "@/lib/types";
 import { cn } from "@/lib/utils";
+import { getDifficultyBadgeStyles } from "@/lib/difficulty-badge";
 import { Navbar } from "@/components/layout/navbar";
 import { Footer } from "@/components/layout/footer";
 import {
@@ -48,34 +49,6 @@ function getSeasonLabel(t: (key: TranslationKey) => string) {
   };
 }
 
-function getDifficultyInfo(t: (key: TranslationKey) => string) {
-  return {
-    easy: {
-      label: t("enums.difficulty.easy"),
-      dot: "bg-emerald-400",
-      text: "text-emerald-700 dark:text-emerald-400",
-      pill: "bg-emerald-500/20 text-emerald-100 border-emerald-400/30",
-    },
-    moderate: {
-      label: t("enums.difficulty.moderate"),
-      dot: "bg-amber-400",
-      text: "text-amber-700 dark:text-amber-400",
-      pill: "bg-amber-500/20 text-amber-100 border-amber-400/30",
-    },
-    hard: {
-      label: t("enums.difficulty.hard"),
-      dot: "bg-orange-500",
-      text: "text-orange-700 dark:text-orange-400",
-      pill: "bg-orange-500/20 text-orange-100 border-orange-400/30",
-    },
-    expert: {
-      label: t("enums.difficulty.expert"),
-      dot: "bg-red-500",
-      text: "text-red-700 dark:text-red-400",
-      pill: "bg-red-500/20 text-red-100 border-red-400/30",
-    },
-  };
-}
 
 // ─── 骨架屏 ───────────────────────────────────────────────────────────────────
 function LoadingNavbarSkeleton() {
@@ -753,7 +726,7 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
   const normalizedRoutes = normalizeLocationRoutes(location);
   const primaryRoute = normalizedRoutes[0];
   const heroDifficulty = location.difficulty ?? primaryRoute?.difficulty;
-  const diffInfo = getDifficultyInfo(t)[heroDifficulty as keyof ReturnType<typeof getDifficultyInfo>] ?? {
+  const diffInfo = getDifficultyBadgeStyles(key => t(key as TranslationKey))[heroDifficulty as keyof ReturnType<typeof getDifficultyBadgeStyles>] ?? {
     label: heroDifficulty || "",
     dot: "bg-stone-400",
     text: "text-stone-700",

--- a/frontend/src/components/features/location-detail/constants.tsx
+++ b/frontend/src/components/features/location-detail/constants.tsx
@@ -7,52 +7,6 @@ import {
   Star,
 } from "lucide-react";
 
-// ─── 难度配置 ─────────────────────────────────────────────────────────────────
-export const DIFFICULTY_CONFIG: Record<
-  string,
-  {
-    label: string;
-    barColor: string;
-    textColor: string;
-    bgColor: string;
-    percent: number;
-    ringColor: string;
-  }
-> = {
-  easy: {
-    label: "enums.difficulty.easy",
-    barColor: "bg-emerald-400",
-    textColor: "text-emerald-700 dark:text-emerald-400",
-    bgColor: "bg-emerald-50 dark:bg-emerald-950/30",
-    percent: 25,
-    ringColor: "ring-emerald-200 dark:ring-emerald-800",
-  },
-  moderate: {
-    label: "enums.difficulty.moderate",
-    barColor: "bg-amber-400",
-    textColor: "text-amber-700 dark:text-amber-400",
-    bgColor: "bg-amber-50 dark:bg-amber-950/30",
-    percent: 50,
-    ringColor: "ring-amber-200 dark:ring-amber-800",
-  },
-  hard: {
-    label: "enums.difficulty.hard",
-    barColor: "bg-orange-500",
-    textColor: "text-orange-700 dark:text-orange-400",
-    bgColor: "bg-orange-50 dark:bg-orange-950/30",
-    percent: 75,
-    ringColor: "ring-orange-200 dark:ring-orange-800",
-  },
-  expert: {
-    label: "enums.difficulty.expert",
-    barColor: "bg-red-500",
-    textColor: "text-red-700 dark:text-red-400",
-    bgColor: "bg-red-50 dark:bg-red-950/30",
-    percent: 100,
-    ringColor: "ring-red-200 dark:ring-red-800",
-  },
-};
-
 // POI 类型图标映射
 export const POI_ICON_MAP: Record<string, React.ReactNode> = {
   waypoint: <Navigation className="h-3.5 w-3.5" />,

--- a/frontend/src/components/features/location-detail/route-info-card.tsx
+++ b/frontend/src/components/features/location-detail/route-info-card.tsx
@@ -11,7 +11,7 @@ import {
 import { useI18n } from "@/hooks/useI18n";
 import { cn } from "@/lib/utils";
 import type { Location } from "@/lib/types";
-import { DIFFICULTY_CONFIG } from "./constants";
+import { DIFFICULTY_CONFIG } from "@/lib/constants";
 import {
   normalizeLocationRoutes,
   type NormalizedLocationRoute,

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -19,6 +19,11 @@ export const DIFFICULTY_CONFIG: Record<
     bg: string;
     color: string;
     activeColor: string;
+    barColor: string;
+    textColor: string;
+    bgColor: string;
+    percent: number;
+    ringColor: string;
   }
 > = {
   easy: {
@@ -28,6 +33,11 @@ export const DIFFICULTY_CONFIG: Record<
     bg: "rgba(217,119,6,0.85)",
     color: "#fff",
     activeColor: "bg-amber-600 border-amber-600 text-white",
+    barColor: "bg-emerald-400",
+    textColor: "text-emerald-700 dark:text-emerald-400",
+    bgColor: "bg-emerald-50 dark:bg-emerald-950/30",
+    percent: 25,
+    ringColor: "ring-emerald-200 dark:ring-emerald-800",
   },
   moderate: {
     label: "适中",
@@ -36,6 +46,11 @@ export const DIFFICULTY_CONFIG: Record<
     bg: "rgba(217,119,6,0.88)",
     color: "#fff",
     activeColor: "bg-amber-500 border-amber-500 text-white",
+    barColor: "bg-amber-400",
+    textColor: "text-amber-700 dark:text-amber-400",
+    bgColor: "bg-amber-50 dark:bg-amber-950/30",
+    percent: 50,
+    ringColor: "ring-amber-200 dark:ring-amber-800",
   },
   hard: {
     label: "困难",
@@ -44,6 +59,11 @@ export const DIFFICULTY_CONFIG: Record<
     bg: "rgba(255,122,101,0.90)",
     color: "#fff",
     activeColor: "bg-orange-500 border-orange-500 text-white",
+    barColor: "bg-orange-500",
+    textColor: "text-orange-700 dark:text-orange-400",
+    bgColor: "bg-orange-50 dark:bg-orange-950/30",
+    percent: 75,
+    ringColor: "ring-orange-200 dark:ring-orange-800",
   },
   expert: {
     label: "专家",
@@ -52,6 +72,11 @@ export const DIFFICULTY_CONFIG: Record<
     bg: "rgba(109,40,217,0.85)",
     color: "#fff",
     activeColor: "bg-red-500 border-red-500 text-white",
+    barColor: "bg-red-500",
+    textColor: "text-red-700 dark:text-red-400",
+    bgColor: "bg-red-50 dark:bg-red-950/30",
+    percent: 100,
+    ringColor: "ring-red-200 dark:ring-red-800",
   },
 };
 

--- a/frontend/src/lib/difficulty-badge.ts
+++ b/frontend/src/lib/difficulty-badge.ts
@@ -1,0 +1,43 @@
+import { DIFFICULTY_CONFIG } from "./constants";
+
+export interface BadgeStyle {
+  label: string;
+  dot: string;
+  text: string;
+  pill: string;
+}
+
+/**
+ * getDifficultyBadgeStyles — 生成地点详情页 hero 区域难度徽章样式
+ *
+ * 基于全局 DIFFICULTY_CONFIG，仅添加 badge 专属的 dot/pill 样式。
+ * @param labelResolver 接收 i18n key，返回本地化标签
+ */
+export function getDifficultyBadgeStyles(
+  labelResolver: (key: string) => string
+): Record<string, BadgeStyle> {
+  const dotColors: Record<string, string> = {
+    easy: "bg-emerald-400",
+    moderate: "bg-amber-400",
+    hard: "bg-orange-500",
+    expert: "bg-red-500",
+  };
+  const pillStyles: Record<string, string> = {
+    easy: "bg-emerald-500/20 text-emerald-100 border-emerald-400/30",
+    moderate: "bg-amber-500/20 text-amber-100 border-amber-400/30",
+    hard: "bg-orange-500/20 text-orange-100 border-orange-400/30",
+    expert: "bg-red-500/20 text-red-100 border-red-400/30",
+  };
+
+  const result = {} as Record<string, BadgeStyle>;
+  for (const key of Object.keys(DIFFICULTY_CONFIG)) {
+    const i18nKey = `enums.difficulty.${key}`;
+    result[key] = {
+      label: labelResolver(i18nKey),
+      dot: dotColors[key],
+      text: DIFFICULTY_CONFIG[key as keyof typeof DIFFICULTY_CONFIG].textColor,
+      pill: pillStyles[key],
+    };
+  }
+  return result;
+}


### PR DESCRIPTION
## 变更范围

1. **扩展全局 `DIFFICULTY_CONFIG`** — 在 `@/lib/constants.ts` 中增加 `barColor` / `textColor` / `bgColor` / `percent` / `ringColor` 字段，供进度条和 route info card 使用
2. **删除重复的 DIFFICULTY_CONFIG** — 从 `location-detail/constants.tsx` 移除本地副本，`route-info-card.tsx` 改为从 `@/lib/constants` 导入
3. **提取 `getDifficultyBadgeStyles` 共享函数** — 新增 `@/lib/difficulty-badge.ts`，基于全局配置生成 hero 区域徽章样式（text 字段复用 `DIFFICULTY_CONFIG.textColor`）
4. **精简 `location-detail-client.tsx`** — 删除 25 行内联 `getDifficultyInfo` 函数，改用共享 helper

## 改动统计

- 5 files changed, +71 / -76 lines（净减 5 行）
- 消除 1 处重复配置（location-detail 的 DIFFICULTY_CONFIG）
- 消除 1 处重复逻辑（location-detail-client 的 getDifficultyInfo）

## 验证

- ✅ `pnpm type-check` — 0 errors
- ✅ `pnpm build` — pass
- ✅ `pnpm i18n:validate` — 0 errors
- ✅ eslint — 0 errors（59 warnings 均为历史债务，与本次改动无关）

## 影响范围

- 仅涉及前端展示层，无 API / DB 变化
- 难度相关的视觉样式（卡片筛选、路线信息卡、hero 徽章）现在共享单一数据源
- 新增两个导出（`BadgeStyle` 接口、`getDifficultyBadgeStyles` 函数）供其他组件复用