### PR TITLE
feat(ci): 加 .github/PULL_REQUEST_TEMPLATE.md（v3.1 SOP 6 段）

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,69 @@
+<!--
+v3.1 PR Description 模板（gomate 仓库强制）
+
+按 v3.1 SOP（含 Martin CR + Wen 测试两层保护）补全 6 段。空段保留标题即可（按情况补内容）。
+-->
+
+## 目的
+
+> 一句话说清楚"为什么" + "做什么"。不要写"修复 xxx 问题"没头没尾的描述。
+
+## 改动一览
+
+| 文件 / 模块 | 改动 |
+| ----------- | ---- |
+| ...         | ...  |
+
+> 列**关键改动点**，不是每个文件一行。新增 / 删除 / 修改 大块分区即可。
+
+## 验收方式（怎么验对）
+
+- [ ] **手动验证步骤 1**（必要时附命令）
+- [ ] **手动验证步骤 2**
+- [ ] **回归确认**：本次改动不影响已上线功能 A / B / C
+
+## 文件后缀清单 + 运行环境
+
+> v3.1 SOP 必填项（Martin CR 基础检查）
+
+| 文件                          | 后缀          | 运行环境                | 风险                        |
+| ----------------------------- | ------------- | ----------------------- | --------------------------- |
+| `api/wrangler.toml`           | .toml         | Cloudflare Workers      | wrangler 解析               |
+| `frontend/src/components/...` | .astro / .tsx | Astro 客户端 hydrate    | TS 注释遗留在 Astro 编译 OK |
+| `frontend/public/sw.js`       | .js           | Service Worker (native) | **不能有 TS 类型注解**      |
+| `scripts/...`                 | .mjs / .sh    | node / shell            | 引号 / 路径转义             |
+
+## 「不改某某文件」声明 + 页面层 CSS 扫描
+
+> v3.1 SOP 必填项（避免 PR body 写「不改 index.astro」但被 `:global(body)` 硬编码覆盖）
+
+- 本 PR 明确**不改**的文件：`api/src/services/foo.ts`、`frontend/src/components/Bar.astro`
+- 已扫页面层 CSS 检查硬编码：无
+- 或：本 PR **改动** `frontend/src/components/Bar.astro` scoped CSS，已确认无 `:global(body)` 残留
+
+## Wen 需验证的场景
+
+> v3.1 SOP 必填项（Martin CR 后由 Wen 接续测试）
+
+- [ ] Chrome / Safari / Firefox **三浏览器**视觉对齐（如本 PR 涉及 UI）
+- [ ] `getComputedStyle` 实测：在 homepage / 详情页读 `--bg-primary` 等关键 token
+- [ ] Lighthouse a11y / perf 分数未退化（如本 PR 涉及 UI）
+- [ ] Service Worker 注册 + cache 换代（如本 PR 改 public/sw.js）
+- [ ] 移动端 3 列 / 2 列自适应正确（如本 PR 涉及 layout）
+- [ ] reduced-motion 用户 fallback 正确
+- [ ] 线上 prod 验证（如本 PR 影响生产）：`getRegistrations()` + `caches.keys()` + hard reload
+
+## 回滚路径
+
+> v3.1 SOP 必填项（明确告诉 Victor / Martin / Wen 出问题怎么 revert）
+
+- `git revert <this-commit>` 无副作用（无 schema / 依赖 / CI 变化）
+- 或：`git reset --hard <last-green-commit>` 回退 dev
+- 或：Feature flag 关闭（如适用）
+
+## 关联
+
+- Slock task: #N（链接 thread）
+- Spec: `notes/<spec>.md` vN
+- 前置 PR: #N
+- 上下游:（受影响服务 / 工具）


### PR DESCRIPTION
## 目的

按 v3.1 SOP（含 Martin CR + Wen 测试两层保护）补 **PR 描述模板**，把目前散在 PR comment 里的「需要 Wen 验证」「文件后缀」「不改某某文件」等必填项**前置到 PR 创建阶段**，减少后置 CR 阶段才发现「漏检某项」的成本。

## 改动一览

| 文件 | 改动 |
|---|---|
| `.github/PULL_REQUEST_TEMPLATE.md`（新） | PR 默认描述模板，6 段结构（每段带 v3.1 必填说明） |

## 模板结构（v3.1 必填 8 段）

1. **目的** — 一句话说 why + what
2. **改动一览** — 表格列关键改动（不要求全文件清单）
3. **验收方式** — checklist 手动验证 + 回归
4. **文件后缀 × 运行环境** — 表清单（含 wrangler.toml / .sw.js / .mjs / .sh 等典型行列）
5. **「不改某某文件」声明 + 页面层 CSS 扫描** — **承 PR #22 B2 复盘**：「不改」陈述时主动扫页面层 CSS
6. **Wen 需验证的场景** — checklist（visual / computed style / Lighthouse / SW / 浏览器 / prod 验证）
7. **回滚路径** — git revert / reset / feature flag 三选一明确
8. **关联** — Slock task + spec + 前置 PR

## v3.1 SOP 自检（@Martin CR 时按这 3 条逐条检查）

1. ✅ **文件后缀 + 运行环境**：本 PR 仅新增 `.md`（PR template）—— **零 src/ / 零 CI / 零视觉改动**
2. ✅ **「不改某某文件」声明**：本 PR **零 src/ 改动**，可全填「无」；下一条同样
3. ✅ **Wen 验证场景**：本 PR 仅 GitHub template 文件，不影响运行时；Wen 无需回归验证，但模板会强制后续所有 PR 写清楚 Wen 场景

## 升硬 gate / 模板升级

- 本 PR 是「约定」，不是「硬约束」；PR 模板不阻止 PR 字段为空，但鼓励作者按格式填
- 后续可考虑加 PR checklist GitHub Action（自动检测 PR body 段是否齐全），作为 P2 跟进

## 跨仓库复用建议

daily-movie / product-stories / oura-pix / daily-book 等仓库可在后续 PR 中参考本模板结构，按需剪裁（截屏示例可直接删）。

## 关联

- Slock task #133
- 线程 `#proj-gomate:4f0d5c61`
- 承 v3.1 复盘 9 条：CR v2 / CR v1 / 测试 v1 / 流程 v2