### PR TITLE
feat(frontend): integrate VditorEditor into story edit page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",
+    "vditor": "^3.11.2",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^2.5.0",
     "tailwindcss": "^4.0.0",

--- a/frontend/src/components/features/discover/story-edit-client.tsx
+++ b/frontend/src/components/features/discover/story-edit-client.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import { useI18n } from "@/hooks/useI18n";
 import { useToast } from "@/hooks/useToast";
 import { MarkdownContent } from "./markdown-content";
+import { VditorEditor } from "./vditor-editor";
 import { StoryToast } from "./story-detail-toast";
 import { useStoryForm } from "./use-story-form";
 import type { FormFields } from "./use-story-form";
@@ -135,8 +136,11 @@ export function StoryEditClient({ storyId }: StoryEditClientProps) {
                 placeholder="输入故事摘要（最多 150 字）" className="w-full px-3 py-2.5 rounded-xl border border-border bg-white text-sm outline-none focus:ring-2 focus:ring-amber-200 focus:border-amber-400 resize-none" />
               <span className="text-xs text-muted-foreground">{form.summary.length}/150</span></div>
             <div><label className="block text-sm font-medium text-foreground mb-1.5">正文（Markdown）</label>
-              <textarea value={form.content} onChange={(e) => updateField("content", e.target.value)} maxLength={10000} rows={12}
-                placeholder="使用 Markdown 编写故事内容" className="w-full px-3 py-2.5 rounded-xl border border-border bg-white text-sm outline-none focus:ring-2 focus:ring-amber-200 focus:border-amber-400 resize-y font-mono" /></div>
+              <VditorEditor
+                value={form.content}
+                onChange={(value) => updateField("content", value)}
+                placeholder="使用 Markdown 编写故事内容"
+              /></div>
             <div><label className="block text-sm font-medium text-foreground mb-1.5">状态</label>
               <select value={form.status} onChange={(e) => updateField("status", e.target.value)}
                 className="w-full px-3 py-2.5 rounded-xl border border-border bg-white text-sm outline-none focus:ring-2 focus:ring-amber-200 focus:border-amber-400">

--- a/frontend/src/components/features/discover/vditor-editor.tsx
+++ b/frontend/src/components/features/discover/vditor-editor.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import * as React from "react";
+import type Vditor from "vditor";
+import { useI18n } from "@/hooks/useI18n";
+
+interface VditorEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  readOnly?: boolean;
+}
+
+/**
+ * Vditor 即时渲染（IR）编辑器组件
+ * 封装 Vditor 3.11+，支持暗色主题
+ */
+export function VditorEditor({ value, onChange, placeholder, readOnly = false }: VditorEditorProps) {
+  const vditorRef = React.useRef<HTMLDivElement>(null);
+  const instanceRef = React.useRef<Vditor | null>(null);
+  const { t } = useI18n(["content"]);
+
+  // 监听暗色主题
+  const [isDark, setIsDark] = React.useState(false);
+  React.useEffect(() => {
+    const checkDark = () => {
+      const dark = document.documentElement.classList.contains("dark") ||
+        window.matchMedia("(prefers-color-scheme: dark)").matches;
+      setIsDark(dark);
+    };
+    checkDark();
+    const observer = new MutationObserver(checkDark);
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+    return () => observer.disconnect();
+  }, []);
+
+  // 初始化 Vditor
+  React.useEffect(() => {
+    if (!vditorRef.current || instanceRef.current) return;
+
+    let cancelled = false;
+    let vditorInstance: Vditor | null = null;
+
+    (async () => {
+      const Vditor = (await import("vditor")).default;
+
+      if (cancelled || !vditorRef.current) return;
+
+      // 导入对应主题 CSS
+      if (isDark) {
+        await import("vditor/dist/css/content-theme/dark.css");
+      } else {
+        await import("vditor/dist/css/content-theme/light.css");
+      }
+
+      vditorInstance = new Vditor(vditorRef.current, {
+        mode: "ir",
+        height: 400,
+        minHeight: 200,
+        placeholder: placeholder ?? t("content.writeStories"),
+        theme: isDark ? "dark" : "classic",
+        toolbar: readOnly
+          ? []
+          : [
+              "headings",
+              "bold",
+              "italic",
+              "strike",
+              "|",
+              "link",
+              "list",
+              "ordered-list",
+              "check",
+              "|",
+              "quote",
+              "line",
+              "code",
+              "inline-code",
+              "|",
+              "table",
+              "undo",
+              "redo",
+              "|",
+              "preview",
+              "fullscreen",
+            ],
+        input: (md: string) => {
+          if (md !== value) {
+            onChange(md);
+          }
+        },
+        after: () => {
+          if (vditorInstance) {
+            vditorInstance.setValue(value);
+          }
+        },
+      });
+
+      if (!cancelled) {
+        instanceRef.current = vditorInstance;
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (instanceRef.current) {
+        try {
+          instanceRef.current.destroy();
+        } catch {
+          // ignore
+        }
+        instanceRef.current = null;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 同步外部 value 变化
+  React.useEffect(() => {
+    if (instanceRef.current && value !== instanceRef.current.getValue()) {
+      instanceRef.current.setValue(value);
+    }
+  }, [value]);
+
+  // 监听主题切换
+  React.useEffect(() => {
+    if (instanceRef.current && isDark !== (instanceRef.current.vditor?.options?.theme === "dark")) {
+      try {
+        instanceRef.current.setTheme(isDark ? "dark" : "classic");
+      } catch (_e) {
+        console.warn("[VditorEditor] Theme switch failed:", _e);
+      }
+    }
+  }, [isDark]);
+
+  // 监听 readOnly 变化
+  React.useEffect(() => {
+    if (instanceRef.current) {
+      try {
+        if (readOnly) {
+          instanceRef.current.disabled();
+        } else {
+          instanceRef.current.enable();
+        }
+      } catch (_e) {
+        console.warn("[VditorEditor] ReadOnly toggle failed:", _e);
+      }
+    }
+  }, [readOnly]);
+
+  return <div ref={vditorRef} className="vditor" />;
+}

--- a/frontend/src/types/vditor.d.ts
+++ b/frontend/src/types/vditor.d.ts
@@ -1,0 +1,43 @@
+// Type declaration for vditor
+declare module "vditor" {
+  interface IOptions {
+    mode?: "wysiwyg" | "ir" | "sv";
+    height?: number | string;
+    minHeight?: number;
+    width?: number | string;
+    placeholder?: string;
+    theme?: "classic" | "dark";
+    icon?: "ant" | "material";
+    toolbar?: string[] | object[];
+    cache?: { enable?: boolean; id?: string };
+    counter?: { enable?: boolean; max?: number };
+    typewriterMode?: boolean;
+    preview?: { delay?: number; maxWidth?: number; mode?: "both" | "editor" | "preview" };
+    resize?: { enable?: boolean; position?: "top" | "bottom" | "none" };
+    lang?: string;
+    after?: () => void;
+    input?: (value: string) => void;
+    blur?: (value: string) => void;
+    focus?: (value: string) => void;
+    select?: (value: string) => void;
+    esc?: (value: string) => void;
+    ctrlEnter?: (value: string) => void;
+  }
+
+  class Vditor {
+    constructor(id: string | HTMLElement, options?: IOptions);
+    vditor: { options: IOptions };
+    getValue(): string;
+    setValue(value: string, clearStack?: boolean): void;
+    setTheme(theme: "dark" | "classic"): void;
+    disabled(): void;
+    enable(): void;
+    focus(): void;
+    blur(): void;
+    destroy(): void;
+    getHTML(): string;
+    insertValue(value: string, render?: boolean): void;
+  }
+
+  export default Vditor;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       tailwindcss:
         specifier: ^4.0.0
         version: 4.3.0
+      vditor:
+        specifier: ^3.11.2
+        version: 3.11.2
       zod:
         specifier: ^3.23.0
         version: 3.25.76
@@ -4041,6 +4044,12 @@ packages:
         integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==,
       }
 
+  diff-match-patch@1.0.5:
+    resolution:
+      {
+        integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==,
+      }
+
   diff@8.0.4:
     resolution:
       {
@@ -7256,6 +7265,12 @@ packages:
         integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
       }
 
+  vditor@3.11.2:
+    resolution:
+      {
+        integrity: sha512-8QguQQUPWbBFocnfQmWjz4jiykQnvsmCuhOomGIVVK7vc+dQq2h8w9qQQuEjUTZpnZT5fEdYbj4aLr1NGdAZaA==,
+      }
+
   vfile-location@5.0.3:
     resolution:
       {
@@ -9908,6 +9923,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  diff-match-patch@1.0.5: {}
+
   diff@8.0.4: {}
 
   dijkstrajs@1.0.3: {}
@@ -12066,6 +12083,10 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  vditor@3.11.2:
+    dependencies:
+      diff-match-patch: 1.0.5
 
   vfile-location@5.0.3:
     dependencies:


### PR DESCRIPTION
## Summary
Replace textarea with VditorEditor for story content editing.

## Changes

### story-edit-client.tsx
- Import VditorEditor component
- Replace content textarea with VditorEditor
- IR mode for inline rendering
- Dark/light theme auto-detection

## Verification
- [x] `pnpm build` passes

Depends on PR #308 (VditorEditor component).