### PR TITLE
test(e2e): extract shared login helpers to e2e/helpers.ts (#330 follow-up)

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,13 +1,5 @@
 import { test, expect } from "@playwright/test";
-
-async function fillLoginForm(page, email: string, password: string) {
-  // Wait for React island hydration so controlled inputs keep their values
-  await page.waitForLoadState("networkidle");
-  const emailInput = page.locator("[data-testid='login-email']");
-  await emailInput.waitFor({ state: "visible" });
-  await emailInput.fill(email);
-  await page.locator("[data-testid='login-password']").fill(password);
-}
+import { fillLoginForm } from "./helpers";
 
 test.describe("Auth", () => {
   test("login page loads and form is interactive", async ({ page }) => {

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,24 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * 等待登录页 React island hydration 完成，然后填写邮箱/密码。
+ *
+ * 登录表单的 input 是 React controlled component；如果在 hydration 完成前 fill，
+ * React 会在接管 DOM 时把值清掉，导致提交时邮箱为空、HTML5 验证拦截。
+ */
+export async function fillLoginForm(page: Page, email: string, password: string) {
+  await page.waitForLoadState("networkidle");
+  const emailInput = page.locator("[data-testid='login-email']");
+  await emailInput.waitFor({ state: "visible" });
+  await emailInput.fill(email);
+  await page.locator("[data-testid='login-password']").fill(password);
+}
+
+/** 使用 admin 测试账号登录 */
+export async function loginAsAdmin(page: Page) {
+  await page.goto("/login");
+  await fillLoginForm(page, "admin@test.com", "test1234");
+  await page.locator("[data-testid='login-submit']").click();
+  await page.waitForURL("/", { timeout: 15000 });
+  await page.waitForLoadState("domcontentloaded");
+}

--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -1,17 +1,5 @@
 import { test, expect } from "@playwright/test";
-
-async function loginAsAdmin(page) {
-  await page.goto("/login");
-  // Wait for React island hydration so controlled inputs keep their values
-  await page.waitForLoadState("networkidle");
-  const emailInput = page.locator("[data-testid='login-email']");
-  await emailInput.waitFor({ state: "visible" });
-  await emailInput.fill("admin@test.com");
-  await page.locator("[data-testid='login-password']").fill("test1234");
-  await page.locator("[data-testid='login-submit']").click();
-  await page.waitForURL("/", { timeout: 15000 });
-  await page.waitForLoadState("domcontentloaded");
-}
+import { loginAsAdmin } from "./helpers";
 
 test.describe("Profile", () => {
   test("profile page requires login", async ({ page }) => {

--- a/e2e/teams.spec.ts
+++ b/e2e/teams.spec.ts
@@ -1,17 +1,5 @@
 import { test, expect } from "@playwright/test";
-
-async function loginAsAdmin(page) {
-  await page.goto("/login");
-  // Wait for React island hydration so controlled inputs keep their values
-  await page.waitForLoadState("networkidle");
-  const emailInput = page.locator("[data-testid='login-email']");
-  await emailInput.waitFor({ state: "visible" });
-  await emailInput.fill("admin@test.com");
-  await page.locator("[data-testid='login-password']").fill("test1234");
-  await page.locator("[data-testid='login-submit']").click();
-  await page.waitForURL("/", { timeout: 15000 });
-  await page.waitForLoadState("domcontentloaded");
-}
+import { loginAsAdmin } from "./helpers";
 
 test.describe("Team Flow", () => {
   test("create team requires login", async ({ page }) => {


### PR DESCRIPTION
## 背景

PR #330 合并后发现 review 中要求的 `loginAsAdmin` helper 提取没有进入 main（merge 时最新 commit 未同步）。本 PR 补齐。

## 改动

- 新增 `e2e/helpers.ts`
  - `fillLoginForm(page, email, password)`：hydration-safe 的登录表单填写
  - `loginAsAdmin(page)`：admin 测试账号一键登录
- `e2e/auth.spec.ts`、`e2e/profile.spec.ts`、`e2e/teams.spec.ts` 改为 import helper，移除重复代码

## 验证

本地 `pnpm e2e:ci`：20/20 通过 ✅

## 关联

- PR #330 的 follow-up
- 为 task #121 队伍申请/审批 E2E 提供可复用的登录 helper

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
