### PR TITLE
fix(ci): correct wrangler secret put syntax in staging workflow

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -31,8 +31,8 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Set API secrets
         run: |
-          pnpm --filter @gomate/api exec wrangler secret put BETTER_AUTH_SECRET --env staging --name BETTER_AUTH_SECRET <<< "${{ secrets.BETTER_AUTH_SECRET }}"
-          pnpm --filter @gomate/api exec wrangler secret put RESEND_API_KEY --env staging --name RESEND_API_KEY <<< "${{ secrets.RESEND_API_KEY }}"
+          printf '%s' "${{ secrets.BETTER_AUTH_SECRET }}" | pnpm --filter @gomate/api exec wrangler secret put BETTER_AUTH_SECRET --env staging
+          printf '%s' "${{ secrets.RESEND_API_KEY }}" | pnpm --filter @gomate/api exec wrangler secret put RESEND_API_KEY --env staging
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## 修复内容

- 移除 
wrangler secret put <key>

Create or update a secret for a Worker

POSITIONALS
  key  The variable name to be accessible in the Worker  [string] [required]

GLOBAL FLAGS
  -c, --config    Path to Wrangler configuration file  [string]
      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
  -h, --help      Show help  [boolean]
  -v, --version   Show version number  [boolean]

OPTIONS
      --name  Name of the Worker. If this is not specified, it will default to the name specified in your Wrangler config file.  [string] 中错误的  参数（该参数指 Worker name，不是 secret name）
- 改用 
wrangler secret put <key>

Create or update a secret for a Worker

POSITIONALS
  key  The variable name to be accessible in the Worker  [string] [required]

GLOBAL FLAGS
  -c, --config    Path to Wrangler configuration file  [string]
      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
  -h, --help      Show help  [boolean]
  -v, --version   Show version number  [boolean]

OPTIONS
      --name  Name of the Worker. If this is not specified, it will default to the name specified in your Wrangler config file.  [string] 方式更安全地输入 secret

## 影响范围

仅 ，不影响生产环境。

## 验证

- [x] 本地 preflight (type-check + lint) 通过

Refs: task #119