### PR TITLE
fix(frontend): sync SSR locale to islands rendering to fix hydration mismatch

### DIFF
--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -303,10 +303,22 @@ export function getNamespaceData(ns: string, locale: Locale): Record<string, unk
 // ─── Locale 管理 ──────────────────────────────────────────────────────────────
 
 /**
+ * SSR 期间由 Layout.astro 设置，确保 islands 服务端渲染时
+ * 与客户端 hydration 使用同一 locale，避免 hydration mismatch
+ */
+declare global {
+   
+  var __SSR_LOCALE__: Locale | undefined;
+}
+
+/**
  * 获取当前 locale（从 URL 或 cookie 读取）
  */
 export function getLocale(): Locale {
-  if (typeof document === "undefined") return DEFAULT_LOCALE;
+  // SSR 环境（无 document）：优先使用 Layout 注入的 locale
+  if (typeof document === "undefined") {
+    return globalThis.__SSR_LOCALE__ ?? DEFAULT_LOCALE;
+  }
 
   const match = document.cookie.match(/gomate_locale=(zh-CN|en)/);
   if (match) return match[1] as Locale;

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -36,6 +36,8 @@ const localsLocale = (Astro.locals as any)?.locale as Locale | undefined;
 const cookieLocale = Astro.cookies.get("gomate_locale")?.value as Locale | undefined;
 const resolvedLocale = localsLocale || cookieLocale;
 const locale: Locale = (resolvedLocale && SUPPORTED_LOCALES.includes(resolvedLocale)) ? resolvedLocale : DEFAULT_LOCALE;
+// 尽早同步 SSR locale，保证 islands 服务端渲染与客户端 hydrate 一致（即使 i18n 数据加载失败也要一致）
+globalThis.__SSR_LOCALE__ = locale;
 
 // ─── SSR i18n 数据加载 ──────────────────────────────────────────────
 // 从 locals 读取页面声明的 namespaces


### PR DESCRIPTION
## 改动范围

修复 PR #364 在 en locale 下仍存在的 hydration 错误 #418/#423/#425（task #130 后续）。

### 根因

PR #364 把 SSR 翻译数据注入了全局 i18n 缓存，但 **没有同步 SSR 解析出的 locale**：

- `Layout.astro` 从 cookie/URL 解析出 `locale`（如 `en`），并把 en 翻译数据注入缓存
- 但 React islands SSR 渲染时，`useI18n` → `getLocale()` 在无 `document` 的 SSR 环境返回 `DEFAULT_LOCALE`（zh-CN）
- en cookie 用户拿到的 SSR HTML 中，Footer 等 island 渲染的是 zh-CN 内容（缓存里只有 en 数据，zh-CN 翻译未命中时落到组件内硬编码中文）
- 客户端 hydrate 时 `getLocale()` 读到 en cookie → 用 en 翻译 → SSR/CSR 文本不一致 → React #418/#423/#425
- zh-CN 默认用户两端一致，所以 dev 验证未暴露；线上 curl 不带 cookie 也复现不了，一度误判为 Cloudflare 缓存问题

### 关键文件

- `frontend/src/i18n/index.ts`
  - `getLocale()` 在 SSR 环境（`typeof document === "undefined"`）优先读 `globalThis.__SSR_LOCALE__`
- `frontend/src/layouts/Layout.astro`
  - 解析出 `locale` 后立即设置 `globalThis.__SSR_LOCALE__ = locale`（放在 i18n 数据加载之前，即使加载失败 locale 也一致）

## 本地验证

```bash
pnpm --filter @gomate/frontend type-check   # 0 errors, 0 warnings
pnpm --filter @gomate/frontend build        # success
```

dev 服务器双 locale 复验（此前只测了 zh-CN，这次补 en）：

| locale cookie | SSR footer tagline | 控制台 |
|---|---|---|
| `en` | `Discover interesting places, find travel companions.`（修复前为中文硬编码） | 无 error/warn |
| `zh-CN` | `发现有趣的地方,找到同行的人。` | 无 error/warn |

## 已知风险与回滚

- 风险：`globalThis.__SSR_LOCALE__` 是模块级全局，Cloudflare Workers 单实例串行处理请求，无并发污染风险；客户端 bundle 不会执行该分支（有 document）
- 回滚：revert 本 PR

## 涉及资源

- 仅前端代码变更，无数据库、环境变量或 Cloudflare 资源变化

## 线上回归计划（合并后）

- 带 `gomate_locale=en` cookie 打开首页：控制台应无 #418/#423/#425，footer 显示英文
- zh-CN 默认访问：控制台干净，footer 中文
- /discover、/locations/{id} 控制台同步复验

fixes task #130
