### PR TITLE
fix(frontend): update markdown-content test assertion to match nofollow security change

### DIFF
--- a/frontend/src/__tests__/markdown-content.test.tsx
+++ b/frontend/src/__tests__/markdown-content.test.tsx
@@ -88,7 +88,7 @@
        const link = screen.getByRole("link", { name: "测试链接" });
        expect(link).toHaveAttribute("href", "https://example.com");
        expect(link).toHaveAttribute("target", "_blank");
-       expect(link).toHaveAttribute("rel", "noopener noreferrer");
+       expect(link).toHaveAttribute("rel", "noopener noreferrer nofollow");
      });
 
      it("渲染自动链接", () => {


### PR DESCRIPTION
The `MarkdownContent` component was updated in a previous security fix to add `nofollow` to external link `rel` attributes, but the corresponding test assertion was not updated. This caused CI test failures.

**Changes:**
- Update the expected `rel` attribute in `markdown-content.test.tsx` from `noopener noreferrer` to `noopener noreferrer nofollow` to match the actual component output.

**Verification:**
- `pnpm test` passes (108 tests, 10 test files)