### PR TITLE
refactor(e2e): apply staging review feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dev:fresh": "pnpm db:reset && concurrently \"pnpm api:dev\" \"pnpm web:dev\"",
     "db:reset": "node scripts/reset-local-db.mjs",
     "e2e": "playwright test",
-    "e2e:staging": "E2E_BASE_URL=https://staging.gomate.live playwright test --project=chromium-staging",
+    "e2e:staging": "E2E_BASE_URL=https://staging.gomate.live playwright test",
     "e2e:ui": "playwright test --ui",
     "e2e:debug": "playwright test --debug",
     "e2e:browser-use": "browser-use <<'PY'\nexec(open('e2e/browser-use/home_smoke.py').read())\nPY",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -53,13 +53,13 @@ export default defineConfig({
       name: "chromium-staging",
       use: {
         ...devices["Desktop Chrome"],
-        baseURL: "https://staging.gomate.live",
+        baseURL: process.env.E2E_BASE_URL || "https://staging.gomate.live",
       },
     },
   ],
 
   // 自动启动本地开发服务器（仅在非 staging 测试时）
-  webServer: process.env.E2E_BASE_URL?.startsWith("https://staging")
+  webServer: process.env.E2E_BASE_URL
     ? undefined
     : {
         command: "pnpm dev:fresh",


### PR DESCRIPTION
## 修复内容

根据 @Martin 的 post-review 反馈：

1. :  project 的  改为读取  环境变量，不再硬编码
2. :  跳过逻辑简化为 ，更健壮
3. :  脚本去掉 ，支持未来多浏览器 staging 测试

## 验证

- [x] 本地 preflight (type-check + lint) 通过

Refs: task #119 post-review