### PR TITLE
refactor(api): replace remaining console.* in email modules with logger

### DIFF
--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -1,6 +1,7 @@
 import { Resend } from "resend";
 import { getEmailField, EmailLocale } from "./email-i18n";
 import { withTimeout } from "./timeout";
+import { logger } from "./logger";
 
 /**
  * 发送密码重置邮件
@@ -14,7 +15,7 @@ export async function sendPasswordResetEmail(
 ): Promise<{ success: boolean; error?: string }> {
   const apiKey = env.RESEND_API_KEY;
   if (!apiKey) {
-    console.warn("[Email] RESEND_API_KEY not configured");
+    logger.warn("[Email] RESEND_API_KEY not configured");
     return { success: false, error: "Email service not configured" };
   }
 
@@ -46,7 +47,7 @@ export async function sendPasswordResetEmail(
 
     return { success: true };
   } catch (error) {
-    console.error("[Email] Failed to send password reset email:", error);
+    logger.error("[Email] Failed to send password reset email:", error);
     return { success: false, error: (error as Error).message };
   }
 }
@@ -94,7 +95,7 @@ export async function sendWelcomeEmail(
 
     return { success: true };
   } catch (error) {
-    console.error("[Email] Failed to send welcome email:", error);
+    logger.error("[Email] Failed to send welcome email:", error);
     return { success: false, error: (error as Error).message };
   }
 }
@@ -137,7 +138,7 @@ export async function sendContactFormEmail(
 
     return { success: true };
   } catch (error) {
-    console.error("[Email] Failed to send contact form email:", error);
+    logger.error("[Email] Failed to send contact form email:", error);
     return { success: false, error: (error as Error).message };
   }
 }
@@ -192,7 +193,7 @@ export async function sendTeamJoinApplicationEmail(
 
     return { success: true };
   } catch (error) {
-    console.error("[Email] Failed to send team join application email:", error);
+    logger.error("[Email] Failed to send team join application email:", error);
     return { success: false, error: (error as Error).message };
   }
 }
@@ -276,7 +277,7 @@ export async function sendFeedbackEmail(
 
     return { success: true };
   } catch (error) {
-    console.error("[Email] Failed to send feedback email:", error);
+    logger.error("[Email] Failed to send feedback email:", error);
     return { success: false, error: (error as Error).message };
   }
 }

--- a/frontend/src/components/features/location-detail/address-row.tsx
+++ b/frontend/src/components/features/location-detail/address-row.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { MapPin, Navigation, Check, Copy } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import { openExternalLink } from "@/lib/open-external";
+import { cn } from "@/lib/utils";
 
 interface AddressRowProps {
   address: string;

--- a/frontend/src/components/features/location-edit-client.tsx
+++ b/frontend/src/components/features/location-edit-client.tsx
@@ -130,7 +130,7 @@ function MapPickerModal({ initialLat, initialLng, onConfirm, onClose }: MapPicke
   const [isLoadingMap, setIsLoadingMap] = React.useState(true);
 
   const [searchQuery, setSearchQuery] = React.useState("");
-  const [searchSuggestions, setSearchSuggestions] = React.useState<any[]>([]);
+  const [searchSuggestions, setSearchSuggestions] = React.useState<Array<{ name: string; location?: string }>>([]);
   const [searchOpen, setSearchOpen] = React.useState(false);
   const [searchLoading, setSearchLoading] = React.useState(false);
   const searchDebounceRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -156,7 +156,7 @@ function MapPickerModal({ initialLat, initialLng, onConfirm, onClose }: MapPicke
           .then((r) => r.json()).then((data) => {
             setSearchLoading(false);
             if (data.status === "1" && data.tips?.length > 0) {
-              const valid = data.tips.filter((t: any) => t.location && t.location !== "[]").slice(0, 8);
+              const valid = data.tips.filter((t: { location?: string }) => t.location && t.location !== "[]").slice(0, 8);
               setSearchSuggestions(valid); setSearchOpen(valid.length > 0);
             } else { setSearchSuggestions([]); setSearchOpen(false); }
           }).catch(() => { setSearchLoading(false); setSearchSuggestions([]); setSearchOpen(false); })
@@ -164,7 +164,7 @@ function MapPickerModal({ initialLat, initialLng, onConfirm, onClose }: MapPicke
     }, 350);
   }
 
-  function handleSearchSelect(tip: any) {
+  function handleSearchSelect(tip: { name: string; location?: string }) {
     setSearchQuery(tip.name); setSearchOpen(false); setSearchSuggestions([]);
     if (!tip.location || tip.location === "[]") return;
     const parts = tip.location.split(","); if (parts.length !== 2) return;
@@ -198,7 +198,7 @@ function MapPickerModal({ initialLat, initialLng, onConfirm, onClose }: MapPicke
         const marker = new AMap.Marker({ position: [parsedLng, parsedLat] });
         marker.setMap(map); markerRef.current = marker;
       }
-      map.on("click", (e: any) => {
+      map.on("click", (e: { lnglat: { lng: number; lat: number } }) => {
         const { lng, lat } = e.lnglat;
         setPickedLat(lat); setPickedLng(lng); setPickedAddress("");
         if (markerRef.current) { markerRef.current.setPosition([lng, lat]); }

--- a/frontend/src/components/features/location-form/location-form-route-fields.tsx
+++ b/frontend/src/components/features/location-form/location-form-route-fields.tsx
@@ -48,7 +48,7 @@ function styledInput(hasError?: boolean) {
   );
 }
 
-const POI_ROLE_OPTIONS = (t: (key: any) => string) => [
+const POI_ROLE_OPTIONS = (t: (key: string) => string) => [
   { value: "waypoint", label: t("admin.poiRoleWaypoint") }, { value: "checkpoint", label: t("admin.poiRoleCheckpoint") },
   { value: "viewpoint", label: t("admin.poiRoleViewpoint") }, { value: "facility", label: t("admin.poiRoleFacility") },
   { value: "poi", label: t("admin.poiRolePoi") },

--- a/frontend/src/components/features/location-form/location-form-settings-fields.tsx
+++ b/frontend/src/components/features/location-form/location-form-settings-fields.tsx
@@ -89,7 +89,7 @@ function AddButton({ label, onAdd }: AddButtonProps) {
   );
 }
 
-const FACILITY_OPTIONS = (t: (key: any) => string) => [
+const FACILITY_OPTIONS = (t: (key: string) => string) => [
   { value: "parking", label: `🅿️ ${t("admin.facilityParking")}` }, { value: "restroom", label: `🚻 ${t("admin.facilityRestroom")}` },
   { value: "water", label: `💧 ${t("admin.facilityWater")}` }, { value: "food", label: `🍱 ${t("admin.facilityFood")}` },
 ];

--- a/frontend/src/components/features/team-detail/use-team-detail.ts
+++ b/frontend/src/components/features/team-detail/use-team-detail.ts
@@ -195,7 +195,7 @@ export function useTeamDetail(teamId: string): UseTeamDetailReturn {
 
   React.useEffect(() => {
     if (team && userId && team.leader?.id === userId) fetchApplications();
-  }, [team?.id, userId, fetchApplications]);
+  }, [team, userId, fetchApplications]);
 
   const handleJoin = React.useCallback(async () => {
     if (!userId) {
@@ -231,7 +231,7 @@ export function useTeamDetail(teamId: string): UseTeamDetailReturn {
     } finally {
       setJoining(false);
     }
-  }, [userId, teamId, joinMsg, showToast, loadTeam]);
+  }, [userId, teamId, joinMsg, showToast, loadTeam, t]);
 
   const handleSaveWechat = React.useCallback(async (wechat: string) => {
     if (!wechat.trim()) {
@@ -253,7 +253,7 @@ export function useTeamDetail(teamId: string): UseTeamDetailReturn {
     } catch {
       showToast({ type: "error", message: t("teams.toast.wechatSaveFailed") });
     }
-  }, [userId, showToast]);
+  }, [userId, showToast, t]);
 
   const handleLeave = React.useCallback(async () => {
     setShowLeave(false);
@@ -270,7 +270,7 @@ export function useTeamDetail(teamId: string): UseTeamDetailReturn {
     } catch {
       showToast({ type: "error", message: t('errors.leaveFailed') });
     }
-  }, [teamId, showToast, loadTeam]);
+  }, [teamId, showToast, loadTeam, t]);
 
   const handleApprove = React.useCallback(async (uid: string) => {
     try {
@@ -286,7 +286,7 @@ export function useTeamDetail(teamId: string): UseTeamDetailReturn {
     } catch {
       showToast({ type: "error", message: t('errors.reviewFailed') });
     }
-  }, [teamId, showToast, loadTeam]);
+  }, [teamId, showToast, loadTeam, t]);
 
   const handleReject = React.useCallback(async (uid: string) => {
     try {
@@ -301,7 +301,7 @@ export function useTeamDetail(teamId: string): UseTeamDetailReturn {
     } catch {
       showToast({ type: "error", message: t('errors.reviewFailed') });
     }
-  }, [teamId, showToast]);
+  }, [teamId, showToast, t]);
 
   const handleFormTeam = React.useCallback(async () => {
     setIsForming(true);
@@ -325,7 +325,7 @@ export function useTeamDetail(teamId: string): UseTeamDetailReturn {
       setIsForming(false);
       setShowFormConfirm(false);
     }
-  }, [teamId, team, showToast, loadTeam]);
+  }, [teamId, team, showToast, loadTeam, t]);
 
   const handleDelete = React.useCallback(async () => {
     setIsDeleting(true);
@@ -344,7 +344,7 @@ export function useTeamDetail(teamId: string): UseTeamDetailReturn {
       setIsDeleting(false);
       setShowDeleteConfirm(false);
     }
-  }, [teamId, showToast]);
+  }, [teamId, showToast, t]);
 
   const members = team?.members || [];
   const allMembers = React.useMemo(() => {


### PR DESCRIPTION
PR #340 missed two files that still used console.* for logging:
- `api/src/lib/email.ts`: 6 occurrences
- `api/src/lib/email-i18n.ts`: 1 occurrence

Replace all with structured logger calls for consistency.

## Verification
- `pnpm type-check` (api): 0 errors
- `pnpm test`: 185 passed