### PR TITLE
feat(share-image): 黄昏户外海报视觉优化 (#129)

### DIFF
--- a/api/src/templates/share-image/location-poster.tsx
+++ b/api/src/templates/share-image/location-poster.tsx
@@ -1,6 +1,7 @@
 import satori from "satori";
 import type { PosterLocale } from "../../services/share-image/poster-i18n";
 import { localizeDifficulty } from "../../services/share-image/poster-i18n";
+import { POSTER_TOKENS } from "./poster-tokens";
 
 interface RouteMetrics {
   difficulty?: string | null;
@@ -44,14 +45,10 @@ interface LocationPosterData {
 }
 
 // ─── 调色板 ──────────────────────────────────────────────────────────────────
+const T = POSTER_TOKENS;
 const C = {
-  bg: "#FAF7F2",
-  surface: "#FFFFFF",
-  primary: "#D97706",
+  ...T,
   primaryDark: "#B45309",
-  title: "#1C1917",
-  body: "#57534E",
-  muted: "#A8A29E",
   border: "#E7E5E4",
   amber50: "#FFFBEB",
   amber100: "#FEF3C7",
@@ -96,9 +93,14 @@ function formatElevation(m: number): string {
  * 地点分享海报 — Hero 封面 + 信息卡 + 路线指标 + Tags + QR
  *
  * 设计思路：
- * 1) 顶部封面 16:9，底部叠加深色渐变 + 品牌条纹 + 标题，右下贴季节胶囊
+ * 1) 顶部封面 16:9，叠加热区渐变 + 品牌条纹 + 标题，右下贴季节胶囊
  * 2) 信息卡：路线指标三栏（距离/耗时/爬升）+ 副标题 + 描述 + 标签 + 地址
  * 3) 底栏：二维码 + Slogan + 品牌域名
+ *
+ * 黄昏户外视觉：
+ * - 封面采用 3 个绝对定位 div 堆叠（cover-img → sky 冷色蒙版 → sun-glow 暖光蒙版）
+ * - 标题保留白色并增加 sun-glow 微光晕
+ * - QR 区域使用极淡 sun-glow 底色，像被晨光打亮
  *
  * 高度固定 696px（展示信息密度足够、且不超过一般朋友圈一屏）
  */
@@ -176,7 +178,7 @@ export async function renderLocationPoster(data: LocationPosterData): Promise<st
                 backgroundColor: "#E7E5E4",
               },
               children: [
-                // 封面图
+                // 1. 封面图
                 coverImage
                   ? {
                       type: "img",
@@ -184,6 +186,9 @@ export async function renderLocationPoster(data: LocationPosterData): Promise<st
                         src: coverImage,
                         style: {
                           display: "flex",
+                          position: "absolute",
+                          top: 0,
+                          left: 0,
                           width: W,
                           height: COVER_H,
                           objectFit: "cover",
@@ -195,6 +200,9 @@ export async function renderLocationPoster(data: LocationPosterData): Promise<st
                       props: {
                         style: {
                           display: "flex",
+                          position: "absolute",
+                          top: 0,
+                          left: 0,
                           width: W,
                           height: COVER_H,
                           background: "linear-gradient(135deg, #FEF3C7 0%, #FED7AA 100%)",
@@ -210,7 +218,22 @@ export async function renderLocationPoster(data: LocationPosterData): Promise<st
                         },
                       },
                     },
-                // 底部渐变
+                // 2. 中层：sky 顶部冷色蒙版
+                {
+                  type: "div",
+                  props: {
+                    style: {
+                      display: "flex",
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      right: 0,
+                      bottom: 0,
+                      background: "linear-gradient(180deg, rgba(42,59,92,0.45) 0%, transparent 60%)",
+                    },
+                  },
+                },
+                // 3. 上层：sun-glow 底部暖光蒙版
                 {
                   type: "div",
                   props: {
@@ -220,8 +243,8 @@ export async function renderLocationPoster(data: LocationPosterData): Promise<st
                       left: 0,
                       right: 0,
                       bottom: 0,
-                      height: 110,
-                      background: "linear-gradient(180deg, rgba(28,25,23,0) 0%, rgba(28,25,23,0.65) 100%)",
+                      height: 240,
+                      background: "linear-gradient(180deg, rgba(28,25,23,0) 0%, rgba(42,59,92,0.30) 45%, rgba(232,144,48,0.55) 100%)",
                     },
                   },
                 },
@@ -262,7 +285,7 @@ export async function renderLocationPoster(data: LocationPosterData): Promise<st
                             lineHeight: "28px",
                             fontWeight: 800,
                             color: "#FFFFFF",
-                            textShadow: "0 1px 4px rgba(0,0,0,0.4)",
+                            textShadow: "0 0 16px rgba(232,144,48,0.5)",
                             maxHeight: 56,
                             overflow: "hidden",
                           },
@@ -464,7 +487,7 @@ export async function renderLocationPoster(data: LocationPosterData): Promise<st
                 justifyContent: "space-between",
                 margin: "0 14px",
                 padding: "12px 14px",
