### PR TITLE
fix(i18n): add missing home empty-state translation keys

### DIFF
--- a/frontend/public/locales/en/home.json
+++ b/frontend/public/locales/en/home.json
@@ -1,6 +1,9 @@
 {
   "featuredLocations": "Featured Locations",
   "recentTeams": "Recent Teams",
+  "noTeams": "No Active Teams",
+  "noTeamsDescription": "There are no active teams yet. Be the first to create one!",
+  "createFirstTeam": "Create First Team",
   "cta": {
     "title": "Ready to Go?",
     "subtitle": "Find your travel companions, the journey is not far",

--- a/frontend/public/locales/ja/home.json
+++ b/frontend/public/locales/ja/home.json
@@ -1,6 +1,9 @@
 {
   "featuredLocations": "厳選スポット",
   "recentTeams": "最近のチーム",
+  "noTeams": "アクティブなチームはありません",
+  "noTeamsDescription": "まだアクティブなチームがありません。最初のチームを作成しましょう！",
+  "createFirstTeam": "最初のチームを作成",
   "cta": {
     "title": "準備はできましたか",
     "subtitle": "同行者を見つければ、旅は遠くない",

--- a/frontend/public/locales/zh-CN/home.json
+++ b/frontend/public/locales/zh-CN/home.json
@@ -1,6 +1,9 @@
 {
   "featuredLocations": "精选地点",
   "recentTeams": "近期队伍",
+  "noTeams": "暂无活跃队伍",
+  "noTeamsDescription": "目前还没有活跃的队伍，成为第一个创建队伍的人吧！",
+  "createFirstTeam": "创建第一个队伍",
   "cta": {
     "title": "准备好了吗",
     "subtitle": "找到同行的人，出发就不远",


### PR DESCRIPTION
## Problem\nProduction homepage renders raw i18n keys when the recent-teams list is empty:\n- `home.noTeams`\n- `home.noTeamsDescription`\n- `home.createFirstTeam`\n\n## Fix\nAdd the missing keys to `frontend/public/locales/{en,zh-CN,ja}/home.json`.\n\n## Verification\n- `pnpm i18n:build` regenerates `locales-data.ts` successfully.\n- `pnpm type-check` passes.\n- Verified `localesData.en.home.noTeams`, `localesData['zh-CN'].home.noTeams`, and `localesData.ja.home.noTeams` are populated.\n\n## Scope\nOnly translation files changed; no component or logic changes.