### PR TITLE
fix: 迁移 0009 添加 IF NOT EXISTS 保证幂等

### DIFF
--- a/api/db/migrations/0009_perf_composite_indexes.sql
+++ b/api/db/migrations/0009_perf_composite_indexes.sql
@@ -1,12 +1,13 @@
 -- Migration: Add composite indexes for query optimization
+-- 使用 IF NOT EXISTS 保证幂等：生产环境可能已通过其他路径创建部分索引
 -- Stories: status + created_at (for filtered list queries)
-CREATE INDEX stories_status_created_at_idx ON stories(status, created_at);
+CREATE INDEX IF NOT EXISTS stories_status_created_at_idx ON stories(status, created_at);
 
 -- Team members: team_id + status (for member count queries)
-CREATE INDEX team_members_team_status_idx ON team_members(team_id, status);
+CREATE INDEX IF NOT EXISTS team_members_team_status_idx ON team_members(team_id, status);
 
 -- User favorites: user_id + created_at (for favorites list)
-CREATE INDEX user_favorites_user_created_idx ON user_favorites(user_id, created_at);
+CREATE INDEX IF NOT EXISTS user_favorites_user_created_idx ON user_favorites(user_id, created_at);
 
 -- Share events: entity_type + entity_id (for share stats)
-CREATE INDEX share_events_entity_idx ON share_events(entity_type, entity_id);
+CREATE INDEX IF NOT EXISTS share_events_entity_idx ON share_events(entity_type, entity_id);


### PR DESCRIPTION
## 问题

CI deploy 阶段失败：

index team_members_team_status_idx already exists: SQLITE_ERROR [code: 7500]

迁移 0009_perf_composite_indexes.sql 使用 CREATE INDEX，但生产 D1 上该索引已存在（可能从其他路径手动创建过），导致迁移失败阻塞部署。

## 修复

4 个 CREATE INDEX 全部改为 CREATE INDEX IF NOT EXISTS，保证迁移可重复执行。

## 改动

1 file changed, 5 insertions(+), 4 deletions(-)

## 影响

- 无破坏性：IF NOT EXISTS 在索引已存在时静默跳过
- 不改变任何表结构，仅让迁移幂等
- 回滚方式：revert 即可