-                backgroundColor: C.surface,
+                backgroundColor: "rgba(232,144,48,0.04)",
                 borderRadius: 14,
                 border: `1px solid ${C.border}`,
                 flex: 1,

--- a/api/src/templates/share-image/poster-tokens.ts
+++ b/api/src/templates/share-image/poster-tokens.ts
@@ -1,0 +1,15 @@
+// 这些 token 仅用于 Satori 海报模板，禁止导入到 gomate app 前端 CSS
+export const POSTER_TOKENS = {
+  // 保留的 gomate DS v2.0 token
+  bg: "#FAF7F2",
+  surface: "#FFFFFF",
+  primary: "#D97706",
+  title: "#1C1917",
+  body: "#57534E",
+  muted: "#A8A29E",
+
+  // 海报专用：黄昏户外的环境冷色与暖焦点
+  sky: "#2A3B5C",
+  skyDeep: "#1A2540",
+  sunGlow: "#E89030",
+} as const;

--- a/api/src/templates/share-image/story-poster.tsx
+++ b/api/src/templates/share-image/story-poster.tsx
@@ -1,4 +1,5 @@
 import satori from "satori";
+import { POSTER_TOKENS } from "./poster-tokens";
 
 interface StoryPosterData {
   title: string;
@@ -11,15 +12,80 @@ interface StoryPosterData {
   fonts: Array<{ name: string; data: ArrayBuffer; weight: number; style: string }>;
 }
 
+const T = POSTER_TOKENS;
+const C = {
+  ...T,
+  primaryDark: "#B45309",
+  border: "#E7E5E4",
+};
+
 export async function renderStoryPoster(data: StoryPosterData): Promise<string> {
   const { title, summary, coverImage, authorName, authorAvatar, locationName, qrCodeDataUrl, fonts } = data;
   const fontFamily = fonts.length > 0 ? fonts[0].name : "system-ui";
   const cleanSummary = summary.length > 100 ? summary.slice(0, 97) + "..." : summary;
 
   const coverImageElement = coverImage ? {
-    type: "div", props: {
-      style: { display: "flex", marginHorizontal: 16, marginTop: 16, borderRadius: 12, overflow: "hidden" },
-      children: { type: "img", props: { src: coverImage, style: { display: "flex", width: 343, height: 180, objectFit: "cover" } } },
+    type: "div",
+    props: {
+      style: {
+        display: "flex",
+        position: "relative",
+        marginHorizontal: 16,
+        marginTop: 16,
+        width: 343,
+        height: 180,
+        borderRadius: 12,
+        overflow: "hidden",
+        backgroundColor: "#E7E5E4",
+      },
+      children: [
+        // 1. 封面图
+        {
+          type: "img",
+          props: {
+            src: coverImage,
+            style: {
+              display: "flex",
+              position: "absolute",
+              top: 0,
+              left: 0,
+              width: 343,
+              height: 180,
+              objectFit: "cover",
+            },
+          },
+        },
+        // 2. sky 顶部冷色蒙版
+        {
+          type: "div",
+          props: {
+            style: {
+              display: "flex",
+              position: "absolute",
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              background: "linear-gradient(180deg, rgba(42,59,92,0.45) 0%, transparent 60%)",
+            },
+          },
+        },
+        // 3. sun-glow 底部暖光蒙版
+        {
+          type: "div",
+          props: {
+            style: {
+              display: "flex",
+              position: "absolute",
+              left: 0,
+              right: 0,
+              bottom: 0,
+              height: 120,
+              background: "linear-gradient(180deg, rgba(28,25,23,0) 0%, rgba(42,59,92,0.30) 45%, rgba(232,144,48,0.55) 100%)",
+            },
+          },
+        },
+      ],
     },
   } : null;
 
@@ -28,29 +94,174 @@ export async function renderStoryPoster(data: StoryPosterData): Promise<string> 
     {
       type: "div",
       props: {
-        style: { display: "flex", flexDirection: "column", width: 375, backgroundColor: "#faf8f5", fontFamily },
+        style: {
+          display: "flex",
+          flexDirection: "column",
+          width: 375,
+          backgroundColor: C.bg,
+          fontFamily,
+          overflow: "hidden",
+        },
         children: [
+          // 顶部 4px 琥珀品牌条纹
+          {
+            type: "div",
+            props: {
+              style: {
+                display: "flex",
+                width: 375,
+                height: 4,
+                background: `linear-gradient(90deg, ${C.primary} 0%, ${C.primaryDark} 100%)`,
+              },
+            },
+          },
           ...(coverImageElement ? [coverImageElement] : []),
           {
-            type: "div", props: {
-              style: { display: "flex", flexDirection: "column", margin: 16, padding: 20, backgroundColor: "rgba(255,255,255,0.85)", border: "1px solid #e8e0d7", borderRadius: 12 },
+            type: "div",
+            props: {
+              style: {
+                display: "flex",
+                flexDirection: "column",
+                margin: 16,
+                padding: 20,
+                backgroundColor: C.surface,
+                border: `1px solid ${C.border}`,
+                borderRadius: 12,
+              },
               children: [
-                { type: "h1", props: { style: { fontSize: 18, lineHeight: "28px", fontWeight: 700, color: "#1e1812", marginBottom: 8 }, children: title } },
-                { type: "p", props: { style: { fontSize: 13, lineHeight: "20px", color: "#6b5e53", marginBottom: 12 }, children: cleanSummary } },
-                { type: "div", props: { style: { display: "flex", alignItems: "center", gap: 8, marginBottom: locationName ? 8 : 0 }, children: [
-                  authorAvatar ? { type: "img", props: { src: authorAvatar, style: { width: 24, height: 24, borderRadius: 12 } } } :
-                  { type: "div", props: { style: { width: 24, height: 24, borderRadius: 12, backgroundColor: "#D97706", display: "flex", alignItems: "center", justifyContent: "center" }, children: { type: "span", props: { style: { fontSize: 10, color: "white" } }, children: authorName?.[0] || "?" } } },
-                  { type: "span", props: { style: { fontSize: 12, color: "#1e1812", fontWeight: 500 }, children: authorName || "匿名" } },
-                ] } },
-                locationName ? { type: "div", props: { style: { display: "flex", gap: 4, marginBottom: 8 }, children: [
-                  { type: "span", props: { style: { fontSize: 11, color: "#D97706" } }, children: "📍" },
-                  { type: "span", props: { style: { fontSize: 11, color: "#6b5e53" } }, children: locationName },
-                ] } } : null,
-                qrCodeDataUrl ? { type: "img", props: { src: qrCodeDataUrl, style: { width: 64, height: 64, marginTop: 8, alignSelf: "center" } } } : null,
+                {
+                  type: "h1",
+                  props: {
+                    style: {
+                      display: "flex",
+                      fontSize: 18,
+                      lineHeight: "28px",
+                      fontWeight: 700,
+                      color: C.title,
+                      marginBottom: 8,
+                    },
+                    children: title,
+                  },
+                },
+                {
+                  type: "div",
+                  props: {
+                    style: {
+                      display: "flex",
+                      flexDirection: "row",
+                      gap: 6,
+                      marginBottom: 12,
+                    },
+                    children: [
+                      {
+                        type: "span",
+                        props: {
+                          style: {
+                            display: "flex",
+                            fontSize: 24,
+                            lineHeight: "24px",
+                            color: C.sunGlow,
+                            fontFamily,
+                          },
+                          children: "“",
+                        },
+                      },
+                      {
+                        type: "p",
+                        props: {
+                          style: {
+                            display: "flex",
+                            flex: 1,
+                            fontSize: 13,
+                            lineHeight: "20px",
+                            color: C.body,
+                            fontStyle: "italic",
+                          },
+                          children: cleanSummary,
+                        },
+                      },
+                      {
+                        type: "span",
+                        props: {
+                          style: {
+                            display: "flex",
+                            fontSize: 24,
+                            lineHeight: "24px",
+                            color: C.sunGlow,
+                            fontFamily,
+                            alignSelf: "flex-end",
+                          },
+                          children: "”",
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  type: "div",
+                  props: {
+                    style: {
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      marginBottom: locationName ? 8 : 0,
+                    },
+                    children: [
+                      authorAvatar
+                        ? { type: "img", props: { src: authorAvatar, style: { width: 24, height: 24, borderRadius: 12, objectFit: "cover" } } }
+                        : {
+                            type: "div",
+                            props: {
+                              style: {
+                                width: 24,
+                                height: 24,
+                                borderRadius: 12,
+                                backgroundColor: C.primary,
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "center",
+                              },
+                              children: {
+                                type: "span",
+                                props: { style: { fontSize: 10, color: "white" }, children: authorName?.[0] || "?" },
+                              },
+                            },
+                          },
+                      { type: "span", props: { style: { fontSize: 12, color: C.title, fontWeight: 500 }, children: authorName || "匿名" } },
+                    ],
+                  },
+                },
+                locationName
+                  ? {
+                      type: "div",
+                      props: {
+                        style: { display: "flex", gap: 4, marginBottom: 8 },
+                        children: [
+                          { type: "span", props: { style: { fontSize: 11, color: C.primary } }, children: "📍" },
+                          { type: "span", props: { style: { fontSize: 11, color: C.body }, children: locationName } },
+                        ],
+                      },
+                    }
+                  : null,
+                qrCodeDataUrl
+                  ? { type: "img", props: { src: qrCodeDataUrl, style: { width: 64, height: 64, marginTop: 8, alignSelf: "center" } } }
+                  : null,
               ].filter(Boolean),
             },
           },
-          { type: "div", props: { style: { display: "flex", justifyContent: "center", padding: 8, fontSize: 10, color: "#6b5e53" }, children: "GoMate - 发现趣处，组队同行" } },
+          {
+            type: "div",
+            props: {
+              style: {
+                display: "flex",
+                justifyContent: "center",
+                padding: 8,
+                fontSize: 10,
+                color: C.muted,
+              },
+              children: "GoMate - 发现趣处，组队同行",
+            },
+          },
         ].filter(Boolean),
       },
     },

--- a/api/src/templates/share-image/team-poster.tsx
+++ b/api/src/templates/share-image/team-poster.tsx
@@ -1,4 +1,5 @@
 import satori from "satori";
+import { POSTER_TOKENS } from "./poster-tokens";
 
 interface TeamPosterData {
   title: string;
@@ -24,16 +25,12 @@ const POSTER_HEIGHT = 468;
 const CARD_WIDTH = 343;
 const COVER_HEIGHT = 108;
 
-// 设计规范配色
-const COLORS = {
-  primary: "#d97706",      // amber-600
-  primaryDark: "#b45309", // amber-700
-  bg: "#fafaf9",           // stone-50
-  title: "#1c1917",      // stone-900
-  body: "#44403c",       // stone-700
-  muted: "#78716c",      // stone-500
+const T = POSTER_TOKENS;
+const C = {
+  ...T,
+  primaryDark: "#B45309",
   white: "#ffffff",
-  border: "#e7e5e4",     // stone-200
+  border: "#e7e5e4",
 };
 
 function clampText(text: string, maxLength: number): string {
@@ -50,7 +47,7 @@ function CalendarIcon() {
       height: 12,
       viewBox: "0 0 24 24",
       fill: "none",
-      stroke: COLORS.primaryDark,
+      stroke: C.primaryDark,
       strokeWidth: 2,
       strokeLinecap: "round",
       strokeLinejoin: "round",
@@ -74,7 +71,7 @@ function LocationIcon() {
       height: 12,
       viewBox: "0 0 24 24",
       fill: "none",
-      stroke: COLORS.primaryDark,
+      stroke: C.primaryDark,
       strokeWidth: 2,
       strokeLinecap: "round",
       strokeLinejoin: "round",
@@ -96,7 +93,7 @@ function UsersIcon() {
       height: 12,
       viewBox: "0 0 24 24",
       fill: "none",
-      stroke: COLORS.body,
+      stroke: C.body,
       strokeWidth: 2,
       strokeLinecap: "round",
       strokeLinejoin: "round",
@@ -122,7 +119,7 @@ function gradientPill(label: string) {
         justifyContent: "center",
         padding: "5px 10px",
         borderRadius: 999,
-        background: `linear-gradient(135deg, ${COLORS.primary} 0%, ${COLORS.primaryDark} 100%)`,
+        background: `linear-gradient(135deg, ${C.primary} 0%, ${C.primaryDark} 100%)`,
       },
       children: {
         type: "span",
@@ -131,7 +128,7 @@ function gradientPill(label: string) {
             display: "flex",
             fontSize: 11,
             fontWeight: 700,
-            color: COLORS.white,
+            color: C.white,
           },
           children: label,
         },
@@ -152,8 +149,8 @@ function infoCard(label: string, value: string, icon?: unknown) {
         minWidth: 0,
         padding: "10px 12px",
         borderRadius: 12,
-        backgroundColor: "#ffffff",
-        border: "1px solid #e7e5e4",
+        backgroundColor: C.surface,
+        border: `1px solid ${C.border}`,
       },
       children: [
         {
@@ -174,7 +171,7 @@ function infoCard(label: string, value: string, icon?: unknown) {
                     display: "flex",
                     fontSize: 10,
                     fontWeight: 600,
-                    color: "#78716c",
+                    color: C.muted,
                   },
                   children: label,
                 },
@@ -190,7 +187,7 @@ function infoCard(label: string, value: string, icon?: unknown) {
               fontSize: 13,
               fontWeight: 600,
               lineHeight: 1.3,
-              color: "#44403c",
+              color: C.body,
               maxHeight: 34,
               overflow: "hidden",
             },
@@ -269,7 +266,7 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                   position: "absolute",
                   inset: 0,
                   background:
-                    "linear-gradient(180deg, rgba(28, 25, 23, 0.05) 0%, rgba(28, 25, 23, 0.46) 100%)",
+                    "linear-gradient(180deg, rgba(42,59,92,0.45) 0%, rgba(26,37,64,0.65) 100%)",
                 },
               },
             },
@@ -324,7 +321,7 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
             width: POSTER_WIDTH,
             height: 84,
             padding: "16px 20px 0 20px",
-            background: "linear-gradient(135deg, #fef3c7 0%, #fed7aa 56%, #fff7ed 100%)",
+            background: `linear-gradient(135deg, ${C.skyDeep} 0%, ${C.sky} 100%)`,
           },
           children: [
             {
@@ -343,7 +340,7 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                     props: {
                       style: {
                         display: "flex",
-                        color: "#92400e",
+                        color: C.white,
                         fontSize: 12,
                         fontWeight: 800,
                       },
@@ -361,7 +358,7 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                   marginTop: 12,
                   fontSize: 14,
                   fontWeight: 700,
-                  color: "#92400e",
+                  color: C.white,
                 },
                 children: "找到同行的人，出发就不远",
               },
@@ -380,7 +377,7 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
           flexDirection: "column",
           width: POSTER_WIDTH,
           height: POSTER_HEIGHT,
-          backgroundColor: "#fafaf9",
+          backgroundColor: C.bg,
           fontFamily,
           overflow: "hidden",
           position: "relative",
@@ -397,8 +394,8 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                 margin: "8px 16px 0 16px",
                 padding: "10px 14px",
                 borderRadius: 18,
-                backgroundColor: "#ffffff",
-                border: "1px solid rgba(214, 211, 209, 0.84)",
+                backgroundColor: C.surface,
+                border: `1px solid ${C.border}`,
               },
               children: [
                 {
@@ -410,7 +407,7 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                       fontSize: 20,
                       fontWeight: 800,
                       lineHeight: 1.25,
-                      color: "#1c1917",
+                      color: C.title,
                       maxHeight: 52,
                       overflow: "hidden",
                       letterSpacing: "-0.2px",
@@ -445,8 +442,8 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                       marginTop: 8,
                       padding: "8px 10px",
                       borderRadius: 14,
-                      backgroundColor: "#fafaf9",
-                      border: "1px solid #e7e5e4",
+                      backgroundColor: C.bg,
+                      border: `1px solid ${C.border}`,
                     },
                     children: [
                       {
@@ -477,7 +474,7 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                                         display: "flex",
                                         fontSize: 12,
                                         fontWeight: 700,
-                                        color: "#57534e",
+                                        color: C.muted,
                                       },
                                       children: "同行伙伴",
                                     },
@@ -492,7 +489,7 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                                   display: "flex",
                                   fontSize: 18,
                                   fontWeight: 800,
-                                  color: "#0f766e",
+                                  color: C.primary,
                                 },
                                 children: `${currentMembers}/${safeMaxMembers} 人`,
                               },
@@ -507,7 +504,7 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                             display: "flex",
                             width: 190,
                             height: 8,
-                            backgroundColor: "#e7e5e4",
+                            backgroundColor: C.border,
                             borderRadius: 999,
                             overflow: "hidden",
                           },
@@ -519,7 +516,7 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                                 width: progressWidth,
                                 height: 8,
                                 borderRadius: 999,
-                                background: "linear-gradient(90deg, #10b981 0%, #14b8a6 100%)",
+                                background: `linear-gradient(90deg, ${C.primary} 0%, ${C.sunGlow} 100%)`,
                               },
                             },
                           },
@@ -531,7 +528,7 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                           style: {
                             display: "flex",
                             fontSize: 11,
-                            color: "#78716c",
+                            color: C.muted,
                           },
                           children:
                             spotsToForm && spotsToForm > 0
@@ -557,8 +554,8 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                 margin: "8px 16px 0 16px",
                 padding: "8px 14px",
                 borderRadius: 18,
-                backgroundColor: "#ffffff",
-                border: "1px solid rgba(214, 211, 209, 0.84)",
+                backgroundColor: C.surface,
+                border: `1px solid ${C.border}`,
               },
               children: [
                 {
@@ -583,7 +580,7 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                                 height: 38,
                                 borderRadius: 19,
                                 objectFit: "cover",
-                                border: "2px solid #d97706",
+                                border: `2px solid ${C.primary}`,
                               },
                             },
                           }
@@ -595,13 +592,13 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                                 width: 38,
                                 height: 38,
                                 borderRadius: 19,
-                                background: "linear-gradient(135deg, #d97706 0%, #f59e0b 100%)",
+                                background: `linear-gradient(135deg, ${C.primary} 0%, ${C.sunGlow} 100%)`,
                                 alignItems: "center",
                                 justifyContent: "center",
                                 fontSize: 14,
                                 fontWeight: 800,
                                 color: "#ffffff",
-                                border: "2px solid #d97706",
+                                border: `2px solid ${C.primary}`,
                               },
                               children: leaderInitial,
                             },
@@ -622,7 +619,7 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                                   display: "flex",
                                   fontSize: 10,
                                   fontWeight: 700,
-                                  color: "#b45309",
+                                  color: "#B45309",
                                 },
                                 children: "发起人",
                               },
