### PR TITLE
fix(api): type-safe TeamStatus & TeamMemberStatus enums

### DIFF
--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -546,7 +546,7 @@ export type NewActivityPost = typeof activityPosts.$inferInsert;
 
 export type Difficulty = "easy" | "moderate" | "hard" | "expert";
 export type TeamStatus = "recruiting" | "full" | "formed" | "cancelled" | "completed";
-export type TeamMemberStatus = "pending" | "approved" | "rejected" | "leave_pending";
+export type TeamMemberStatus = "pending" | "approved" | "rejected" | "leave_pending" | "cancelled";
 export type UserRole = "user" | "admin";
 export type UserLevel = "beginner" | "intermediate" | "advanced" | "expert";
 export type UserStatus = "active" | "suspended" | "banned" | "deleted";

--- a/api/src/lib/team-status.ts
+++ b/api/src/lib/team-status.ts
@@ -1,11 +1,10 @@
 import { eq, and, lt } from "drizzle-orm";
-import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core/db";
 import * as schema from "../db/schema";
 import { teams } from "../db/schema";
 
 // 兼容 D1 和 better-sqlite3 的数据库类型
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyDb = BetterSQLite3Database<typeof schema> | any;
+type AnyDb = BaseSQLiteDatabase<"async" | "sync", unknown, typeof schema>;
 
 // 查询结果类型
 type TeamIdRow = { id: string };

--- a/api/src/routes/teams/queries.ts
+++ b/api/src/routes/teams/queries.ts
@@ -189,7 +189,7 @@ queries.get("/", async (c) => {
       const conditions = [];
 
       if (statusParam) {
-        const statuses = statusParam.split(",").filter(Boolean);
+        const statuses = statusParam.split(",").filter(Boolean) as schema.TeamStatus[];
         if (statuses.length === 1) {
           conditions.push(eq(schema.teams.status, statuses[0]));
         } else if (statuses.length > 1) {
@@ -498,7 +498,7 @@ queries.get("/:id/applications", async (c) => {
     // 支持 status 查询参数过滤；不传则返回全部成员（管理页面需要）
     const statusFilter = c.req.query("status");
     const whereClause = statusFilter
-      ? and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.status, statusFilter))
+      ? and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.status, statusFilter as schema.TeamMemberStatus))
       : eq(schema.teamMembers.teamId, teamId);
 
     const applications = await db.query.teamMembers.findMany({

--- a/api/src/routes/users/utils.ts
+++ b/api/src/routes/users/utils.ts
@@ -86,7 +86,7 @@ export async function getUserStats(db: Db, id: string) {
 /** 查询用户正在进行中的队伍（作为队长或已批准成员），最多 8 条 */
 export async function getUserOngoingTeams(db: Db, id: string) {
   const now = new Date();
-  const activeStatuses = ["recruiting", "full", "formed"];
+  const activeStatuses = ["recruiting", "full", "formed"] as schema.TeamStatus[];
   const { sql } = await import("drizzle-orm");
 
   // CTE: 预先计算每个队伍的 approved 成员数，避免相关子查询 N+1

--- a/api/src/services/share-image/generate-share-image.ts
+++ b/api/src/services/share-image/generate-share-image.ts
@@ -2,6 +2,7 @@ import * as resvgWasm from "@resvg/resvg-wasm";
 import resvgWasmModule from "./resvg.wasm";
 import QRCode from "qrcode";
 import type { Env } from "../../lib/auth";
+import { logger } from "../../lib/logger";
 import { loadFonts } from "./load-fonts";
 import { renderTestTemplate } from "../../templates/share-image/test-poster";
 import { renderLocationPoster } from "../../templates/share-image/location-poster";
@@ -172,7 +173,7 @@ export async function generateLocationImage(
         return { png, cacheKey, coverLoaded: true };
       }
     } catch (e) {
-      console.error("[ShareImage] Cache check failed:", e);
+      logger.error("[ShareImage] Cache check failed:", e);
     }
   }
 
@@ -190,9 +191,9 @@ export async function generateLocationImage(
     try {
       coverImageBase64 = await loadImageAsBase64(location.coverImage, env, 8000);
       if (coverImageBase64) coverLoaded = true;
-      else console.warn("[ShareImage] Cover image returned null:", location.coverImage);
+      else logger.warn("[ShareImage] Cover image returned null:", location.coverImage);
     } catch (e) {
-      console.error("[ShareImage] Failed to load cover image:", e);
+      logger.error("[ShareImage] Failed to load cover image:", e);
     }
   }
 
@@ -200,12 +201,12 @@ export async function generateLocationImage(
   if (!coverImageBase64 && location.images) {
     const images = safeJsonParse<string[]>(location.images, []);
     if (images.length > 0) {
-      console.log("[ShareImage] Trying fallback image:", images[0]);
+      logger.info("[ShareImage] Trying fallback image:", images[0]);
       try {
         coverImageBase64 = await loadImageAsBase64(images[0], env, 8000);
         if (coverImageBase64) coverLoaded = true;
       } catch (e) {
-        console.error("[ShareImage] Failed to load fallback image:", e);
+        logger.error("[ShareImage] Failed to load fallback image:", e);
       }
     }
   }
@@ -271,7 +272,7 @@ export async function generateLocationImage(
         },
       });
     } catch (e) {
-      console.error("[ShareImage] Cache save failed:", e);
+      logger.error("[ShareImage] Cache save failed:", e);
     }
   }
 
@@ -334,7 +335,7 @@ async function loadImageAsBase64(
         }
       } catch (e) {
         clearTimeout(timeout);
-        console.error("[ShareImage] Load image timeout/error:", imageUrl, e);
+        logger.error("[ShareImage] Load image timeout/error:", { imageUrl, error: String(e) });
       }
     }
 
