### PR TITLE
test(e2e): improve Phase 2 test robustness with data-testid and deterministic waits

### DIFF
--- a/api/src/lib/auth.ts
+++ b/api/src/lib/auth.ts
@@ -90,6 +90,9 @@ export function createAuth(env: Env) {
 
   const db = createDb(env.DB);
 
+  // 本地 HTTP 开发时不能使用 Secure cookie，否则浏览器不会保存/发送 session
+  const isSecure = (env.APP_URL || "").startsWith("https");
+
   return betterAuth({
     database: drizzleAdapter(db as never, {
       provider: "sqlite",
@@ -137,14 +140,16 @@ export function createAuth(env: Env) {
     advanced: {
       generateId: () => nanoid(),
       defaultCookieAttributes: {
-        sameSite: "none",
-        secure: true,
+        sameSite: isSecure ? "none" : "lax",
+        secure: isSecure,
         path: "/",
       },
-      crossSubDomainCookies: {
-        enabled: true,
-        domain: ".gomate.live",
-      },
+      crossSubDomainCookies: isSecure
+        ? {
+            enabled: true,
+            domain: ".gomate.live",
+          }
+        : undefined,
     },
     user: {
       additionalFields: {

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,5 +1,14 @@
 import { test, expect } from "@playwright/test";
 
+async function fillLoginForm(page, email: string, password: string) {
+  // Wait for React island hydration so controlled inputs keep their values
+  await page.waitForLoadState("networkidle");
+  const emailInput = page.locator("[data-testid='login-email']");
+  await emailInput.waitFor({ state: "visible" });
+  await emailInput.fill(email);
+  await page.locator("[data-testid='login-password']").fill(password);
+}
+
 test.describe("Auth", () => {
   test("login page loads and form is interactive", async ({ page }) => {
     await page.goto("/login");
@@ -7,27 +16,24 @@ test.describe("Auth", () => {
     await expect(page.locator("form")).toBeVisible();
     await expect(page.locator("[data-testid='login-email']")).toBeVisible();
     await expect(page.locator("[data-testid='login-password']")).toBeVisible();
-    await page.locator("[data-testid='login-email']").fill("leader_a@test.com");
-    await page.locator("[data-testid='login-password']").fill("test1234");
+    await fillLoginForm(page, "leader_a@test.com", "test1234");
     await page.locator("[data-testid='login-submit']").click();
     await expect(page.locator("body")).toBeVisible();
   });
 
   test("successful login redirects to home", async ({ page }) => {
     await page.goto("/login");
-    await page.locator("[data-testid='login-email']").fill("admin@test.com");
-    await page.locator("[data-testid='login-password']").fill("test1234");
+    await fillLoginForm(page, "admin@test.com", "test1234");
     await page.locator("[data-testid='login-submit']").click();
     // Deterministic assertion: wait for navigation to home
-    await page.waitForURL("/", { timeout: 5000 });
+    await page.waitForURL("/", { timeout: 15000 });
     await expect(page).toHaveURL(/\/$/);
     await expect(page.locator("body")).toContainText("GoMate");
   });
 
   test("invalid credentials show error or stay on login", async ({ page }) => {
     await page.goto("/login");
-    await page.locator("[data-testid='login-email']").fill("nonexistent@test.com");
-    await page.locator("[data-testid='login-password']").fill("wrongpassword");
+    await fillLoginForm(page, "nonexistent@test.com", "wrongpassword");
     await page.locator("[data-testid='login-submit']").click();
     // Wait for any navigation or response to settle, then assert we remain on login
     await page.waitForLoadState("networkidle");

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -18,18 +18,10 @@ test.describe("Auth", () => {
     await page.locator("[data-testid='login-email']").fill("admin@test.com");
     await page.locator("[data-testid='login-password']").fill("test1234");
     await page.locator("[data-testid='login-submit']").click();
-    // Wait for navigation to complete (success or failure)
-    await page.waitForTimeout(3000);
-    // Check if we're on home page or still on login (login may fail with seeded data)
-    const url = page.url();
-    if (url.includes("/login")) {
-      // Login failed - check error is shown or page is still responsive
-      await expect(page.locator("body")).toBeVisible();
-    } else {
-      // Login succeeded - should be on home
-      await expect(page).toHaveURL(/\/$/);
-      await expect(page.locator("body")).toContainText("GoMate");
-    }
+    // Deterministic assertion: wait for navigation to home
+    await page.waitForURL("/", { timeout: 5000 });
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.locator("body")).toContainText("GoMate");
   });
 
   test("invalid credentials show error or stay on login", async ({ page }) => {
@@ -37,10 +29,9 @@ test.describe("Auth", () => {
     await page.locator("[data-testid='login-email']").fill("nonexistent@test.com");
     await page.locator("[data-testid='login-password']").fill("wrongpassword");
     await page.locator("[data-testid='login-submit']").click();
-    await page.waitForTimeout(2000);
-    // Should stay on login page or show error
-    const url = page.url();
-    expect(url.includes("/login")).toBe(true);
+    // Wait for any navigation or response to settle, then assert we remain on login
+    await page.waitForLoadState("networkidle");
+    await expect(page).toHaveURL(/\/login/);
   });
 
   test("register page loads and form is interactive", async ({ page }) => {

--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -2,7 +2,11 @@ import { test, expect } from "@playwright/test";
 
 async function loginAsAdmin(page) {
   await page.goto("/login");
-  await page.locator("[data-testid='login-email']").fill("admin@test.com");
+  // Wait for React island hydration so controlled inputs keep their values
+  await page.waitForLoadState("networkidle");
+  const emailInput = page.locator("[data-testid='login-email']");
+  await emailInput.waitFor({ state: "visible" });
+  await emailInput.fill("admin@test.com");
   await page.locator("[data-testid='login-password']").fill("test1234");
   await page.locator("[data-testid='login-submit']").click();
   await page.waitForURL("/", { timeout: 15000 });

--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -1,5 +1,14 @@
 import { test, expect } from "@playwright/test";
 
+async function loginAsAdmin(page) {
+  await page.goto("/login");
+  await page.locator("[data-testid='login-email']").fill("admin@test.com");
+  await page.locator("[data-testid='login-password']").fill("test1234");
+  await page.locator("[data-testid='login-submit']").click();
+  await page.waitForURL("/", { timeout: 15000 });
+  await page.waitForLoadState("domcontentloaded");
+}
+
 test.describe("Profile", () => {
   test("profile page requires login", async ({ page }) => {
     await page.goto("/profile");
@@ -13,13 +22,10 @@ test.describe("Profile", () => {
   });
 
   test("profile page loads when logged in", async ({ page }) => {
-    await page.goto("/login");
-    await page.locator("input#email").fill("admin@test.com");
-    await page.locator("input#password").fill("test1234");
-    await page.locator("button[type='submit']").click();
-    await page.waitForTimeout(3000);
-    // Navigate to profile regardless of login result
+    await loginAsAdmin(page);
     await page.goto("/profile");
+    await page.waitForLoadState("domcontentloaded");
+    await expect(page).toHaveURL(/\/profile/);
     await expect(page.locator("body")).toBeVisible();
     await expect(page.locator("text=Internal Server Error")).not.toBeVisible();
   });

--- a/e2e/teams.spec.ts
+++ b/e2e/teams.spec.ts
@@ -2,7 +2,11 @@ import { test, expect } from "@playwright/test";
 
 async function loginAsAdmin(page) {
   await page.goto("/login");
-  await page.locator("[data-testid='login-email']").fill("admin@test.com");
+  // Wait for React island hydration so controlled inputs keep their values
+  await page.waitForLoadState("networkidle");
+  const emailInput = page.locator("[data-testid='login-email']");
+  await emailInput.waitFor({ state: "visible" });
+  await emailInput.fill("admin@test.com");
   await page.locator("[data-testid='login-password']").fill("test1234");
   await page.locator("[data-testid='login-submit']").click();
   await page.waitForURL("/", { timeout: 15000 });

--- a/e2e/teams.spec.ts
+++ b/e2e/teams.spec.ts
@@ -1,25 +1,58 @@
 import { test, expect } from "@playwright/test";
 
+async function loginAsAdmin(page) {
+  await page.goto("/login");
+  await page.locator("[data-testid='login-email']").fill("admin@test.com");
+  await page.locator("[data-testid='login-password']").fill("test1234");
+  await page.locator("[data-testid='login-submit']").click();
+  await page.waitForURL("/", { timeout: 15000 });
+  await page.waitForLoadState("domcontentloaded");
+}
+
 test.describe("Team Flow", () => {
   test("create team requires login", async ({ page }) => {
     await page.goto("/teams/create");
-    await expect(page).toHaveURL(/\/login/);
+    // Wait patiently for the auth redirect to complete (i18n routing may add locale prefix)
+    await page.waitForURL(/\/login/, { timeout: 10000 });
   });
 
   test("create team flow", async ({ page }) => {
-    await page.goto("/login");
-    await page.locator("input#email").fill("admin@test.com");
-    await page.locator("input#password").fill("test1234");
-    await page.locator("button[type='submit']").click();
-    await page.waitForTimeout(3000);
-    // Navigate to create team regardless of login result
+    await loginAsAdmin(page);
+
+    // Navigate to create team form
     await page.goto("/teams/create");
+    await page.waitForLoadState("domcontentloaded");
+    await expect(page).toHaveURL(/\/teams\/create/);
+
+    // Fill out the form using data-testid selectors
+    await page.locator("[data-testid='create-team-title']").fill("E2E Test Team");
+
+    // Select a location from the dropdown
+    const locationSelect = page.locator("[data-testid='create-team-location']");
+    await expect(locationSelect).toBeVisible();
+    // Pick the first non-empty option
+    const options = await locationSelect.locator("option").allTextContents();
+    const firstRealOption = options.find((text) => text.trim() !== "");
+    if (firstRealOption) {
+      await locationSelect.selectOption({ label: firstRealOption });
+    }
+
+    await page.locator("[data-testid='create-team-date']").fill("2026-12-31");
+    await page.locator("[data-testid='create-team-time']").fill("10:00");
+    await page.locator("[data-testid='create-team-max-members']").fill("5");
+    await page.locator("[data-testid='create-team-description']").fill("Created by E2E test");
+
+    // Submit and wait for navigation to the new team detail page
+    await page.locator("[data-testid='create-team-submit']").click();
+    await page.waitForURL(/\/teams\/.+/, { timeout: 5000 });
+
     await expect(page.locator("body")).toBeVisible();
     await expect(page.locator("text=Internal Server Error")).not.toBeVisible();
   });
 
   test("team detail page loads", async ({ page }) => {
     await page.goto("/teams/1");
+    await page.waitForLoadState("domcontentloaded");
     await expect(page.locator("body")).toBeVisible();
     await expect(page.locator("text=Internal Server Error")).not.toBeVisible();
   });

--- a/frontend/src/components/features/create-team-client.tsx
+++ b/frontend/src/components/features/create-team-client.tsx
@@ -294,6 +294,7 @@ export function CreateTeamClient() {
             <FieldGroup icon="✏️" label={t("teams.formLabel.name")} required>
               <input
                 id="title"
+                data-testid="create-team-title"
                 name="title"
                 type="text"
                 placeholder={t("teams.formPlaceholder.name")}
@@ -310,6 +311,7 @@ export function CreateTeamClient() {
                 <MapPin className="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 pointer-events-none text-muted-foreground" />
                 <select
                   id="locationId"
+                  data-testid="create-team-location"
                   name="locationId"
                   value={formData.locationId}
                   onChange={handleChange}
@@ -333,6 +335,7 @@ export function CreateTeamClient() {
                   <Calendar className="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 pointer-events-none text-muted-foreground" />
                   <input
                     id="date"
+                    data-testid="create-team-date"
                     name="date"
                     type="date"
                     value={formData.date}
@@ -349,6 +352,7 @@ export function CreateTeamClient() {
                   <Clock className="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 pointer-events-none text-muted-foreground" />
                   <input
                     id="time"
+                    data-testid="create-team-time"
                     name="time"
                     type="time"
                     value={formData.time}
@@ -384,6 +388,7 @@ export function CreateTeamClient() {
                   )}
                   <select
                     id="durationMin"
+                    data-testid="create-team-duration"
                     name="durationMin"
                     value={formData.durationMin}
                     onChange={handleDurationChange}
@@ -438,6 +443,7 @@ export function CreateTeamClient() {
                   <Users className="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 pointer-events-none text-muted-foreground" />
                   <input
                     id="maxMembers"
+                    data-testid="create-team-max-members"
                     name="maxMembers"
                     type="number"
                     min={2}
@@ -456,6 +462,7 @@ export function CreateTeamClient() {
             <FieldGroup icon="📝" label={t("teams.formLabel.description")} required hint={t("teams.descriptionHint")}>
               <textarea
                 id="description"
+                data-testid="create-team-description"
                 name="description"
                 placeholder={t("teams.formPlaceholder.description")}
                 value={formData.description}
@@ -494,6 +501,7 @@ export function CreateTeamClient() {
                 {t("common.cancel")}
               </button>
               <SubmitButton
+                data-testid="create-team-submit"
                 loading={isSubmitting || !hasWechat}
                 loadingText={!hasWechat ? t("teams.wechatRequiredBtn") : t("teams.createBtnLoading")}
                 className="flex-2"

--- a/frontend/src/components/layout/navbar.tsx
+++ b/frontend/src/components/layout/navbar.tsx
@@ -126,6 +126,7 @@ export function Navbar({ className }: NavbarProps) {
             {/* ---- Logo ---- */}
             <a
               href="/"
+              data-testid="nav-logo"
               className="flex items-center gap-2.5 group shrink-0"
               aria-label="GoMate"
             >
@@ -150,6 +151,7 @@ export function Navbar({ className }: NavbarProps) {
                   <a
                     key={link.href}
                     href={link.href}
+                    data-testid={`nav-link-${link.href.replace(/\//g, "-") || "home"}`}
                     aria-current={active ? "page" : undefined}
                     className={cn(
                       "relative px-3.5 py-2 text-sm font-medium rounded-lg transition-colors duration-150",
@@ -270,17 +272,18 @@ export function Navbar({ className }: NavbarProps) {
                   </div>
 
                   {/* 主 CTA：发布队伍 */}
-                  <CtaButton href="/teams/create" label={t("nav.createTeam")} icon={<Plus className="h-4 w-4" />} />
+                  <CtaButton href="/teams/create" data-testid="nav-create-team" label={t("nav.createTeam")} icon={<Plus className="h-4 w-4" />} />
                 </>
               ) : (
                 <>
                   <a
                     href="/login"
+                    data-testid="nav-login"
                     className="text-sm font-medium text-muted-foreground px-3 py-1.5 rounded-lg hover:bg-accent hover:text-foreground transition-colors duration-150"
                   >
                     {t("nav.login")}
                   </a>
-                  <CtaButton href="/register" label={t("nav.register")} />
+                  <CtaButton href="/register" data-testid="nav-register" label={t("nav.register")} />
                 </>
               )}
             </div>
@@ -288,6 +291,7 @@ export function Navbar({ className }: NavbarProps) {
             {/* ---- 移动端汉堡按钮 ---- */}
             <button
               type="button"
+              data-testid="nav-mobile-menu-toggle"
               className="md:hidden p-2 rounded-lg text-muted-foreground hover:bg-accent hover:text-foreground transition-colors duration-150"
               onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
               aria-label={isMobileMenuOpen ? t("common.closeMenu") : t("common.openMenu")}
@@ -469,14 +473,17 @@ function CtaButton({
   href,
   label,
   icon,
+  "data-testid": dataTestId,
 }: {
   href: string;
   label: string;
   icon?: React.ReactNode;
+  "data-testid"?: string;
 }) {
   return (
     <a
       href={href}
+      data-testid={dataTestId}
       className="flex items-center gap-1.5 text-sm font-medium px-4 py-1.5 rounded-lg transition-all hover:scale-[1.02] active:scale-[0.97] bg-primary text-primary-foreground shadow-md hover:shadow-lg transition-shadow"
     >
       {icon}


### PR DESCRIPTION
## 改动内容

1. **补齐关键交互元素的 data-testid**
   - 创建队伍表单：、、、、、、、
   - 导航栏：、、、、、

2. **消除不稳定的等待和条件分支**
   - ：登录成功改为  确定性断言，去掉  和 
   -  / ：提取  helper，复用登录逻辑

3. **解决 React island hydration 竞争**
   - 登录表单是 controlled input，在 hydration 完成前 fill 会被 React 冲掉
   - 增加  +  后再填值

4. **修复本地 HTTP 开发 session 不持久**
   -  的 cookie / 改为按  协议判断
   - 本地 HTTP 使用 ，避免登录后 session cookie 不被浏览器保存

## 本地验证

```bash
pnpm e2e:ci
```

结果：**20/20 全部通过** ✅

## 影响范围

- E2E 测试文件（、、）
- 前端组件（、）
- Auth 配置（）

## 注意事项

- 生产环境（HTTPS）cookie 行为不变：仍使用  和跨子域 cookie
- 本地 HTTP 开发时 session 现在可以正常保持，创建队伍等需要登录的流程测试才能通过

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)