### PR TITLE
fix(frontend): Vditor 显式 cache.enable=false 修复线上编辑器瘫痪 (task #144)

### DIFF
--- a/frontend/src/components/features/discover/vditor-editor.tsx
+++ b/frontend/src/components/features/discover/vditor-editor.tsx
@@ -104,6 +104,10 @@ export function VditorEditor({ value, onChange, placeholder, readOnly = false }:
           placeholder: placeholderRef.current ?? t("content.writeStories"),
           theme: dark ? "dark" : "classic",
           cdn: VDITOR_CDN,
+          // vditor 3.11+ 默认启用 localStorage 缓存且要求显式 cache.id，
+          // 缺失时报 "need options.cache.id" 导致编辑器初始化失败（线上发布/编辑瘫痪）。
+          // 草稿由 useStoryForm 自行管理，这里直接禁用 vditor 缓存。
+          cache: { enable: false },
           toolbar: readOnly
             ? []
             : [


### PR DESCRIPTION
## 🔴 P0 线上修复：发布/编辑故事正文瘫痪

**现象**：线上发布故事页 Vditor 编辑器容器空白、无法输入正文（console `need options.cache.id`），发布故事功能实际瘫痪；编辑页同组件同病。

**根因**：vditor 3.11.x 默认 `cache.enable = true` 且要求显式 `cache.id`，缺失时 `new Vditor()` 构造即 throw（已在 node_modules vditor 3.11.2 源码核实：`mergedOptions.cache.enable && !mergedOptions.cache.id → throw`）。全仓唯一实例化点 `vditor-editor.tsx` 未传 cache 配置。

**修复**：Vditor options 增加 `cache: { enable: false }`（+4 行含注释）。草稿由 `useStoryForm` 自行管理，vditor 的 localStorage 缓存本就是多余状态源，禁用无功能损失。

## 本地验证

- type-check 0 errors / build pass
- 根因路径在 vditor 源码逐行核实（非猜测）

## Wen 需验证场景

1. **发布页**（wen-qa 登录态）：Vditor 正常渲染、可输入正文、SV 分屏预览正常
2. **编辑页**（fixture 故事 8cL9s8WLmSksmUv_vwKzv）：编辑器加载已有正文、可编辑保存
3. console 无 `need options.cache.id`，无新增 error
4. 线上回归重点：发布故事全流程（标题+正文+提交）走通

## 回滚

+4 行配置，revert 即恢复原状（但恢复即瘫痪，回滚价值仅在于排查误判）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
