### PR TITLE
fix(a11y): deepen score-card text colors for WCAG AA contrast

### DIFF
--- a/frontend/src/components/features/location-detail/route-info-card.tsx
+++ b/frontend/src/components/features/location-detail/route-info-card.tsx
@@ -160,7 +160,7 @@ function getMetricItems(
       icon: <Clock className="h-4 w-4" />,
       label: t("locations.estimatedTime"),
       value: metricValue(route.duration, t),
-      accent: "text-sky-600 dark:text-sky-400",
+      accent: "text-sky-700 dark:text-sky-400",
       bg: "bg-sky-50 dark:bg-sky-950/30",
     },
     {
@@ -174,7 +174,7 @@ function getMetricItems(
       icon: <TrendingUp className="h-4 w-4" />,
       label: t("locations.totalElevation"),
       value: metricValue(route.elevation, t),
-      accent: "text-emerald-600 dark:text-emerald-400",
+      accent: "text-emerald-700 dark:text-emerald-400",
       bg: "bg-emerald-50 dark:bg-emerald-950/30",
     },
   ];
@@ -236,7 +236,7 @@ function RouteNoteBlock({
       <p
         className={cn(
           "mb-2 flex items-center gap-1.5 text-[11px] font-bold uppercase",
-          tone === "warning" ? "text-orange-600 dark:text-orange-400" : "text-stone-500 dark:text-stone-400"
+          tone === "warning" ? "text-orange-700 dark:text-orange-400" : "text-stone-500 dark:text-stone-400"
         )}
       >
         {icon}


### PR DESCRIPTION
## 改动

- `text-sky-600` → `text-sky-700`
- `text-emerald-600` → `text-emerald-700`
- `text-orange-600` → `text-orange-700`

仅影响 `frontend/src/components/features/location-detail/route-info-card.tsx` 的评分指标卡片（时间、海拔）和路线注意事项标题。

不动 design-system token，不扩散到 #135 已修区域。

## 验证

```bash
pnpm preflight
```

通过（0 errors，24 hints 为既有）。

---
🤖 Generated with [Claude Code](https://claude.com/code/claude-code)
