### PR TITLE
fix(e2e): remove unsupported --headless flag from e2e:ci

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -77,7 +77,7 @@ jobs:
         run: pnpm e2e:ci
         env:
           CI: true
-          PUBLIC_API_URL: https://api.gomate.live
+          PUBLIC_API_URL: http://localhost:8799
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dev:fresh": "pnpm db:reset && concurrently \"pnpm api:dev\" \"pnpm web:dev\"",
     "db:reset": "node scripts/reset-local-db.mjs",
     "e2e": "playwright test",
-    "e2e:ci": "playwright test --headless",
+    "e2e:ci": "playwright test",
     "e2e:staging": "E2E_BASE_URL=https://staging.gomate.live playwright test",
     "e2e:ui": "playwright test --ui",
     "e2e:debug": "playwright test --debug",


### PR DESCRIPTION
## 问题

1. `pnpm e2e:ci` 执行 `playwright test --headless` 会失败：

```
error: unknown option '--headless'
(Did you mean --headed?)
```

Playwright 1.61.1 默认即为 headless 模式，不需要也不支持 `--headless` CLI flag。

2. PR Validation 的 E2E job 设置了 `PUBLIC_API_URL=https://api.gomate.live`，这会让本地 E2E 测试中的前端调用生产 API，而不是 `pnpm dev:fresh` 启动的本地 API。

## 修复

- 将 `e2e:ci` 脚本改为 `playwright test`，保持与 `e2e` 脚本一致
- 将 workflow 中的 `PUBLIC_API_URL` 改为 `http://localhost:8799`，确保本地 E2E 测试真实验证本地代码

## 验证

- 本地运行 `pnpm exec playwright test` 通过 40 个测试
- 本次修复确保 PR Validation workflow 中的 E2E 步骤能正确指向本地 API 并正常执行

---

注意：本 PR 针对 Jeff 在 task #120 中直接推送到 main 的代码做补丁修复。后续 main 推送仍需严格走 PR 流程。
