### PR TITLE
security(upload): add file extension validation and MIME consistency check

### DIFF
--- a/api/src/routes/upload.ts
+++ b/api/src/routes/upload.ts
@@ -12,11 +12,21 @@ const upload = new Hono<{ Bindings: Env }>();
 
 /** 允许的图片 MIME 类型 */
 const ALLOWED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
+/** 允许的文件扩展名 */
+const ALLOWED_EXTENSIONS = ["jpg", "jpeg", "png", "gif", "webp"];
 /** 最大文件大小：5MB */
 const MAX_FILE_SIZE = 5 * 1024 * 1024;
 /** 上传速率限制：10 次/小时 */
 const UPLOAD_RATE_LIMIT_MAX = 10;
 const UPLOAD_RATE_LIMIT_WINDOW = 3600;
+
+/** MIME 类型到扩展名的映射 */
+const MIME_TO_EXT: Record<string, string[]> = {
+  "image/jpeg": ["jpg", "jpeg"],
+  "image/png": ["png"],
+  "image/gif": ["gif"],
+  "image/webp": ["webp"],
+};
 
 /** 常见图片格式的 Magic Number */
 const MAGIC_NUMBERS = {
@@ -44,8 +54,25 @@ function validateMagicNumber(buffer: ArrayBuffer): boolean {
 }
 
 /**
- * 生成 R2 对象公开 URL
+ * 验证文件扩展名是否在白名单中，且与 MIME 类型一致
  */
+function validateFileExtension(file: File): { valid: boolean; ext: string; error?: string } {
+  const fileName = file.name || "";
+  const extMatch = fileName.match(/\.([a-zA-Z0-9]+)$/);
+  const ext = extMatch ? extMatch[1].toLowerCase() : "";
+
+  if (!ext || !ALLOWED_EXTENSIONS.includes(ext)) {
+    return { valid: false, ext: "", error: `Invalid file extension: .${ext}. Allowed: ${ALLOWED_EXTENSIONS.join(", ")}` };
+  }
+
+  // 验证 MIME 类型和扩展名的一致性
+  const expectedExts = MIME_TO_EXT[file.type];
+  if (!expectedExts || !expectedExts.includes(ext)) {
+    return { valid: false, ext, error: `MIME type ${file.type} does not match extension .${ext}` };
+  }
+
+  return { valid: true, ext };
+}
 function getPublicUrl(env: Env, key: string): string | null {
   if (!env.R2_PUBLIC_URL) {
     logger.error("[Upload] R2_PUBLIC_URL not configured");
@@ -55,6 +82,12 @@ function getPublicUrl(env: Env, key: string): string | null {
 }
 
 async function uploadImageFile(c: { env: Env; req: { header: (name: string) => string | undefined } }, file: File, key: string) {
+  // 验证文件扩展名和 MIME 类型一致性
+  const extValidation = validateFileExtension(file);
+  if (!extValidation.valid) {
+    return { error: APIErrors.badRequest(extValidation.error || "Invalid file extension"), status: 400 as const };
+  }
+
   if (!ALLOWED_IMAGE_TYPES.includes(file.type))
     return { error: APIErrors.badRequest("Invalid file type. Allowed: JPEG, PNG, GIF, WebP"), status: 400 as const };
   if (file.size > MAX_FILE_SIZE)
@@ -114,7 +147,10 @@ upload.post("/avatar", async (c) => {
       }
     }
 
-    const ext = file.type.split("/")[1] || "jpg";
+    const extValidation = validateFileExtension(file);
+    if (!extValidation.valid) return c.json(APIErrors.badRequest(extValidation.error || "Invalid file"), 400);
+
+    const ext = extValidation.ext;
     const key = `avatars/${userId}-${Date.now()}.${ext}`;
     const result = await uploadImageFile(c, file, key);
     if ("error" in result) return c.json(result.error, result.status);
@@ -187,7 +223,10 @@ upload.post("/location", async (c) => {
     const rateLimit = await checkRateLimit(c.env.GOMATE_KV, `rate:upload:${session.user.id}`, UPLOAD_RATE_LIMIT_MAX, UPLOAD_RATE_LIMIT_WINDOW);
     if (!rateLimit.allowed) return c.json(APIErrors.badRequest(`上传过于频繁，请 ${rateLimit.retryAfter} 秒后重试`), 429);
 
-    const ext = file.type.split("/")[1] || "jpg";
+    const extValidation = validateFileExtension(file);
+    if (!extValidation.valid) return c.json(APIErrors.badRequest(extValidation.error || "Invalid file"), 400);
+
+    const ext = extValidation.ext;
     const key = `locations/${Date.now()}.${ext}`;
     const result = await uploadImageFile(c, file, key);
     if ("error" in result) return c.json(result.error, result.status);
@@ -216,7 +255,10 @@ upload.post("/story", async (c) => {
     const rateLimit = await checkRateLimit(c.env.GOMATE_KV, `rate:upload:${session.user.id}`, UPLOAD_RATE_LIMIT_MAX, UPLOAD_RATE_LIMIT_WINDOW);
     if (!rateLimit.allowed) return c.json(APIErrors.badRequest(`上传过于频繁，请 ${rateLimit.retryAfter} 秒后重试`), 429);
 
-    const ext = file.type.split("/")[1] || "jpg";
+    const extValidation = validateFileExtension(file);
+    if (!extValidation.valid) return c.json(APIErrors.badRequest(extValidation.error || "Invalid file"), 400);
+
+    const ext = extValidation.ext;
     const key = `stories/${session.user.id}-${Date.now()}.${ext}`;
     const result = await uploadImageFile(c, file, key);
     if ("error" in result) return c.json(result.error, result.status);


### PR DESCRIPTION
## 变更

- 添加 ALLOWED_EXTENSIONS 白名单（jpg, jpeg, png, gif, webp）
- 添加 MIME_TO_EXT 映射验证 MIME 类型与扩展名一致性
- 添加 validateFileExtension() 辅助函数
- 使用验证后的扩展名生成 R2 key，不再信任客户端提供的 MIME 类型
- 防止 MIME 类型欺骗攻击

## 验证

- [x] pnpm type-check 通过（0 errors）
- [x] pnpm api:test 通过（185 passed）

## 关联

P2: upload-security