### PR TITLE
fix(staging): add custom domains and SESSION KV bindings for staging

### DIFF
--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -77,6 +77,10 @@ migrations_dir = "db/migrations"
 binding = "GOMATE_KV"
 id = "5668184b0f7642f6895b716ca84d1c4a"
 
+[[env.staging.routes]]
+pattern = "api-staging.gomate.live"
+custom_domain = true
+
 [env.staging.placement]
 mode = "smart"
 
@@ -84,7 +88,6 @@ mode = "smart"
 enabled = true
 head_sampling_rate = 1
 
-# 定时任务：每天 UTC 12:10（北京时间晚上 8:10）更新过期队伍状态
 [env.staging.triggers]
 crons = ["10 12 * * *"]
 
@@ -125,6 +128,5 @@ mode = "smart"
 enabled = true
 head_sampling_rate = 0.1
 
-# 定时任务：每天 UTC 12:10（北京时间晚上 8:10）更新过期队伍状态
 [env.production.triggers]
 crons = ["10 12 * * *"]

--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -29,6 +29,14 @@ binding = "ASSETS"
 [env.staging.vars]
 PUBLIC_API_URL = "https://api-staging.gomate.live"
 
+[[env.staging.kv_namespaces]]
+binding = "SESSION"
+id = "f8480fa769054962ab59333aa7015ff6"
+
+[[env.staging.routes]]
+pattern = "staging.gomate.live"
+custom_domain = true
+
 [env.staging.observability]
 enabled = true
 
@@ -45,6 +53,10 @@ binding = "ASSETS"
 
 [env.production.vars]
 PUBLIC_API_URL = "https://api.gomate.live"
+
+[[env.production.kv_namespaces]]
+binding = "SESSION"
+id = "6e3db6b00bc4421faeb1402c2e51f7d1"
 
 [env.production.observability]
 enabled = true


### PR DESCRIPTION
## 变更

- api/wrangler.toml：为 api-staging.gomate.live 添加 custom domain route
- frontend/wrangler.toml：为 staging.gomate.live 添加 custom domain route
- frontend/wrangler.toml：为 staging 和 production 显式声明 SESSION KV namespace ID

## 验证

- staging API 已部署：https://api-staging.gomate.live/health 返回 200
- staging 前端已部署：https://staging.gomate.live/ 返回 200
- BETTER_AUTH_SECRET 和 RESEND_API_KEY 已通过 wrangler secret put 设置到 staging worker
- /auth/sign-in/email 返回正常 JSON（401 表示未注册用户，说明 auth 服务正常）

## 说明

此前 staging 初始配置已推到 main（task #119）。本 PR 补全自定义域名和 SESSION KV 绑定，避免 GitHub Actions 自动部署到 staging 时因 auto-provisioning KV 已存在而失败。

/cc @jiahong-wu @Jeff

Refs: task #119
