### PR TITLE
refactor(api): extract Beijing timezone utilities to shared module

### DIFF
--- a/api/src/lib/date-utils.ts
+++ b/api/src/lib/date-utils.ts
@@ -1,0 +1,33 @@
+/**
+ * Date/time formatting utilities with Beijing timezone (UTC+8) support.
+ *
+ * NOTE: This project primarily serves users in China, so Beijing time
+ * is the default display timezone. All hard-coded UTC+8 offsets should
+ * be consolidated here to avoid duplication.
+ */
+
+const BEIJING_OFFSET_MS = 8 * 60 * 60 * 1000;
+
+/** Format a Date as Beijing date and time strings */
+export function formatBeijingDateTime(date: Date | null): { date: string | null; time: string | null } {
+  if (!date) return { date: null, time: null };
+  const beijingDate = new Date(date.getTime() + BEIJING_OFFSET_MS);
+  return {
+    date: beijingDate.toISOString().split("T")[0],
+    time: beijingDate.toISOString().slice(11, 16),
+  };
+}
+
+/** Format a Date as Beijing date string (YYYY-MM-DD) */
+export function formatBeijingDate(date: Date | null): string | null {
+  if (!date) return null;
+  const beijingDate = new Date(date.getTime() + BEIJING_OFFSET_MS);
+  return beijingDate.toISOString().split("T")[0];
+}
+
+/** Format a Date as Beijing time string (HH:mm) */
+export function formatBeijingTime(date: Date | null): string | null {
+  if (!date) return null;
+  const beijingDate = new Date(date.getTime() + BEIJING_OFFSET_MS);
+  return beijingDate.toISOString().slice(11, 16);
+}

--- a/api/src/routes/teams/queries.ts
+++ b/api/src/routes/teams/queries.ts
@@ -6,6 +6,7 @@ import { createDb } from "../../db";
 import * as schema from "../../db/schema";
 import type { Env } from "../../lib/auth";
 import { getTimeFilterRange, parseRequirements, getRouteTags } from "./utils";
+import { formatBeijingDateTime } from "../../lib/date-utils";
 import { getCachedOrFetch, buildListCacheKey, setPublicCacheHeaders } from "../../lib/cache";
 import { updateExpiredTeams } from "../../lib/team-status";
 import { APIErrors } from "../../lib/api-errors";
@@ -307,10 +308,7 @@ function formatTeams(result: {
   return result.map((row) => {
     const startDate = new Date(row.startTime);
     const endDate = new Date(row.endTime);
-    // 使用北京时间（UTC+8）格式化日期和时间
-    const beijingDate = new Date(startDate.getTime() + 8 * 60 * 60 * 1000);
-    const date = beijingDate.toISOString().split("T")[0];
-    const time = beijingDate.toISOString().slice(11, 16);
+    const { date, time } = formatBeijingDateTime(startDate);
     const durationHours = Math.round(
       (endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60)
     );
@@ -386,10 +384,7 @@ queries.get("/:id", async (c) => {
       : false;
 
     const startDate = new Date(teamWithRelations.startTime);
-    // 使用北京时间（UTC+8）格式化日期和时间
-    const beijingDate = new Date(startDate.getTime() + 8 * 60 * 60 * 1000);
-    const date = beijingDate.toISOString().split("T")[0];
-    const time = beijingDate.toISOString().slice(11, 16);
+    const { date, time } = formatBeijingDateTime(startDate);
     const durationMinutes = teamWithRelations.durationMin ||
       Math.round((new Date(teamWithRelations.endTime).getTime() - startDate.getTime()) / 60000);
     const durationHours = Math.round(durationMinutes / 60);

--- a/api/src/routes/users/utils.ts
+++ b/api/src/routes/users/utils.ts
@@ -1,18 +1,12 @@
 import * as schema from "../../db/schema";
 import { and, eq, ne, gt, inArray } from "drizzle-orm";
 import type { createDb } from "../../db";
+import { formatBeijingDateTime } from "../../lib/date-utils";
 
 type Db = ReturnType<typeof createDb>;
 
-/** 格式化日期为北京时间（UTC+8）的 date 和 time 字符串 */
-export function formatBeijingDateTime(date: Date | null): { date: string | null; time: string | null } {
-  if (!date) return { date: null, time: null };
-  const beijingDate = new Date(date.getTime() + 8 * 60 * 60 * 1000);
-  return {
-    date: beijingDate.toISOString().split("T")[0],
-    time: beijingDate.toISOString().slice(11, 16),
-  };
-}
+// Re-export for backward compatibility
+export { formatBeijingDateTime };
 
 /** 返回安全的用户对象（时间戳格式） */
 export function sanitizeUser(user: typeof schema.users.$inferSelect) {


### PR DESCRIPTION
Eliminate hard-coded UTC+8 offsets scattered across route files by introducing a centralized date-utils module.

## Changes
- Create `api/src/lib/date-utils.ts` with `formatBeijingDateTime`, `formatBeijingDate`, and `formatBeijingTime`
- Update `api/src/routes/users/utils.ts` to import from shared module
- Update `api/src/routes/teams/queries.ts` to use shared module instead of inline `+ 8 * 60 * 60 * 1000`

## Verification
- `pnpm type-check`: 0 errors
- `pnpm test`: 185 passed