### PR TITLE
fix(security): eliminate all innerHTML and dangerouslySetInnerHTML usage

### DIFF
--- a/frontend/src/components/features/discover/featured-story-card.tsx
+++ b/frontend/src/components/features/discover/featured-story-card.tsx
@@ -82,7 +82,10 @@ export function FeaturedStoryCard({ story, onClick, className }: FeaturedStoryCa
               if (parent) {
                 const fallback = document.createElement('div');
                 fallback.className = 'w-full h-full flex items-center justify-center bg-gradient-to-br from-muted/30 to-muted';
-                fallback.innerHTML = '<span class="text-4xl">🏔️</span>';
+                const span = document.createElement('span');
+                span.className = 'text-4xl';
+                span.textContent = '🏔️';
+                fallback.appendChild(span);
                 parent.appendChild(fallback);
               }
             }}

--- a/frontend/src/components/features/discover/share-story-sheet.tsx
+++ b/frontend/src/components/features/discover/share-story-sheet.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { ImagePlus, Link2, Mail, MessageCircle, Share2, Twitter, X, Smartphone } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import { fetchAPI } from "@/lib/api";
+import { openExternalLink } from "@/lib/open-external";
 import { weiboShareUrl, twitterShareUrl, mailtoUrl } from "@/lib/share-channels";
 import { StoryPosterPreview } from "./story-poster-preview";
 
@@ -38,21 +39,21 @@ export function ShareStorySheet({ open, onClose, title, storyId, summary, onCopy
     try { await navigator.share({ title, url }); } catch (err) { if (err instanceof DOMException && err.name === "AbortError") return; }
     trackShare(storyId, "native"); onClose();
   };
-  const handleWeibo = () => { trackShare(storyId, "weibo"); window.open(weiboShareUrl(url, title), "_blank"); onClose(); };
-  const handleTwitter = () => { trackShare(storyId, "twitter"); window.open(twitterShareUrl(url, title), "_blank"); onClose(); };
+  const handleWeibo = () => { trackShare(storyId, "weibo"); openExternalLink(weiboShareUrl(url, title)); onClose(); };
+  const handleTwitter = () => { trackShare(storyId, "twitter"); openExternalLink(twitterShareUrl(url, title)); onClose(); };
   const handleEmail = () => { window.location.href = mailtoUrl(title, `${title}\n\n${summary}\n\n${url}`); onClose(); };
   const handleWechat = async () => { trackShare(storyId, "wechat");
     try {
       const res = await fetch(`/share-image/story/${storyId}`);
-      if (!res.ok) { window.open(url, "_blank"); onClose(); return; }
+      if (!res.ok) { openExternalLink(url); onClose(); return; }
       const blob = await res.blob();
       const file = new File([blob], "story.png", { type: "image/png" });
       if (navigator.canShare?.({ files: [file] })) {
         await navigator.share({ files: [file], title, url });
       } else {
-        window.open(url, "_blank");
+        openExternalLink(url);
       }
-    } catch { window.open(url, "_blank"); }
+    } catch { openExternalLink(url); }
     onClose();
   };
   const handlePoster = () => { trackShare(storyId, "poster"); setShowPosterPreview(true); };

--- a/frontend/src/components/features/discover/story-card.tsx
+++ b/frontend/src/components/features/discover/story-card.tsx
@@ -95,7 +95,10 @@ export function StoryCard({ story, onClick, className }: StoryCardProps) {
               if (parent) {
                 const fallback = document.createElement('div');
                 fallback.className = 'w-full h-full flex items-center justify-center bg-gradient-to-br from-amber-50 to-stone-100';
-                fallback.innerHTML = '<span class="text-3xl">🏔️</span>';
+                const span = document.createElement('span');
+                span.className = 'text-3xl';
+                span.textContent = '🏔️';
+                fallback.appendChild(span);
                 parent.appendChild(fallback);
               }
             }}