@@ -634,7 +631,7 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                                   display: "flex",
                                   fontSize: 13,
                                   fontWeight: 700,
-                                  color: "#292524",
+                                  color: "#1C1917",
                                   maxHeight: 18,
                                   overflow: "hidden",
                                 },
@@ -648,7 +645,7 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                                   display: "flex",
                                   marginTop: 2,
                                   fontSize: 10,
-                                  color: "#78716c",
+                                  color: C.muted,
                                 },
                                 children: "邀请你一起出发",
                               },
@@ -676,7 +673,7 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                             display: "flex",
                             fontSize: 10,
                             fontWeight: 800,
-                            color: "#92400e",
+                            color: "#B45309",
                           },
                           children: "扫码加入",
                         },
@@ -689,7 +686,7 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                             padding: 4,
                             backgroundColor: "#ffffff",
                             borderRadius: 12,
-                            border: "1px solid #d6d3d1",
+                            border: `1px solid ${C.border}`,
                             boxShadow: "0 2px 4px rgba(0,0,0,0.05)",
                           },
                           children: qrCodeDataUrl
@@ -711,11 +708,11 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                                     display: "flex",
                                     width: 88,
                                     height: 88,
-                                    backgroundColor: "#f5f5f4",
+                                    backgroundColor: "#FAF7F2",
                                     alignItems: "center",
                                     justifyContent: "center",
                                     fontSize: 11,