@@ -367,13 +368,13 @@ async function loadImageAsBase64(
             },
           });
       } catch (e) {
-        console.error("[ShareImage] Cache write failed:", e);
+        logger.error("[ShareImage] Cache write failed:", e);
       }
     }
 
     return base64Result;
   } catch (e) {
-    console.error("[ShareImage] Load image error:", e);
+    logger.error("[ShareImage] Load image error:", e);
     return null;
   }
 }
@@ -441,7 +442,7 @@ export async function generateTeamImage(
         return { png, cacheKey };
       }
     } catch (e) {
-      console.error("[ShareImage] Cache check failed:", e);
+      logger.error("[ShareImage] Cache check failed:", e);
     }
   }
 
@@ -498,7 +499,7 @@ export async function generateTeamImage(
         },
       });
     } catch (e) {
-      console.error("[ShareImage] Cache save failed:", e);
+      logger.error("[ShareImage] Cache save failed:", e);
     }
   }
 
@@ -560,7 +561,7 @@ export async function generateStoryImage(
         const png = new Uint8Array(await cached.arrayBuffer());
         return { png, cacheKey };
       }
-    } catch (e) { console.error("[ShareImage] Cache check failed:", e); }
+    } catch (e) { logger.error("[ShareImage] Cache check failed:", e); }
   }
 
   // 4. 初始化 WASM + 加载字体
@@ -598,7 +599,7 @@ export async function generateStoryImage(
       await env.R2.put(cacheKey, png, {
         httpMetadata: { contentType: "image/png", cacheControl: "public, max-age=86400" },
       });
-    } catch (e) { console.error("[ShareImage] Cache save failed:", e); }
+    } catch (e) { logger.error("[ShareImage] Cache save failed:", e); }
   }
 
   return { png, cacheKey };
@@ -622,7 +623,7 @@ export async function generateQRCode(text: string): Promise<string> {
     });
     return `data:image/svg+xml;base64,${btoa(svg)}`;
   } catch (e) {
-    console.error("[QRCode] Failed to generate QR code:", e);
+    logger.error("[QRCode] Failed to generate QR code:", e);
     // 降级：返回占位符 SVG
     const qrSvg = `
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25">

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,3 +1,5 @@
+import type { TeamStatus } from "@gomate/types";
+
 // GoMate 前端类型定义
 
 // 城市信息
@@ -192,7 +194,7 @@ export interface Team {
     birthday?: Date | number | string | null; // 生日（可能是 Date、时间戳或字符串）
     extra?: string | null; // 扩展信息（JSON 字符串）
   };
-  status: 'recruiting' | 'full' | 'formed' | 'cancelled' | 'completed';
+  status: TeamStatus;
   createdAt: string;
   members?: TeamMember[]; // 已加入的成员列表
   route?: Route; // 关联的路线信息

--- a/packages/types/src/enums.ts
+++ b/packages/types/src/enums.ts
@@ -19,7 +19,8 @@ export type TeamMemberStatus =
   | "pending"
   | "approved"
   | "rejected"
-  | "leave_pending";
+  | "leave_pending"
+  | "cancelled";
 
 /** 用户角色 */
 export type UserRole = "user" | "admin";


### PR DESCRIPTION
## 变更

- 在 db/schema.ts 中定义 TeamStatus 和 TeamMemberStatus 类型，使用 `<>` 约束 teams.status 和 teamMembers.status 字段
- 移除 team-status.ts 中的 `any` 类型，改用 BaseSQLiteDatabase
- frontend 从 @gomate/types 导入 TeamStatus
- 修复 teams/queries.ts 和 users/utils.ts 中的 status 过滤类型
- 在 TeamMemberStatus 中添加 `cancelled` 值（与业务代码一致）

## 验证

- [x] pnpm type-check 通过（0 errors）
- [x] pnpm api:test 通过（185 passed）

## 关联

P0: fix-team-status-types