### PR TITLE
perf(db): replace correlated subqueries with CTEs for team member counts

### DIFF
--- a/api/src/routes/users/queries.ts
+++ b/api/src/routes/users/queries.ts
@@ -270,11 +270,19 @@ queries.get("/teams/joined", async (c) => {
     const page = Math.max(1, parseInt(c.req.query("page") || "1", 10));
     const pageSize = Math.min(100, parseInt(c.req.query("pageSize") || "10", 10));
 
-    const currentMembersSubquery = sql<number>`(
-      SELECT COUNT(*) FROM team_members
-      WHERE team_members.team_id = ${schema.teams.id}
-      AND team_members.status = 'approved'
-    )`;
+    // CTE: 预先计算每个队伍的 approved 成员数，避免相关子查询 N+1
+    const teamMemberCounts = db.$with("team_member_counts").as(
+      db
+        .select({
+          teamId: schema.teamMembers.teamId,
+          count: sql<number>`count(*)`.as("count"),
+        })
+        .from(schema.teamMembers)
+        .where(eq(schema.teamMembers.status, "approved"))
+        .groupBy(schema.teamMembers.teamId)
+    );
+
+    const currentMembersColumn = sql<number>`COALESCE(${teamMemberCounts.count}, 0)`.as("currentMembers");
 
     const memberships = await db.query.teamMembers.findMany({
       where: (tm, { and }) =>
@@ -297,19 +305,21 @@ queries.get("/teams/joined", async (c) => {
     const hasMore = page < totalPages;
 
     const result = await db
+      .with(teamMemberCounts)
       .select({
         id: schema.teams.id, locationId: schema.teams.locationId, routeId: schema.teams.routeId,
         leaderId: schema.teams.leaderId, title: schema.teams.title, description: schema.teams.description,
         startTime: schema.teams.startTime, endTime: schema.teams.endTime, durationMin: schema.teams.durationMin,
         maxMembers: schema.teams.maxMembers, requirements: schema.teams.requirements,
         icon: schema.teams.icon, status: schema.teams.status, createdAt: schema.teams.createdAt,
-        updatedAt: schema.teams.updatedAt, currentMembers: currentMembersSubquery,
+        updatedAt: schema.teams.updatedAt, currentMembers: currentMembersColumn,
         leaderImage: schema.users.image, leaderName: schema.users.name, leaderLevel: schema.users.level,
         locationName: schema.locations.name, locationCoverImage: schema.locations.coverImage,
       })
       .from(schema.teams)
       .innerJoin(schema.users, eq(schema.users.id, schema.teams.leaderId))
       .leftJoin(schema.locations, eq(schema.locations.id, schema.teams.locationId))
+      .leftJoin(teamMemberCounts, eq(teamMemberCounts.teamId, schema.teams.id))
       .where(and(inArray(schema.teams.id, teamIds), ne(schema.teams.leaderId, session.user.id)))
       .orderBy(desc(schema.teams.createdAt))
       .limit(pageSize)
@@ -356,11 +366,19 @@ queries.get("/created-teams", async (c) => {
     const page = Math.max(1, parseInt(c.req.query("page") || "1", 10));
     const pageSize = Math.min(100, parseInt(c.req.query("pageSize") || "10", 10));
 
-    const currentMembersSubquery = sql<number>`(
-      SELECT COUNT(*) FROM team_members
-      WHERE team_members.team_id = ${schema.teams.id}
-      AND team_members.status = 'approved'
-    )`;
+    // CTE: 预先计算每个队伍的 approved 成员数，避免相关子查询 N+1
+    const teamMemberCounts = db.$with("team_member_counts").as(
+      db
+        .select({
+          teamId: schema.teamMembers.teamId,
+          count: sql<number>`count(*)`.as("count"),
+        })
+        .from(schema.teamMembers)
+        .where(eq(schema.teamMembers.status, "approved"))
+        .groupBy(schema.teamMembers.teamId)
+    );
+
+    const currentMembersColumn = sql<number>`COALESCE(${teamMemberCounts.count}, 0)`.as("currentMembers");
 
     const [{ total }] = await db
       .select({ total: sql<number>`count(*)` })
@@ -371,19 +389,21 @@ queries.get("/created-teams", async (c) => {
     const hasMore = page < totalPages;
 
     const result = await db
+      .with(teamMemberCounts)
       .select({
         id: schema.teams.id, locationId: schema.teams.locationId, routeId: schema.teams.routeId,
         leaderId: schema.teams.leaderId, title: schema.teams.title, description: schema.teams.description,
         startTime: schema.teams.startTime, endTime: schema.teams.endTime, durationMin: schema.teams.durationMin,
         maxMembers: schema.teams.maxMembers, requirements: schema.teams.requirements,
         icon: schema.teams.icon, status: schema.teams.status, createdAt: schema.teams.createdAt,
-        updatedAt: schema.teams.updatedAt, currentMembers: currentMembersSubquery,
+        updatedAt: schema.teams.updatedAt, currentMembers: currentMembersColumn,
         leaderImage: schema.users.image, leaderName: schema.users.name, leaderLevel: schema.users.level,
         locationName: schema.locations.name, locationCoverImage: schema.locations.coverImage,
       })
       .from(schema.teams)
       .innerJoin(schema.users, eq(schema.users.id, schema.teams.leaderId))
       .leftJoin(schema.locations, eq(schema.locations.id, schema.teams.locationId))
+      .leftJoin(teamMemberCounts, eq(teamMemberCounts.teamId, schema.teams.id))
       .where(eq(schema.teams.leaderId, session.user.id))
       .orderBy(desc(schema.teams.createdAt))
       .limit(pageSize)

--- a/api/src/routes/users/utils.ts
+++ b/api/src/routes/users/utils.ts
@@ -94,27 +94,44 @@ export async function getUserOngoingTeams(db: Db, id: string) {
   const now = new Date();
   const activeStatuses = ["recruiting", "full", "formed"];
   const { sql } = await import("drizzle-orm");
-  const currentMembersSubquery = sql<number>`(SELECT COUNT(*) FROM team_members WHERE team_members.team_id = ${schema.teams.id} AND team_members.status = 'approved')`;
+
+  // CTE: 预先计算每个队伍的 approved 成员数，避免相关子查询 N+1
+  const teamMemberCounts = db.$with("team_member_counts").as(
+    db
+      .select({
+        teamId: schema.teamMembers.teamId,
+        count: sql<number>`count(*)`.as("count"),
+      })
+      .from(schema.teamMembers)
+      .where(eq(schema.teamMembers.status, "approved"))
+      .groupBy(schema.teamMembers.teamId)
+  );
+
+  const currentMembersColumn = sql<number>`COALESCE(${teamMemberCounts.count}, 0)`.as("currentMembers");
 
   const ongoingSelect = {
     id: schema.teams.id, title: schema.teams.title, startTime: schema.teams.startTime,
     endTime: schema.teams.endTime, maxMembers: schema.teams.maxMembers, status: schema.teams.status,
     locationName: schema.locations.name, locationCoverImage: schema.locations.coverImage,
-    currentMembers: currentMembersSubquery,
+    currentMembers: currentMembersColumn,
   };
 
   const createdOngoingTeams = await db
+    .with(teamMemberCounts)
     .select(ongoingSelect)
     .from(schema.teams)
     .leftJoin(schema.locations, eq(schema.locations.id, schema.teams.locationId))
+    .leftJoin(teamMemberCounts, eq(teamMemberCounts.teamId, schema.teams.id))
     .where(and(eq(schema.teams.leaderId, id), inArray(schema.teams.status, activeStatuses), gt(schema.teams.endTime, now)))
     .limit(5);
 
   const joinedOngoingTeams = await db
+    .with(teamMemberCounts)
     .select(ongoingSelect)
     .from(schema.teams)
     .innerJoin(schema.teamMembers, eq(schema.teamMembers.teamId, schema.teams.id))
     .leftJoin(schema.locations, eq(schema.locations.id, schema.teams.locationId))
+    .leftJoin(teamMemberCounts, eq(teamMemberCounts.teamId, schema.teams.id))
     .where(
       and(
         eq(schema.teamMembers.userId, id),


### PR DESCRIPTION
Replace correlated subqueries in user routes with CTEs to avoid N+1 query issues.

## Changes
- `api/src/routes/users/utils.ts`: `getUserOngoingTeams` - use CTE for member counts
- `api/src/routes/users/queries.ts`: `/teams/joined` and `/created-teams` - use CTE for member counts

## Why
Correlated subqueries like `SELECT COUNT(*) FROM team_members WHERE team_id = teams.id` execute once per row, causing N+1 query problems. Using CTE with LEFT JOIN + COALESCE computes counts once per query.

## Verification
- `pnpm type-check`: ✅ 0 errors
- `pnpm test`: ✅ 185 passed