### PR TITLE
ci(e2e): E2E 观察期配置与健康度报告

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -58,9 +58,11 @@ jobs:
         run: pnpm --filter @gomate/frontend lint || echo "Lint warnings - to be fixed in dedicated task"
         continue-on-error: true
   # E2E Tests (local dev server)
+  # 观察期：continue-on-error=true，收集 flaky 率，不阻塞 PR 合并
   e2e-tests:
     name: E2E Tests (Local)
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -78,10 +80,22 @@ jobs:
         env:
           CI: true
           PUBLIC_API_URL: http://localhost:8799
+      - name: Generate E2E health report
+        if: always()
+        run: node scripts/e2e-health-report.mjs
       - name: Upload Playwright report
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
           path: e2e-report/
           retention-days: 7
+      - name: Upload E2E health report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-health-report
+          path: |
+            e2e-health-report.json
+            e2e-health-history.json
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,11 @@ e2e-report/
 test-results/
 
 # Misc untracked files that should not be committed
-]
 paseo.json
+
+# E2E health reports
+e2e-health-report.json
+e2e-health-history.json
 
 # testing
 /coverage

--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ pnpm env:check
 
 如果排查后仍无法解决，请附带 `pnpm env:check` 输出和错误日志提 issue。
 
+## E2E CI 观察期
+
+PR Validation 中已启用本地 E2E 测试，当前处于 **2 周观察期**：
+
+- E2E 测试会执行，但 **不阻塞 PR 合并**（`continue-on-error: true`）
+- 每次运行都会自动生成 `e2e-health-report.json` 并上传 artifact
+- 观察指标：flaky rate、failure rate、平均耗时、失败原因分类
+- 目标：连续运行 flaky rate < 5% 后，进入软阻塞期（required 但可 override）
+
+作为开发者，**请在提交 PR 前本地运行 `pnpm e2e:ci` 并确保通过**，减少 CI 噪音。
+
 ## 部署
 
 ```bash

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,16 +18,17 @@ export default defineConfig({
   // 每个测试用 1 个 worker，避免登录状态冲突
   workers: 1,
 
-  // 失败重试 1 次（本地开发时关闭，CI 开启）
-  retries: process.env.CI ? 1 : 0,
+  // CI 中失败重试 2 次，减少偶发失败（观察期统计用）
+  retries: process.env.CI ? 2 : 0,
 
   // 测试超时
   timeout: 30_000,
 
-  // 报告器
+  // 报告器：list + html + json（健康度脚本解析 json）
   reporter: [
     ["list"],
     ["html", { outputFolder: "e2e-report" }],
+    ["json", { outputFile: "e2e-report/results.json" }],
   ],
 
   use: {

--- a/scripts/e2e-health-report.mjs
+++ b/scripts/e2e-health-report.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * E2E 健康度报告生成器
+ *
+ * 解析 Playwright JSON report（e2e-report/results.json），
+ * 输出本次运行的 flaky rate、failure rate、平均耗时、失败原因分布，
+ * 并累积历史记录到 e2e-health-history.json。
+ *
+ * 在 CI 中于 E2E 任务后运行，无论测试是否失败都执行。
+ */
+
+import { readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const REPORT_PATH = "e2e-report/results.json";
+const HEALTH_HISTORY_PATH = "e2e-health-history.json";
+const HEALTH_REPORT_PATH = "e2e-health-report.json";
+
+function toFixed2(n) {
+  return Number.isFinite(n) ? Number(n.toFixed(2)) : 0;
+}
+
+async function main() {
+  const now = new Date().toISOString();
+  let suites = [];
+  let reportExists = false;
+
+  try {
+    const raw = await readFile(REPORT_PATH, "utf-8");
+    const report = JSON.parse(raw);
+    suites = Array.isArray(report.suites) ? report.suites : [];
+    reportExists = true;
+  } catch (err) {
+    console.warn(`[e2e-health-report] 无法读取 ${REPORT_PATH}: ${err.message}`);
+  }
+
+  // 统计
+  let totalTests = 0;
+  let expected = 0;
+  let flaky = 0;
+  let unexpected = 0;
+  let skipped = 0;
+  let totalDurationMs = 0;
+  const failureReasons = [];
+
+  for (const suite of suites) {
+    const specs = Array.isArray(suite.specs) ? suite.specs : [];
+    for (const spec of specs) {
+      const tests = Array.isArray(spec.tests) ? spec.tests : [];
+      for (const test of tests) {
+        totalTests += 1;
+        const results = Array.isArray(test.results) ? test.results : [];
+        const status = test.expectedStatus === "skipped" ? "skipped" : test.ok ? "expected" : "unexpected";
+
+        if (status === "skipped") {
+          skipped += 1;
+        } else if (test.outcome === "flaky") {
+          flaky += 1;
+          expected += 1; // flaky 最终通过
+        } else if (test.ok) {
+          expected += 1;
+        } else {
+          unexpected += 1;
+        }
+
+        for (const result of results) {
+          totalDurationMs += result.duration || 0;
+          if (result.status === "failed" && result.error?.message) {
+            failureReasons.push(result.error.message);
+          }
+        }
+      }
+    }
+  }
+
+  const finishedTests = Math.max(totalTests - skipped, 1);
+  const flakyRate = toFixed2((flaky / finishedTests) * 100);
+  const failureRate = toFixed2((unexpected / finishedTests) * 100);
+  const avgDurationSec = toFixed2(totalDurationMs / 1000 / Math.max(totalTests, 1));
+
+  // 失败原因分类（简单前缀匹配）
+  const failureCategories = {};
+  for (const reason of failureReasons) {
+    const key = reason.includes("timeout")
+      ? "timeout"
+      : reason.includes("selector")
+        ? "selector-not-found"
+        : reason.includes("navigation")
+          ? "navigation"
+          : "other";
+    failureCategories[key] = (failureCategories[key] || 0) + 1;
+  }
+
+  const current = {
+    date: now,
+    reportExists,
+    totalTests,
+    expected,
+    flaky,
+    unexpected,
+    skipped,
+    flakyRate,
+    failureRate,
+    avgDurationSec,
+    failureCategories,
+    failureReasons: failureReasons.slice(0, 20), // 只保留前 20 条
+  };
+
+  // 历史记录
+  let history = [];
+  if (existsSync(HEALTH_HISTORY_PATH)) {
+    try {
+      const raw = await readFile(HEALTH_HISTORY_PATH, "utf-8");
+      history = JSON.parse(raw);
+      if (!Array.isArray(history)) history = [];
+    } catch (err) {
+      console.warn(`[e2e-health-report] 历史记录读取失败: ${err.message}`);
+    }
+  }
+  history.push(current);
+  if (history.length > 30) history = history.slice(-30); // 保留最近 30 次
+
+  await writeFile(HEALTH_REPORT_PATH, JSON.stringify(current, null, 2), "utf-8");
+  await writeFile(HEALTH_HISTORY_PATH, JSON.stringify(history, null, 2), "utf-8");
+
+  console.log("[e2e-health-report] 当前报告:");
+  console.log(`  totalTests: ${totalTests}`);
+  console.log(`  expected: ${expected}, flaky: ${flaky}, unexpected: ${unexpected}, skipped: ${skipped}`);
+  console.log(`  flakyRate: ${flakyRate}%`);
+  console.log(`  failureRate: ${failureRate}%`);
+  console.log(`  avgDurationSec: ${avgDurationSec}s`);
+  console.log(`  failureCategories: ${JSON.stringify(failureCategories)}`);
+}
+
+main().catch((err) => {
+  console.error(`[e2e-health-report] 生成失败: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## 变更

- PR Validation 的 E2E job 增加 `continue-on-error: true`，进入 2 周观察期
- `playwright.config.ts` 增加 JSON reporter 并设置 CI retries=2
- 新增 `scripts/e2e-health-report.mjs`，解析 JSON report 输出 flaky rate / failure rate / avg duration / 失败分类
- PR Validation 上传 health report artifact
- README 增加 E2E CI 观察期说明

## 背景

Victor 终批方案：E2E 放 CI 但分阶段演进（观察期 → 软阻塞 → 硬阻塞）。本 PR 落地观察期配置，不阻塞 PR 合并，同时收集数据支撑后续决策。

## 验证

- `node --check scripts/e2e-health-report.mjs` 通过
- 用样例 JSON report 跑通健康度脚本，输出符合预期

## 后续

- 等 Jeff 的 task #120 测试硬度改进 PR 合并后，结合本 PR 的 health report 收集 2 周数据
- flaky rate < 5% 后进入软阻塞期

cc @jiahong-wu