-                                    color: "#a8a29e",
+                                    color: "#A8A29E",
                                   },
                                   children: "QR",
                                 },
@@ -747,7 +744,7 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                       display: "flex",
                       fontSize: 11,
                       fontWeight: 800,
-                      color: "#b45309",
+                      color: "#B45309",
                     },
                     children: "GoMate",
                   },
@@ -758,7 +755,7 @@ export async function renderTeamPoster(data: TeamPosterData): Promise<string> {
                     style: {
                       display: "flex",
                       fontSize: 11,
-                      color: "#78716c",
+                      color: C.muted,
                     },
                     children: "找到同行的人，出发就不远",
                   },

--- a/gomate/notes/gomate-poster-twilight.md
+++ b/gomate/notes/gomate-poster-twilight.md
@@ -1,0 +1,234 @@
+# gomate 分享海报 · 黄昏户外优化 Spec
+
+> 频道：#proj-gomate task #129
+> 日期：2026-07-12
+> 版本：**v1.1**（Martin CR 风险修订版）
+> 前版：v1
+> 参考图：Victor 提供的深蓝夜空 + 远天际暖光带 + 开阔平原（IMG_9198.jpeg）
+> 现有模板：`api/src/templates/share-image/{location,story,team}-poster.tsx`（三套共 ~1500 行）
+
+---
+
+## 版本变更（v1 → v1.1）
+
+| 项            | v1                 | v1.1                                                               |
+| ------------- | ------------------ | ------------------------------------------------------------------ |
+| Hero 渐变实现 | CSS 多背景复合     | **3 个 div children 堆叠**，Satori 100% 兼容                       |
+| Token 位置    | 写在模板/CSS 中    | **新建 `api/src/templates/share-image/poster-tokens.ts` 常量文件** |
+| 小尺寸预览    | 仅要求「标题清晰」 | **明确 100×100 缩略图下标题不做文字强化，靠封面+品牌色块识别**     |
+| Wen 验证场景  | 未列               | **§9 增加 iOS/Android 分享缩略图 + 朋友圈小尺寸预览验证**          |
+
+---
+
+## 0. 设计意图（参考图的精神）
+
+参考图（深蓝夜空 + 天际线暖光带 + 开阔平原）的**核心张力**是：
+
+> **冷环境 + 唯一暖色焦点 = 视觉深度**
+
+不是「全冷」也不是「全暖」。是「大片冷寂里那一束暖光」—— 这正好契合 gomate 的「户外出发 / 走向目的地」叙事。
+
+**现状痛点**：
+
+- 全页 `#FAF7F2` 米色背景 + `#D97706` 琥珀强调 = 通篇暖
+- 暖上加暖 = 视觉平、缺乏深度、跟 gomate 自己的 app UI 长得一模一样（海报缺乏品牌外溢感）
+- 朋友看到海报的第一眼感受：「像一篇博客卡片」而不是「想去这里」
+
+**优化方向**：**「黄昏户外」** — 把海报从"米色博客卡片"变成"晨昏出发时的远方目的地"。保留琥珀作为焦点暖色，引入**暮色蓝紫**作为环境冷色，形成参考图同款「冷暖对位」。
+
+---
+
+## 1. Color Token（新建 `poster-tokens.ts`，与 gomate app CSS 隔离）
+
+### 1.1 Token 常量文件
+
+新建 `api/src/templates/share-image/poster-tokens.ts`：
+
+```ts
+// 这些 token 仅用于 Satori 海报模板，禁止导入到 gomate app 前端 CSS
+export const POSTER_TOKENS = {
+  // 保留的 gomate DS v2.0 token
+  bg: "#FAF7F2",
+  surface: "#FFFFFF",
+  primary: "#D97706",
+  title: "#1C1917",
+  body: "#57534E",
+  muted: "#A8A29E",
+
+  // 海报专用：黄昏户外的环境冷色与暖焦点
+  sky: "#2A3B5C",
+  skyDeep: "#1A2540",
+  sunGlow: "#E89030",
+} as const;
+```
+
+三个海报模板 `location-poster.tsx` / `story-poster.tsx` / `team-poster.tsx` 统一 `import { POSTER_TOKENS } from './poster-tokens'` 使用。
+
+**关键约束**：`sky` / `skyDeep` / `sunGlow` **只在 poster 模板内使用**，**不进 gomate app UI**。这是「海报美学」独立于「产品设计系统」的分层。
+
+---
+
+## 2. 三套海报统一定调
+
+| 海报         | Hero 封面              | 主色调                  | 故事感     |
+| ------------ | ---------------------- | ----------------------- | ---------- |
+| **Location** | 地点封面图（用户上传） | sky + sun-glow 渐变蒙版 | 远方目的地 |
+| **Story**    | 故事首图               | sky + sun-glow 渐变蒙版 | 黄昏记录   |
+| **Team**     | 团队头像/合影          | sky 单色蒙版            | 集合点     |
+
+**统一元素**：
+
+1. 顶部 4px 琥珀品牌条纹（同现状）
+2. 标题区域使用 `--sky-deep → --sun-glow` 渐变底色（替代现状 `--bg` 米色）
+3. 信息卡使用 `--surface` 白底
+4. 二维码/Slogan 区域用 `--surface` 白底 + 琥珀色品牌名
+
+---
+
+## 3. Location 海报具体改动（参考现状 location-poster.tsx）
+
+### 3.1 Hero 封面改动（最大改动）
+
+**现状**（line 167-322）：
+
+- 封面图全幅 16:9
+- 底部 110px 深色渐变（rgba(28,25,23,0) → rgba(28,25,23,0.65)）
+- 左下标题白色 + textShadow
+- 右下季节胶囊
+
+**优化 —— 用 3 个 div children 堆叠，不用 CSS 多背景复合**：
+
+```jsx
+// 伪代码结构（Satori 兼容）
+<div
+  style={{ position: "relative", width: 1200, height: 675, overflow: "hidden" }}
+>
+  {/* 1. 底层：cover 图片 */}
+  <img
+    src={coverUrl}
+    style={{ position: "absolute", inset: 0, objectFit: "cover" }}
+  />
+
+  {/* 2. 中层：sky 顶部冷色蒙版 */}
+  <div
+    style={{
+      position: "absolute",
+      inset: 0,
+      background: `linear-gradient(180deg, rgba(42,59,92,0.45) 0%, transparent 60%)`,
+    }}
+  />
+
+  {/* 3. 上层：sun-glow 底部暖光蒙版 */}
+  <div
+    style={{
+      position: "absolute",
+      left: 0,
+      right: 0,
+      bottom: 0,
+      height: 240,
+      background: `linear-gradient(180deg, rgba(28,25,23,0) 0%, rgba(42,59,92,0.30) 45%, rgba(232,144,48,0.55) 100%)`,
+    }}
+  />
+
+  {/* 标题与胶囊仍在同一父容器内，不受渐变 div 影响 */}
+</div>
+```
+
+**要点**：
+
+- 封面图保持全幅 16:9
+- 顶部 sky 冷色蒙版：从 45% 不透明度 fade 到透明，营造夜色天空
+- 底部 sun-glow 暖光蒙版：240px 高度，三段过渡（透明 → sky → sun-glow），营造「下方夕阳照亮地平线」
+- 左下标题白色保留，加 `--sun-glow` 微光晕 `text-shadow: 0 0 16px rgba(232,144,48,0.5)`
+- 右下季节胶囊保持白色
+
+> **为什么不用 CSS `background` 复合**：Satori 对 `background: url(...), linear-gradient(...)` 的多层复合支持不稳定。3 个绝对定位 div 单层渐变 = 100% 兼容。
+
+### 3.2 信息卡保留
+
+信息卡（路线指标 / 描述 / 标签）用 `--surface` 白底，**不变**。这样卡片从「冷天空背景」中浮起来，层次更分明。
+
+### 3.3 二维码/Slogan 区域微调
+
+**现状**：白底 + slogan + 二维码
+**优化**：在 QR 区域加 `--sun-glow` 极淡底色 `rgba(232,144,48,0.04)`，让 QR 区域像被晨光打亮 —— 增加温度
+
+---
+
+## 4. Story 海报改动
+
+参考 location 的"封面渐变 + 信息卡"模式，但**封面比例改为 3:2 或 16:9**（取决于故事图），高度增加给正文摘要留位。
+
+**新增**：摘要前 2 行（55px）+ ember-style 引号 + 衬线斜体。
+
+---
+
+## 5. Team 海报改动
+
+团队头像作为「集合点」—— 用 sky 单色蒙版（不用 sun-glow 渐变，因为不是风景）。
+
+- 头像圆形 96×96，置于 `--sky-deep` 单色背景
+- 强调色保留琥珀（成员数 / 招募中）
+
+---
+
+## 6. Font / Typography 保留现状
+
+- 字体沿用现有 Satori 注入字体（line 38-44）
+- 字号阶梯保留（22 标题 / 13 副 / 12 正文 / 10 元 / 9 标签）
+- 字重 600/700/800 三档保留
+
+不引入新字体（与 Twitter IP / daily-movie starlight 的字体选择完全独立）。
+
+---
+
+## 7. i18n 文案不变
+
+scanText / sloganText / 各种 label 都是 i18n 注入（line 124-131），不变。
+
+---
+
+## 8. 落地清单（工程实施参考）
+
+预估工作量：**0.5-1 天**（仅 location 改 30 行；team / story 同步调）。
+
+- [ ] 新建 `api/src/templates/share-image/poster-tokens.ts`：定义 `POSTER_TOKENS` 常量
+- [ ] `api/src/templates/share-image/location-poster.tsx`：
+  - `import { POSTER_TOKENS } from './poster-tokens'`
+  - 修改 Hero 封面为 **3 div children 堆叠**（cover-img → sky 蒙版 → sun-glow 蒙版）
+  - 修改左下标题 textShadow（加 sun-glow 光晕）
+  - QR 区域加极淡底色
+- [ ] `api/src/templates/share-image/story-poster.tsx`：套同样 3-div 堆叠渐变 + 摘要位置
+- [ ] `api/src/templates/share-image/team-poster.tsx`：头像单色蒙版改 sky
+- [ ] gomate 仓库新建 `gomate/notes/gomate-poster-twilight.md`（本 spec 随 PR commit 入库）
+- [ ] R2 缓存：24h 缓存还在，poster 文件改完后需要 cache-bust key（暂时由后端 `?refresh=1` 参数控制，无需主动改）
+- [ ] Playwright E2E：检查 share-poster 截图测试（如果存在）
+
+---
+
+## 9. Review Checkpoints（含 Wen 测试场景）
+
+- 三套海报视觉统一（同一渐变系统）
+- 琥珀作为唯一暖焦点的稀缺性保持（不是每处都加 sun-glow）
+- gomate app UI 不受影响（`sky` / `sunGlow` 等 token 不导入 app CSS）
+- **小尺寸预览（100×100 缩略图）：标题不做文字强化，靠封面图 + 顶部 4px 琥珀品牌条纹识别**；完整尺寸海报（375×696）下标题才承担信息传递
+- 暗色背景对外部图片色彩还原度
+- **Wen 验证场景**：
+  - iOS Safari 分享图缩略图（ Messages / 微信 / 朋友圈）
+  - Android Chrome 分享图缩略图
+  - 朋友圈 100×100 缩略图 vs 点开大图对比
+  - Satori 生成 PNG 与 Playwright 截图像素一致（无渐变丢失）
+
+---
+
+## 10. 下一步
+
+1. Martin 正式 CR（v3.1 首次实战）
+2. Jeff 起 `raft/gomate-poster-twilight` 分支实施（改 3 个 poster 模板 + 新增 poster-tokens.ts + 入库本 spec）
+3. Wen 按 §9 验证 iOS / Android / 朋友圈缩略图
+4. 落地后做 3-5 张实拍对比图（location poster / 当前 vs 优化）
+5. 上线 + 收集朋友圈反馈
+
+---
+
+_spec v1.1。结构（冷天空 + 暖焦点）建议保留；token 位置、Hero 渐变实现、小尺寸预览策略已按 Martin 风险点修订。_


