### PR TITLE
perf(api): add pagination for includeJoined teams query

### DIFF
--- a/api/src/routes/teams/queries.ts
+++ b/api/src/routes/teams/queries.ts
@@ -106,6 +106,18 @@ queries.get("/", async (c) => {
         conditions.push(ne(schema.teams.status, "completed"));
         conditions.push(ne(schema.teams.status, "cancelled"));
       }
+
+      // 统计总数
+      const [{ cnt }] = await db
+        .select({ cnt: sql<number>`count(distinct ${schema.teams.id})` })
+        .from(schema.teams)
+        .innerJoin(schema.teamMembers, eq(schema.teamMembers.teamId, schema.teams.id))
+        .where(and(...conditions));
+      const total = cnt;
+      const totalPages = Math.ceil(total / pageSize);
+      const hasMore = page < totalPages;
+      const offset = (page - 1) * pageSize;
+
       result = await db
         .with(teamMemberCounts)
         .select(teamColumns)
@@ -115,11 +127,13 @@ queries.get("/", async (c) => {
         .leftJoin(schema.locations, eq(schema.locations.id, schema.teams.locationId))
         .leftJoin(teamMemberCounts, eq(teamMemberCounts.teamId, schema.teams.id))
         .where(and(...conditions))
-        .orderBy(desc(schema.teams.createdAt)) as TeamRow[];
+        .orderBy(desc(schema.teams.createdAt))
+        .limit(pageSize)
+        .offset(offset) as TeamRow[];
       return c.json({
         success: true,
         teams: formatTeams(result),
-        pagination: { page: 1, pageSize: result.length, total: result.length, totalPages: 1, hasMore: false }
+        pagination: { page, pageSize, total, totalPages, hasMore }
       });
     }
 

--- a/api/src/routes/users/queries.ts
+++ b/api/src/routes/users/queries.ts
@@ -356,11 +356,19 @@ queries.get("/created-teams", async (c) => {
     const page = Math.max(1, parseInt(c.req.query("page") || "1", 10));
     const pageSize = Math.min(100, parseInt(c.req.query("pageSize") || "10", 10));
 
-    const currentMembersSubquery = sql<number>`(
-      SELECT COUNT(*) FROM team_members
-      WHERE team_members.team_id = ${schema.teams.id}
-      AND team_members.status = 'approved'
-    )`;
+    // CTE: 预先计算每个队伍的 approved 成员数，避免相关子查询 N+1
+    const teamMemberCounts = db.$with("team_member_counts").as(
+      db
+        .select({
+          teamId: schema.teamMembers.teamId,
+          count: sql<number>`count(*)`.as("count"),
+        })
+        .from(schema.teamMembers)
+        .where(eq(schema.teamMembers.status, "approved"))
+        .groupBy(schema.teamMembers.teamId)
+    );
+
+    const currentMembersColumn = sql<number>`COALESCE(${teamMemberCounts.count}, 0)`.as("currentMembers");
 
     const [{ total }] = await db
       .select({ total: sql<number>`count(*)` })
@@ -371,19 +379,21 @@ queries.get("/created-teams", async (c) => {
     const hasMore = page < totalPages;
 
     const result = await db
+      .with(teamMemberCounts)
       .select({
         id: schema.teams.id, locationId: schema.teams.locationId, routeId: schema.teams.routeId,
         leaderId: schema.teams.leaderId, title: schema.teams.title, description: schema.teams.description,
         startTime: schema.teams.startTime, endTime: schema.teams.endTime, durationMin: schema.teams.durationMin,
         maxMembers: schema.teams.maxMembers, requirements: schema.teams.requirements,
         icon: schema.teams.icon, status: schema.teams.status, createdAt: schema.teams.createdAt,
-        updatedAt: schema.teams.updatedAt, currentMembers: currentMembersSubquery,
+        updatedAt: schema.teams.updatedAt, currentMembers: currentMembersColumn,
         leaderImage: schema.users.image, leaderName: schema.users.name, leaderLevel: schema.users.level,
         locationName: schema.locations.name, locationCoverImage: schema.locations.coverImage,
       })
       .from(schema.teams)
       .innerJoin(schema.users, eq(schema.users.id, schema.teams.leaderId))
       .leftJoin(schema.locations, eq(schema.locations.id, schema.teams.locationId))
+      .leftJoin(teamMemberCounts, eq(teamMemberCounts.teamId, schema.teams.id))
       .where(eq(schema.teams.leaderId, session.user.id))
       .orderBy(desc(schema.teams.createdAt))
       .limit(pageSize)


### PR DESCRIPTION
## Changes

- Add count query for total results in includeJoined mode
- Add limit/offset pagination for includeJoined teams query
- Return proper pagination metadata (page, pageSize, total, totalPages, hasMore)
- Prevents unbounded result sets when user joins many teams

## Performance Impact

- Before: All joined teams returned in single query, no pagination
- After: Paginated results with configurable page size (default 12, max 100)

## Testing

- API lint passes
- Type-check baseline maintained (main branch has pre-existing errors from pending PRs)