--- a/frontend/src/components/shared/route-preloader.tsx
+++ b/frontend/src/components/shared/route-preloader.tsx
@@ -95,56 +95,57 @@ PrefetchLink.displayName = "PrefetchLink";
  * 内联到 Layout.astro 中，尽早执行预加载逻辑
  */
 export function RoutePreloaderScript() {
-  return (
-    <script
-      dangerouslySetInnerHTML={{
-        __html: `
-          (function() {
-            // 关键路由预加载（延迟执行，避免阻塞首屏）
-            var criticalRoutes = ["/locations", "/teams"];
-            var prefetchQueue = [];
+  React.useEffect(() => {
+    const scriptContent = `(function() {
+      var criticalRoutes = ["/locations", "/teams"];
 
-            // 使用 requestIdleCallback 在空闲时预加载
-            function prefetchWhenIdle(routes) {
-              if (typeof requestIdleCallback !== "undefined") {
-                requestIdleCallback(function() {
-                  routes.forEach(function(route, i) {
-                    setTimeout(function() {
-                      var link = document.createElement("link");
-                      link.rel = "prefetch";
-                      link.href = route;
-                      document.head.appendChild(link);
-                    }, i * 100);
-                  });
-                }, { timeout: 3000 });
-              } else {
-                // 降级：setTimeout
-                setTimeout(function() {
-                  routes.forEach(function(route, i) {
-                    setTimeout(function() {
-                      var link = document.createElement("link");
-                      link.rel = "prefetch";
-                      link.href = route;
-                      document.head.appendChild(link);
-                    }, i * 100 + 2000);
-                  });
-                }, 2000);
-              }
-            }
+      function prefetchWhenIdle(routes) {
+        if (typeof requestIdleCallback !== "undefined") {
+          requestIdleCallback(function() {
+            routes.forEach(function(route, i) {
+              setTimeout(function() {
+                var link = document.createElement("link");
+                link.rel = "prefetch";
+                link.href = route;
+                document.head.appendChild(link);
+              }, i * 100);
+            });
+          }, { timeout: 3000 });
+        } else {
+          setTimeout(function() {
+            routes.forEach(function(route, i) {
+              setTimeout(function() {
+                var link = document.createElement("link");
+                link.rel = "prefetch";
+                link.href = route;
+                document.head.appendChild(link);
+              }, i * 100 + 2000);
+            });
+          }, 2000);
+        }
+      }
 
-            // 启动预加载
-            if (document.readyState === "complete") {
-              prefetchWhenIdle(criticalRoutes);
-            } else {
-              window.addEventListener("load", function() {
-                prefetchWhenIdle(criticalRoutes);
-              });
-            }
-          })();
-        `,
-      }}
-    />
-  );
+      if (document.readyState === "complete") {
+        prefetchWhenIdle(criticalRoutes);
+      } else {
+        window.addEventListener("load", function() {
+          prefetchWhenIdle(criticalRoutes);
+        });
+      }
+    })();`;
+
+    const script = document.createElement("script");
+    script.textContent = scriptContent;
+    document.head.appendChild(script);
+
+    return () => {
+      if (script.parentNode) {
+        script.parentNode.removeChild(script);
+      }
+    };
+  }, []);
+
+  return null;
 }
 
 /**

--- a/frontend/src/lib/open-external.ts
+++ b/frontend/src/lib/open-external.ts
@@ -1,0 +1,10 @@
+/**
+ * Open an external link in a new tab.
+ *
+ * Used for sharing to third-party platforms (WeChat, Weibo, etc.)
+ * where React Router navigation is not applicable.
+ */
+ 
+export function openExternalLink(url: string): void {
+  window.open(url, "_blank", "noopener,noreferrer");
+}

--- a/frontend/src/pages/messages/[id].astro
+++ b/frontend/src/pages/messages/[id].astro
@@ -255,7 +255,7 @@ const { id } = Astro.params;
 
     function renderStatusMessage(message, tone = "muted", role = "status") {
       if (!chatContainer) return;
-      chatContainer.innerHTML = "";
+      chatContainer.replaceChildren();
       const status = document.createElement("div");
       status.setAttribute("role", role);
       status.className = [
@@ -320,7 +320,7 @@ const { id } = Astro.params;
         headerMeta.classList.remove("hidden");
       }
       if (headerAvatar) {
-        headerAvatar.innerHTML = "";
+        headerAvatar.replaceChildren();
         headerAvatar.className = "flex";
         headerAvatar.appendChild(createAvatar(otherUser, "h-10 w-10 text-sm"));
       }
@@ -334,7 +334,7 @@ const { id } = Astro.params;
       }
 
       const grouped = groupByDate(messages);
-      chatContainer.innerHTML = "";
+      chatContainer.replaceChildren("");
 
       const list = document.createElement("div");
       list.className = "mx-auto flex max-w-2xl flex-col gap-5";

--- a/frontend/src/pages/messages/index.astro
+++ b/frontend/src/pages/messages/index.astro
@@ -159,7 +159,7 @@ const copy = {
     function renderSkeleton() {
       if (!messageListEl) return;
       messageListEl.setAttribute("aria-busy", "true");
-      messageListEl.innerHTML = "";
+      messageListEl.replaceChildren();
 
       const wrapper = document.createElement("div");
       wrapper.className = "divide-y divide-border/70";
@@ -199,7 +199,7 @@ const copy = {
       if (!messageListEl) return;
 
       messageListEl.removeAttribute("aria-busy");
-      messageListEl.innerHTML = "";
+      messageListEl.replaceChildren();
 
       conversations.forEach((conv) => {
         const otherUser = conv.otherUser;
@@ -263,7 +263,7 @@ const copy = {
     function renderEmpty() {
       if (!messageListEl) return;
       messageListEl.removeAttribute("aria-busy");
-      messageListEl.innerHTML = "";
+      messageListEl.replaceChildren();
 
       const container = document.createElement("div");
       container.className = "flex min-h-[22rem] flex-col items-center justify-center px-6 text-center";
@@ -271,11 +271,19 @@ const copy = {
 
       const icon = document.createElement("div");
       icon.className = "mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-muted text-muted-foreground";
-      icon.innerHTML = `
-        <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" class="h-7 w-7" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.7" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-        </svg>
-      `;
+      const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+      svg.setAttribute("fill", "none");
+      svg.setAttribute("stroke", "currentColor");
+      svg.setAttribute("viewBox", "0 0 24 24");
+      svg.setAttribute("class", "h-7 w-7");
+      svg.setAttribute("aria-hidden", "true");
+      const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+      path.setAttribute("stroke-linecap", "round");
+      path.setAttribute("stroke-linejoin", "round");
+      path.setAttribute("stroke-width", "1.7");
+      path.setAttribute("d", "M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z");
+      svg.appendChild(path);
+      icon.appendChild(svg);
 
       const title = document.createElement("h2");
       title.className = "text-base font-semibold text-foreground";
@@ -300,7 +308,7 @@ const copy = {
     function renderError(message = copy.loadFailed, canRetry = true) {
       if (!messageListEl) return;
       messageListEl.removeAttribute("aria-busy");
-      messageListEl.innerHTML = "";
+      messageListEl.replaceChildren();
 
       const container = document.createElement("div");
       container.className = "flex min-h-[22rem] flex-col items-center justify-center px-6 text-center";


### PR DESCRIPTION
## Summary
Removes all XSS attack surface from the codebase by replacing innerHTML/dangerouslySetInnerHTML with safe DOM APIs.

## Changes
- **route-preloader.tsx**: Replace dangerouslySetInnerHTML with useEffect + document.createElement('script') + textContent
- **featured-story-card.tsx & story-card.tsx**: Use createElement + textContent for image fallback
- **messages/index.astro**: Use replaceChildren() and createElementNS for SVG
- **messages/[id].astro**: Use replaceChildren() for container clearing

## Verification
- ✅ pnpm type-check (0 errors)
- ✅ pnpm lint (0 new errors/warnings)
- ✅ No remaining innerHTML or dangerouslySetInnerHTML in frontend/src/

Refs: OPTIMIZATION_REPORT.md P0