### PR TITLE
feat(frontend): 故事详情页信息层级收敛 (task #141)

### DIFF
--- a/frontend/src/components/features/discover/story-detail-ui.tsx
+++ b/frontend/src/components/features/discover/story-detail-ui.tsx
@@ -2,12 +2,12 @@ import {
   AlertTriangle,
   ArrowLeft,
   ArrowRight,
+  Eye,
   FileText,
   Heart,
   Loader2,
   MapPin,
   Share2,
-  Trash2,
 } from "lucide-react";
 import { Avatar } from "@/components/ui/avatar";
 import { cn } from "@/lib/utils";
@@ -20,8 +20,7 @@ export const SHELL_WIDTH = "mx-auto w-full max-w-5xl px-4 sm:px-6 lg:px-8";
 export function StoryEyebrow({ story, t }: { story: Story; t: TFunction }) {
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <span className="inline-flex items-center gap-1.5 rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
-        <MapPin className="h-3.5 w-3.5" aria-hidden="true" />
+      <span className="text-sm font-medium text-primary">
         {story.location?.name || t("content.discover.outdoorStory")}
       </span>
     </div>
@@ -100,6 +99,7 @@ export function StoryActions({
   isLiking,
   onLike,
   onShare,
+  viewsText,
   t,
 }: {
   liked: boolean;
@@ -107,6 +107,7 @@ export function StoryActions({
   isLiking: boolean;
   onLike: () => void;
   onShare: () => void;
+  viewsText?: string;
   t: TFunction;
 }) {
   return (
@@ -138,6 +139,12 @@ export function StoryActions({
           {t("content.discover.share")}
         </button>
       </div>
+      {viewsText && (
+        <p className="mt-4 flex items-center justify-center gap-1.5 text-sm text-muted-foreground">
+          <Eye className="h-4 w-4" aria-hidden="true" />
+          {viewsText}
+        </p>
+      )}
     </div>
   );
 }
@@ -153,9 +160,8 @@ export function StoryDeleteButton({
     <button
       type="button"
       onClick={onClick}
-      className="inline-flex min-h-10 items-center gap-2 rounded-lg border border-destructive/20 bg-destructive/10 px-3 text-sm font-medium text-destructive transition-colors hover:bg-destructive/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      className="inline-flex min-h-10 items-center gap-1.5 rounded-lg px-2 text-sm font-medium text-destructive transition-colors hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
     >
-      <Trash2 className="h-4 w-4" aria-hidden="true" />
       <span className="hidden sm:inline">{t("content.discover.deleteStory")}</span>
     </button>
   );

--- a/frontend/src/components/features/discover/story-detail-utils.ts
+++ b/frontend/src/components/features/discover/story-detail-utils.ts
@@ -1,4 +1,4 @@
-import { Clock, Eye, FileText, Heart, type LucideIcon } from "lucide-react";
+import { Clock, type LucideIcon } from "lucide-react";
 import type { Story, TFunction } from "./story-detail-types";
 
 export interface StoryMetric {
@@ -7,8 +7,9 @@ export interface StoryMetric {
   value: string;
 }
 
+// spec v1.1 §3.3：byline 只保留「作者 · 日期 · 阅读时长」，
+// 浏览量/点赞数下移到文章底部操作区（见 StoryActions）
 export function getStoryMetrics(story: Story, locale: string, t: TFunction): StoryMetric[] {
-  const numberFormatter = new Intl.NumberFormat(locale);
   const publishedDate = new Intl.DateTimeFormat(locale, {
     year: "numeric",
     month: "long",
@@ -24,30 +25,16 @@ export function getStoryMetrics(story: Story, locale: string, t: TFunction): Sto
       value: publishedDate,
     },
     {
-      icon: Eye,
-      label: t("content.discover.views"),
-      value: t("content.discover.viewCount", {
-        count: numberFormatter.format(story.viewCount),
-      }),
-    },
-    {
-      icon: Heart,
-      label: t("content.discover.likes"),
-      value: t("content.discover.likeCount", {
-        count: numberFormatter.format(story.likeCount),
-      }),
-    },
-    {
       icon: Clock,
       label: t("content.discover.readingTime"),
       value: t("content.discover.readTime", { minutes: readMinutes }),
     },
-    {
-      icon: FileText,
-      label: t("content.discover.characters"),
-      value: t("content.discover.characterCount", {
-        count: numberFormatter.format(characterCount),
-      }),
-    },
   ];
+}
+
+export function getViewCountText(story: Story, locale: string, t: TFunction): string {
+  const numberFormatter = new Intl.NumberFormat(locale);
+  return t("content.discover.viewCount", {
+    count: numberFormatter.format(story.viewCount),
+  });
 }

--- a/frontend/src/components/features/discover/story-detail.tsx
+++ b/frontend/src/components/features/discover/story-detail.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { ArrowLeft, FileText, Share2 } from "lucide-react";
+import { ArrowLeft, FileText } from "lucide-react";
 import { apiDelete, apiGet, apiPost, fetchCurrentUser } from "@/lib/api";
 import type { SessionUser } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -23,7 +23,7 @@ import {
   StoryDetailError,
   StoryEyebrow,
 } from "./story-detail-ui";
-import { getStoryMetrics } from "./story-detail-utils";
+import { getStoryMetrics, getViewCountText } from "./story-detail-utils";
 
 export function StoryDetail({ storyId }: StoryDetailProps) {
   const { t, locale } = useI18n(["content", "common"]);
@@ -101,25 +101,6 @@ export function StoryDetail({ storyId }: StoryDetailProps) {
       showToast({ type: "error", message: t("content.discover.shareFailed") });
     }
   }, [showToast, t]);
-
-  const handleShare = React.useCallback(async () => {
-    if (!story) return;
-
-    if (navigator.share) {
-      try {
-        await navigator.share({
-          title: story.title,
-          text: story.summary,
-          url: window.location.href,
-        });
-        return;
-      } catch (err) {
-        if (err instanceof DOMException && err.name === "AbortError") return;
-      }
-    }
-
-    await copyCurrentUrl();
-  }, [copyCurrentUrl, story]);
 
   const handleLike = React.useCallback(async () => {
     if (isLiking) return;
@@ -242,15 +223,6 @@ export function StoryDetail({ storyId }: StoryDetailProps) {
                 />
               </>
             )}
-            <button
-              type="button"
-              onClick={() => setShowShareSheet(true)}
-              className="inline-flex min-h-10 items-center gap-2 rounded-lg border border-border bg-card px-3 text-sm font-medium text-muted-foreground shadow-sm transition-colors hover:border-primary/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-              aria-label={t("content.discover.share")}
-            >
-              <Share2 className="h-4 w-4" aria-hidden="true" />
-              <span className="hidden sm:inline">{t("content.discover.share")}</span>
-            </button>
           </div>
         </div>
       </div>
@@ -259,11 +231,11 @@ export function StoryDetail({ storyId }: StoryDetailProps) {
         <StoryEyebrow story={story} t={t} />
 
         <div className="space-y-4">
-          <h1 className="text-3xl font-bold leading-tight text-foreground sm:text-4xl lg:text-5xl">
+          <h1 className="text-2xl font-bold leading-tight text-foreground sm:text-3xl">
             {story.title}
           </h1>
           {story.summary && (
-            <p className="border-l-2 border-primary/50 pl-4 text-base leading-7 text-muted-foreground sm:text-lg sm:leading-8">
+            <p className="text-lg leading-relaxed text-muted-foreground">
               {story.summary}
             </p>
           )}
@@ -273,7 +245,7 @@ export function StoryDetail({ storyId }: StoryDetailProps) {
       </header>
 
       {story.coverImage && (
-        <figure className={cn(SHELL_WIDTH, "mt-8")}>
+        <figure className={cn(CONTENT_WIDTH, "mt-8")}>
           <div className="overflow-hidden rounded-lg border border-border bg-muted shadow-sm">
             <img
               src={story.coverImage}
@@ -299,7 +271,8 @@ export function StoryDetail({ storyId }: StoryDetailProps) {
           likeCount={story.likeCount}
           isLiking={isLiking}
           onLike={handleLike}
-          onShare={handleShare}
+          onShare={() => setShowShareSheet(true)}
+          viewsText={getViewCountText(story, locale, t)}
           t={t}
         />
       </main>


### PR DESCRIPTION
## 改动范围

task #141（P1）：故事详情页信息层级收敛，按 `notes/gomate-story-module-design-spec.md` §3.3 实施（spec 随 PR #367 入库）。与 #139 无文件重叠，可独立合并。

**关键文件**
- `story-detail-utils.ts`：metrics 5 项 → 2 项（日期 + 阅读时长）；新增 `getViewCountText`
- `story-detail-ui.tsx`：eyebrow 去彩色 pill 改纯文字；StoryActions 增加底部浏览量行；删除按钮降级为 text-destructive 文字按钮
- `story-detail.tsx`：标题降档 `text-2xl sm:text-3xl`；摘要去引用块样式；封面容器 `max-w-5xl` → `max-w-3xl`；删顶部 share 按钮，分享入口收敛到底部 StoryActions

**分享入口说明**：顶部 share 按钮是 ShareStorySheet（海报/微博/微信/复制链接，task #129 海报能力入口）的唯一触发点。按 spec「只保留底部 StoryActions 一处」，底部 onShare 由 `handleShare`（navigator.share/复制链接）改为打开 ShareStorySheet——分享渠道能力不变，入口唯一。`handleShare` 死代码已移除。

## 本地验证

- type-check 0 errors / lint pass / build pass
- Playwright 双 locale（zh-CN + en）冒烟（真实故事 KRRveBdOwvnekgDjNgAwp，`PUBLIC_API_URL=https://api.gomate.live pnpm web:dev` 5432）：
  - byline dl 仅 1 个 metric 节点（阅读时长；日期在作者名下方，合计作者/日期/阅读时长 3 项）
  - h1 `text-2xl sm:text-3xl`；摘要无 `border-l-2`；封面容器 `max-w-3xl`
  - 顶部操作区仅剩「返回」（未登录态）
  - 底部出现浏览量（zh「1,391 次浏览」/ en「1,393 views」）
  - console 0 error

## Wen 需验证场景

1. **byline**：细数 metrics DOM 节点 = 作者 + 日期 + 阅读时长 3 项，无浏览量/点赞数/字数
2. **底部操作区**：点赞 + 分享按钮，下方浏览量 muted 行
3. **分享流**：底部「分享」→ ShareStorySheet 打开 → 海报预览 / 复制链接 / 微博微信渠道正常（task #129 海报能力回归）
4. **作者/管理员视角**：编辑按钮保留、删除为 text-destructive 文字按钮；删除确认弹窗流程不变
5. **双 locale**（zh-CN + en cookie）+ console 0 error（#418/#423/#425 hydration 不复发）

## 回滚

纯 UI 收敛，无逻辑/契约变更；revert 即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
