### PR TITLE
fix(lint): replace window.open with openExternalLink utility

### DIFF
--- a/frontend/src/components/features/discover/share-story-sheet.tsx
+++ b/frontend/src/components/features/discover/share-story-sheet.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { ImagePlus, Link2, Mail, MessageCircle, Share2, Twitter, X, Smartphone } from "lucide-react";
+import { openExternalLink } from "@/lib/open-external";
 import { useI18n } from "@/hooks/useI18n";
 import { fetchAPI } from "@/lib/api";
 import { weiboShareUrl, twitterShareUrl, mailtoUrl } from "@/lib/share-channels";
@@ -38,21 +39,21 @@ export function ShareStorySheet({ open, onClose, title, storyId, summary, onCopy
     try { await navigator.share({ title, url }); } catch (err) { if (err instanceof DOMException && err.name === "AbortError") return; }
     trackShare(storyId, "native"); onClose();
   };
-  const handleWeibo = () => { trackShare(storyId, "weibo"); window.open(weiboShareUrl(url, title), "_blank"); onClose(); };
-  const handleTwitter = () => { trackShare(storyId, "twitter"); window.open(twitterShareUrl(url, title), "_blank"); onClose(); };
+  const handleWeibo = () => { trackShare(storyId, "weibo"); openExternalLink(weiboShareUrl(url, title)); onClose(); };
+  const handleTwitter = () => { trackShare(storyId, "twitter"); openExternalLink(twitterShareUrl(url, title)); onClose(); };
   const handleEmail = () => { window.location.href = mailtoUrl(title, `${title}\n\n${summary}\n\n${url}`); onClose(); };
   const handleWechat = async () => { trackShare(storyId, "wechat");
     try {
       const res = await fetch(`/share-image/story/${storyId}`);
-      if (!res.ok) { window.open(url, "_blank"); onClose(); return; }
+      if (!res.ok) { openExternalLink(url); onClose(); return; }
       const blob = await res.blob();
       const file = new File([blob], "story.png", { type: "image/png" });
       if (navigator.canShare?.({ files: [file] })) {
         await navigator.share({ files: [file], title, url });
       } else {
-        window.open(url, "_blank");
+        openExternalLink(url);
       }
-    } catch { window.open(url, "_blank"); }
+    } catch { openExternalLink(url); }
     onClose();
   };
   const handlePoster = () => { trackShare(storyId, "poster"); setShowPosterPreview(true); };

--- a/frontend/src/components/features/location-detail/address-row.tsx
+++ b/frontend/src/components/features/location-detail/address-row.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { MapPin, Navigation, Check, Copy } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
+import { openExternalLink } from "@/lib/open-external";
 import { cn } from "@/lib/utils";
 
 interface AddressRowProps {
@@ -28,7 +29,7 @@ export function AddressRow({ address, coordinates, locationName, className }: Ad
     e.stopPropagation();
     const dest = encodeURIComponent(locationName || address);
     const url = `https://uri.amap.com/navigation?to=${coordinates!.lng},${coordinates!.lat},${dest}&callnative=0`;
-    window.open(url, "_blank", "noopener,noreferrer");
+    openExternalLink(url);
   };
 
   return (

--- a/frontend/src/components/features/location-detail/location-intro-card.tsx
+++ b/frontend/src/components/features/location-detail/location-intro-card.tsx
@@ -12,6 +12,7 @@ import {
   Sparkles,
 } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
+import { openExternalLink } from "@/lib/open-external";
 import { cn } from "@/lib/utils";
 import type { Location, Tag } from "@/lib/types";
 
@@ -62,7 +63,7 @@ export function LocationIntroCard({
     if (!coordinates) return;
     const dest = encodeURIComponent(location.name || address || "");
     const url = `https://uri.amap.com/navigation?to=${coordinates.lng},${coordinates.lat},${dest}&callnative=0`;
-    window.open(url, "_blank", "noopener,noreferrer");
+    openExternalLink(url);
   };
 
   React.useEffect(() => {

--- a/frontend/src/components/features/share-poster-modal.tsx
+++ b/frontend/src/components/features/share-poster-modal.tsx
@@ -112,6 +112,7 @@ export function SharePosterModal({
 
       if (isIOS) {
         // Open image in new tab for iOS (user can long press to save)
+        // eslint-disable-next-line no-restricted-properties
         const newWindow = window.open();
         if (newWindow) {
           newWindow.document.write(`

--- a/frontend/src/components/features/team-detail/share-poster-preview.tsx
+++ b/frontend/src/components/features/team-detail/share-poster-preview.tsx
@@ -115,6 +115,7 @@ export function SharePosterPreview({
 
       if (isIOS) {
         // Open image in new tab for iOS (user can long press to save)
+        // eslint-disable-next-line no-restricted-properties
         const newWindow = window.open();
         if (newWindow) {
           newWindow.document.write(`

--- a/frontend/src/lib/open-external.ts
+++ b/frontend/src/lib/open-external.ts
@@ -1,0 +1,10 @@
+/**
+ * Open an external link in a new tab.
+ *
+ * Used for sharing to third-party platforms (WeChat, Weibo, etc.)
+ * where React Router navigation is not applicable.
+ */
+export function openExternalLink(url: string): void {
+  // eslint-disable-next-line no-restricted-properties
+  window.open(url, "_blank", "noopener,noreferrer");
+}


### PR DESCRIPTION
## 变更

- 新增 <code>frontend/src/lib/open-external.ts</code> 包装 <code>window.open</code>
- 替换 <code>share-story-sheet.tsx</code>、<code>address-row.tsx</code>、<code>location-intro-card.tsx</code> 中的 <code>window.open</code> 为 <code>openExternalLink</code>
- 对 <code>share-poster-modal.tsx</code> 和 <code>share-poster-preview.tsx</code> 添加 <code>eslint-disable</code> 注释（空白窗口为合法用途）
- 修复 5 个 <code>no-restricted-properties</code> lint warnings

## 验证

- [x] <code>pnpm type-check</code> 通过
- [x] <code>pnpm lint</code> 0 errors, 56 warnings → 51 warnings

## 关联

Refs: OPTIMIZATION_REPORT.md P1