### PR TITLE
refactor: upgrade lint warn rules to error, replace window.open with wrapper

### DIFF
--- a/api/eslint.config.js
+++ b/api/eslint.config.js
@@ -12,7 +12,7 @@ export default tseslint.config(
       },
     },
     rules: {
-      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
       '@typescript-eslint/ban-ts-comment': ['error', {
         'ts-expect-error': 'allow-with-description',

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -43,7 +43,7 @@ export default tseslint.config(
         varsIgnorePattern: '^_',
         caughtErrorsIgnorePattern: '^_',
       }],
-      'no-restricted-properties': ['warn', {
+      'no-restricted-properties': ['error', {
         object: 'window',
         property: 'open',
         message: 'Use window.open sparingly; prefer React Router navigation',

--- a/frontend/src/components/features/discover/share-story-sheet.tsx
+++ b/frontend/src/components/features/discover/share-story-sheet.tsx
@@ -5,6 +5,7 @@ import { ImagePlus, Link2, Mail, MessageCircle, Share2, Twitter, X, Smartphone }
 import { useI18n } from "@/hooks/useI18n";
 import { fetchAPI } from "@/lib/api";
 import { weiboShareUrl, twitterShareUrl, mailtoUrl } from "@/lib/share-channels";
+import { openExternalUrl } from "@/lib/window-utils";
 import { StoryPosterPreview } from "./story-poster-preview";
 
 
@@ -38,21 +39,21 @@ export function ShareStorySheet({ open, onClose, title, storyId, summary, onCopy
     try { await navigator.share({ title, url }); } catch (err) { if (err instanceof DOMException && err.name === "AbortError") return; }
     trackShare(storyId, "native"); onClose();
   };
-  const handleWeibo = () => { trackShare(storyId, "weibo"); window.open(weiboShareUrl(url, title), "_blank"); onClose(); };
-  const handleTwitter = () => { trackShare(storyId, "twitter"); window.open(twitterShareUrl(url, title), "_blank"); onClose(); };
+  const handleWeibo = () => { trackShare(storyId, "weibo"); openExternalUrl(weiboShareUrl(url, title)); onClose(); };
+  const handleTwitter = () => { trackShare(storyId, "twitter"); openExternalUrl(twitterShareUrl(url, title)); onClose(); };
   const handleEmail = () => { window.location.href = mailtoUrl(title, `${title}\n\n${summary}\n\n${url}`); onClose(); };
   const handleWechat = async () => { trackShare(storyId, "wechat");
     try {
       const res = await fetch(`/share-image/story/${storyId}`);
-      if (!res.ok) { window.open(url, "_blank"); onClose(); return; }
+      if (!res.ok) { openExternalUrl(url); onClose(); return; }
       const blob = await res.blob();
       const file = new File([blob], "story.png", { type: "image/png" });
       if (navigator.canShare?.({ files: [file] })) {
         await navigator.share({ files: [file], title, url });
       } else {
-        window.open(url, "_blank");
+        openExternalUrl(url);
       }
-    } catch { window.open(url, "_blank"); }
+    } catch { openExternalUrl(url); }
     onClose();
   };
   const handlePoster = () => { trackShare(storyId, "poster"); setShowPosterPreview(true); };

--- a/frontend/src/components/features/location-detail/address-row.tsx
+++ b/frontend/src/components/features/location-detail/address-row.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { MapPin, Navigation, Check, Copy } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import { cn } from "@/lib/utils";
+import { openExternalUrl } from "@/lib/window-utils";
 
 interface AddressRowProps {
   address: string;
@@ -28,7 +29,7 @@ export function AddressRow({ address, coordinates, locationName, className }: Ad
     e.stopPropagation();
     const dest = encodeURIComponent(locationName || address);
     const url = `https://uri.amap.com/navigation?to=${coordinates!.lng},${coordinates!.lat},${dest}&callnative=0`;
-    window.open(url, "_blank", "noopener,noreferrer");
+    openExternalUrl(url);
   };
 
   return (

--- a/frontend/src/components/features/location-detail/location-intro-card.tsx
+++ b/frontend/src/components/features/location-detail/location-intro-card.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import { cn } from "@/lib/utils";
+import { openExternalUrl } from "@/lib/window-utils";
 import type { Location, Tag } from "@/lib/types";
 
 interface LocationIntroCardProps {
@@ -62,7 +63,7 @@ export function LocationIntroCard({
     if (!coordinates) return;
     const dest = encodeURIComponent(location.name || address || "");
     const url = `https://uri.amap.com/navigation?to=${coordinates.lng},${coordinates.lat},${dest}&callnative=0`;
-    window.open(url, "_blank", "noopener,noreferrer");
+    openExternalUrl(url);
   };
 
   React.useEffect(() => {

--- a/frontend/src/components/features/share-poster-modal.tsx
+++ b/frontend/src/components/features/share-poster-modal.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { API_BASE } from "@/lib/api";
+import { openBlankWindow } from "@/lib/window-utils";
 import { useI18n } from "@/hooks/useI18n";
 import { Loader2, ImageIcon, Link2, X, Download, RefreshCw } from "lucide-react";
 
@@ -107,7 +108,7 @@ export function SharePosterModal({
 
       if (isIOS) {
         // Open image in new tab for iOS (user can long press to save)
-        const newWindow = window.open();
+        const newWindow = openBlankWindow();
         if (newWindow) {
           newWindow.document.write(`
             <html>

--- a/frontend/src/components/features/team-detail/share-poster-preview.tsx
+++ b/frontend/src/components/features/team-detail/share-poster-preview.tsx
@@ -5,6 +5,7 @@ import { useState, useRef, useCallback } from "react";
 import { useI18n } from "@/hooks/useI18n";
 import { Link2, X, CheckCircle, Download, Loader2, Share2, RefreshCw } from "lucide-react";
 import { useShareImage } from "@/hooks/use-share-image";
+import { openBlankWindow } from "@/lib/window-utils";
 
 interface SharePosterPreviewProps {
   open: boolean;
@@ -115,7 +116,7 @@ export function SharePosterPreview({
 
       if (isIOS) {
         // Open image in new tab for iOS (user can long press to save)
-        const newWindow = window.open();
+        const newWindow = openBlankWindow();
         if (newWindow) {
           newWindow.document.write(`
             <html>

--- a/frontend/src/lib/window-utils.ts
+++ b/frontend/src/lib/window-utils.ts
@@ -1,0 +1,17 @@
+/**
+ * Open an external URL in a new tab with safe defaults.
+ * Prefer this over raw window.open() to ensure noopener/noreferrer.
+ */
+export function openExternalUrl(url: string): void {
+  // eslint-disable-next-line no-restricted-properties -- canonical wrapper for external URLs
+  window.open(url, '_blank', 'noopener,noreferrer');
+}
+
+/**
+ * Open a blank window for printing/rendering content.
+ * Use sparingly; prefer in-app preview when possible.
+ */
+export function openBlankWindow(): Window | null {
+  // eslint-disable-next-line no-restricted-properties -- canonical wrapper for blank window
+  return window.open();
+}


### PR DESCRIPTION
## 变更

### ESLint warn → error 升级
- **api**: `no-explicit-any` warn → error
- **frontend**: `no-restricted-properties` (window.open) warn → error

### window.open 重构
- 新建 `window-utils.ts`，提供 `openExternalUrl()` 和 `openBlankWindow()`
- 替换 5 个文件中 9 处 raw `window.open()` 调用

### 已知遗留
- `no-explicit-any` (frontend): 保持 warn，~20 处违规需要单独清理
- `react-hooks/exhaustive-deps`: 保持 warn，~30 处需要单独修复

## 验证
- type-check: 0 errors
- lint: 0 errors, 50 warnings (已知债务)

🤖 Generated with [Claude Code](https://claude.com/claude-code)