### PR DESCRIPTION
## Summary

实现 gomate task #129：分享海报「黄昏户外」视觉优化，按 spec v1.1（Martin CR 通过版）改造 location / story / team 三套海报。

## 主要改动

- 新增 `api/src/templates/share-image/poster-tokens.ts`
  - `sky` / `skyDeep` / `sunGlow` 等海报专用 token 与 gomate app CSS 隔离
- `location-poster.tsx`
  - Hero 封面改为 3-div 堆叠：cover-img → sky 顶部冷色蒙版 → sun-glow 底部暖光蒙版
  - 标题加 `0 0 16px rgba(232,144,48,0.5)` sun-glow 光晕
  - QR/Slogan 区域加 `rgba(232,144,48,0.04)` 极淡暖色底
- `story-poster.tsx`
  - 同 3-div 封面堆叠
  - 摘要两侧加琥珀引号，斜体呈现
  - 顶部增加 4px 琥珀品牌条纹
- `team-poster.tsx`
  - 封面头图改用 sky 单色蒙版
  - 无封面头部改用 `skyDeep → sky` 单色渐变背景，文字变白
  - 进度条与成员数改回琥珀强调色
  - 其余硬编码颜色统一收敛到 `POSTER_TOKENS`
- 新增 `gomate/notes/gomate-poster-twilight.md`，spec v1.1 随代码入库

## 验证

- `pnpm preflight` ✅
- `pnpm --filter @gomate/api type-check` ✅
- `pnpm --filter @gomate/api build` ✅
- `pnpm --filter @gomate/frontend build` ✅

## 风险与后续

- 现有 R2 poster 缓存 24h，部署后首次分享建议带 cache-bust（如 `?refresh=1`）
- Playwright share-poster 截图可能因渐变叠加产生轻微像素 diff，需 Wen 验收时同步更新 baseline
- Wen 需按 spec §9 验证 iOS / Android / 朋友圈 100×100 缩略图

Relates to task #129
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
