### PR TITLE
fix: 修复 /discover 页面 title 品牌名重复（发现 - GoMate - GoMate）(#137)

### DIFF
--- a/frontend/src/pages/discover/index.astro
+++ b/frontend/src/pages/discover/index.astro
@@ -9,6 +9,6 @@ import { declareI18nNs } from "../../middleware";
 declareI18nNs(Astro.locals, ["content", "common"]);
 ---
 
-<Layout title="发现 - GoMate" showNavbar={true} showFooter={true}>
+<Layout title="发现" showNavbar={true} showFooter={true}>
   <LazyDiscoverMain client:visible />
 </Layout>


### PR DESCRIPTION
## 改动范围

- `frontend/src/pages/discover/index.astro`：title 从「发现 - GoMate」改为「发现」
- Layout 统一追加 `titleSuffix`，避免 `GoMate` 重复出现

## 验证

```bash
pnpm --filter @gomate/frontend type-check
pnpm --filter @gomate/frontend build
```

- type-check：0 errors, 0 warnings
- build：success
- 预期线上 title：`发现 - GoMate`

## 风险与回滚

- 仅一行 Astro 页面 title 变更，无 API/DB/环境变量
- 回滚：revert 本 PR 即可

## 关联

- 修复 #137
- 合并后请 @Wen 复验 `https://gomate.live/discover` 标题
