### PR TITLE
fix: break infinite re-render loop in useLocationDetail hook

### DIFF
--- a/frontend/src/hooks/useLocationDetail.ts
+++ b/frontend/src/hooks/useLocationDetail.ts
@@ -3,7 +3,7 @@
  * 管理地点加载、队伍、相关地点等状态
  */
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import type { Location, Team } from "@/lib/types";
 import { safeFetch } from "@/lib/api-helpers";
 
@@ -28,26 +28,9 @@ export function useLocationDetail({ locationId, onError }: UseLocationDetailOpti
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const loadLocation = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-
-    const data = await safeFetch<{ success: boolean; location: Location }>(
-      `/api/locations/${locationId}`
-    );
-
-    if (data?.success && data.location) {
-      setLocation(data.location);
-      loadTeams(data.location.id);
-      loadRelatedLocations(data.location.id);
-    } else {
-      const errorMsg = "Location not found";
-      setError(errorMsg);
-      onError?.(errorMsg);
-    }
-
-    setIsLoading(false);
-  }, [locationId, onError]);
+  // 用 ref 持有最新的 onError，避免其变化时重建 loadLocation 导致无限循环
+  const onErrorRef = useRef(onError);
+  useEffect(() => { onErrorRef.current = onError; });
 
   const loadTeams = useCallback(async (locId: string) => {
     const data = await safeFetch<{ success: boolean; teams: Team[] }>(
@@ -68,6 +51,27 @@ export function useLocationDetail({ locationId, onError }: UseLocationDetailOpti
       );
     }
   }, []);
+
+  const loadLocation = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    const data = await safeFetch<{ success: boolean; location: Location }>(
+      `/api/locations/${locationId}`
+    );
+
+    if (data?.success && data.location) {
+      setLocation(data.location);
+      loadTeams(data.location.id);
+      loadRelatedLocations(data.location.id);
+    } else {
+      const errorMsg = "Location not found";
+      setError(errorMsg);
+      onErrorRef.current?.(errorMsg);
+    }
+
+    setIsLoading(false);
+  }, [locationId, loadTeams, loadRelatedLocations]);
 
   useEffect(() => {
     loadLocation();


### PR DESCRIPTION
## 问题

地点详情页闪退。`useLocationDetail` hook 中 `onError` 回调被直接放入 `useCallback` 依赖数组：

```ts
const loadLocation = useCallback(async () => { ... }, [locationId, onError]);
```

而调用方传入的是内联箭头函数：

```tsx
useLocationDetail({ locationId, onError: (err) => console.error(...) });
```

每次渲染 `onError` 都是新引用 → `loadLocation` 重建 → `useEffect` 再次触发 → `setIsLoading(true)` → 再次渲染 → 循环。短时间内发出 200+ 请求，页面崩溃。

## 修复

将 `onError` 存入 `useRef`，从 `loadLocation` 依赖数组中移除。ref 在每次渲染时更新，不影响 callback 身份：

```ts
const onErrorRef = useRef(onError);
useEffect(() => { onErrorRef.current = onError; });
```

`loadLocation` 现在只依赖稳定的值：`[locationId, loadTeams, loadRelatedLocations]`。

## 验证

- ✅ type-check: 0 errors
- ✅ lint: 0 errors (58 warnings 均为历史债务)
- ✅ i18n:build: pass

## 影响范围

- 仅修改 `frontend/src/hooks/useLocationDetail.ts`
- 修复线上 crash，无 API/DB 变化
- 行为完全等价，只是消除了无限循环