### PR TITLE
feat(frontend): 编辑页取消弹窗 a11y + title 重复修复 + spec v1.2 入库 (task #140/#145)

### DIFF
--- a/frontend/src/components/features/discover/story-edit-client.tsx
+++ b/frontend/src/components/features/discover/story-edit-client.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import { useI18n } from "@/hooks/useI18n";
 import { useToast } from "@/hooks/useToast";
 import { FormField, Input, Select, Textarea } from "@/components/ui/form-input";
+import { useModalA11y } from "@/hooks/useModalA11y";
 import { VditorEditor } from "./vditor-editor";
 import { StoryToast } from "./story-detail-toast";
 import { useStoryForm } from "./use-story-form";
@@ -34,6 +35,10 @@ export function StoryEditClient({ storyId }: StoryEditClientProps) {
 
   const coverInputRef = React.useRef<HTMLInputElement>(null);
   const [showCancelConfirm, setShowCancelConfirm] = React.useState(false);
+  const cancelPanelRef = React.useRef<HTMLDivElement>(null);
+  const closeCancelConfirm = React.useCallback(() => setShowCancelConfirm(false), []);
+  // spec §4.1：role=alertdialog + 焦点 trap + Esc + 焦点还原
+  useModalA11y(showCancelConfirm, cancelPanelRef, closeCancelConfirm);
 
   // Dirty detection
   const isDirty = React.useMemo(() => {
@@ -263,19 +268,27 @@ export function StoryEditClient({ storyId }: StoryEditClientProps) {
 
       {/* Cancel Confirmation Dialog */}
       {showCancelConfirm && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={() => setShowCancelConfirm(false)}>
-          <div className="mx-4 w-full max-w-sm rounded-2xl border border-border bg-card p-6 shadow-xl" onClick={(e) => e.stopPropagation()}>
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={closeCancelConfirm}>
+          <div
+            ref={cancelPanelRef}
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="cancel-edit-title"
+            aria-describedby="cancel-edit-desc"
+            className="mx-4 w-full max-w-sm rounded-2xl border border-border bg-card p-6 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
             <div className="flex items-center gap-3 mb-4">
               <div className="w-10 h-10 rounded-full bg-destructive/10 flex items-center justify-center">
                 <AlertTriangle className="h-5 w-5 text-destructive" />
               </div>
               <div>
-                <h3 className="font-semibold text-foreground">放弃编辑？</h3>
-                <p className="text-sm text-muted-foreground">当前修改将不会保存</p>
+                <h3 id="cancel-edit-title" className="font-semibold text-foreground">放弃编辑？</h3>
+                <p id="cancel-edit-desc" className="text-sm text-muted-foreground">当前修改将不会保存</p>
               </div>
             </div>
             <div className="flex gap-2 justify-end">
-              <button onClick={() => setShowCancelConfirm(false)} className="px-4 py-2 rounded-md border border-border text-sm font-medium text-foreground hover:bg-accent transition-colors">
+              <button onClick={closeCancelConfirm} className="px-4 py-2 rounded-md border border-border text-sm font-medium text-foreground hover:bg-accent transition-colors">
                 继续编辑
               </button>
               <button onClick={confirmDiscard} className="px-4 py-2 rounded-md bg-destructive text-destructive-foreground text-sm font-medium hover:bg-destructive/90 transition-colors">

--- a/frontend/src/hooks/useModalA11y.ts
+++ b/frontend/src/hooks/useModalA11y.ts
@@ -1,0 +1,74 @@
+import * as React from "react";
+
+const FOCUSABLE =
+  'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
+/**
+ * 弹窗可访问性 hook（对齐 daily-book modal-a11y 已验证模式，spec §4.1）：
+ * - 打开时焦点移入弹窗第一个可交互元素（最多 5×50ms 重试，避开渲染/过渡时序坑）
+ * - Tab / Shift+Tab 在弹窗内循环 trap（含焦点落出弹窗的兜底拦回）
+ * - Esc 关闭
+ * - 关闭后焦点还原到触发元素
+ */
+export function useModalA11y(
+  open: boolean,
+  panelRef: React.RefObject<HTMLElement | null>,
+  onClose: () => void,
+) {
+  const previousFocusRef = React.useRef<HTMLElement | null>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const panel = panelRef.current;
+    if (!panel) return;
+
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+
+    const target = panel.querySelector<HTMLElement>(FOCUSABLE);
+    let attempts = 0;
+    let cancelled = false;
+    const tryFocus = () => {
+      if (cancelled) return;
+      target?.focus();
+      if (document.activeElement !== target && attempts++ < 5) {
+        setTimeout(tryFocus, 50);
+      }
+    };
+    tryFocus();
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const focusables = Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
+        (el) => el.offsetParent !== null,
+      );
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      // 兜底：焦点落在弹窗外时先拦回弹窗内首位
+      if (!panel.contains(document.activeElement)) {
+        e.preventDefault();
+        first.focus();
+      } else if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener("keydown", onKeyDown);
+      const prev = previousFocusRef.current;
+      if (prev && document.contains(prev)) prev.focus();
+      previousFocusRef.current = null;
+    };
+  }, [open, panelRef, onClose]);
+}

--- a/frontend/src/pages/discover/[id]/edit.astro
+++ b/frontend/src/pages/discover/[id]/edit.astro
@@ -11,6 +11,6 @@ declareI18nNs(Astro.locals, ["content", "common", "ui"]);
 const { id } = Astro.params;
 ---
 
-<Layout title="编辑故事 - GoMate" showNavbar={true} showFooter={false}>
+<Layout title="编辑故事" showNavbar={true} showFooter={false}>
   <StoryEditClient storyId={id!} client:only="react" />
 </Layout>

--- a/frontend/src/pages/discover/create.astro
+++ b/frontend/src/pages/discover/create.astro
@@ -9,6 +9,6 @@ import { declareI18nNs } from "../../middleware";
 declareI18nNs(Astro.locals, ["content", "common", "ui"]);
 ---
 
-<Layout title="发布故事 - GoMate" showNavbar={true} showFooter={true}>
+<Layout title="发布故事" showNavbar={true} showFooter={true}>
   <CreateStoryClient client:load />
 </Layout>

--- a/notes/gomate-story-module-design-spec.md
+++ b/notes/gomate-story-module-design-spec.md
@@ -3,7 +3,7 @@
 > 需求：task #138（@Steven）
 > 拆分：task #139（P0 DS v2.0 统一）、#140（P0 弹窗 a11y）、#141（P1 详情页层级）、#142（P1 移动端）、#143（P2 验证放宽）
 > 范围：`/discover/[id]` 详情、`/discover/[id]/edit` 编辑、`/discover/create` 发布
-> 设计者：@Steven · 2026-07-18 · v1.1（§6 补 #143 设计定义）
+> 设计者：@Steven · 2026-07-18 · v1.2（§6 补 #143 设计定义；表单元素以共享套件 form-input.tsx 为准）
 > 问题清单：`notes/gomate-story-pages-ux-analysis.md`
 
 ---
@@ -20,26 +20,27 @@
 
 所有替换必须走 token / 语义类，禁止再写死 amber hex 或 Tailwind amber 色阶。
 
-| 旧写法（编辑页/发布页）                                  | DS v2.0 替换                                                   | 说明                                        |
-| -------------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------- |
-| `bg-gradient-to-b from-amber-50/30 to-white`（整页背景） | `bg-background`（`#faf8f5`）                                   | 禁止任何页面级渐变                          |
-| `bg-amber-500` / `bg-amber-600`（主按钮、标签）          | `bg-primary`（`#D97706`，dark `#F59E0B`）                      | hover 用 `#B45309`（.btn-primary 已含）     |
-| `text-amber-600` / `text-amber-700`                      | `text-primary` 或 `text-accent-foreground`（`#92400E`）        | 小字提示用 accent-foreground 保证对比度     |
-| `bg-amber-50` / `bg-amber-100`（提示条、tag 底）         | `bg-accent`（`#FFFBEB`）或 `bg-secondary`（`#f2ede7`）         | 提示条用 bg-accent + text-accent-foreground |
-| `rounded-xl`（卡片/输入框）                              | `rounded-lg`（16px，卡片）/ `rounded-md`（12px，按钮、输入框） | 见 §4 圆角规则                              |
-| `focus:ring-amber-200`                                   | `focus:ring-ring`（`--ring: #D97706`）                         |                                             |
-| `border-amber-200` 等                                    | `border-border`（`#e8e0d7`）                                   |                                             |
-| 自定义阴影                                               | `shadow-card` / `shadow-card-hover` / `shadow-warm-sm`         | 禁止新造阴影值                              |
+| 旧写法（编辑页/发布页）                                  | DS v2.0 替换                                                                                | 说明                                        |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| `bg-gradient-to-b from-amber-50/30 to-white`（整页背景） | `bg-background`（`#faf8f5`）                                                                | 禁止任何页面级渐变                          |
+| `bg-amber-500` / `bg-amber-600`（主按钮、标签）          | `bg-primary`（`#D97706`，dark `#F59E0B`）                                                   | hover 用 `#B45309`（.btn-primary 已含）     |
+| `text-amber-600` / `text-amber-700`                      | `text-primary` 或 `text-accent-foreground`（`#92400E`）                                     | 小字提示用 accent-foreground 保证对比度     |
+| `bg-amber-50` / `bg-amber-100`（提示条、tag 底）         | `bg-accent`（`#FFFBEB`）或 `bg-secondary`（`#f2ede7`）                                      | 提示条用 bg-accent + text-accent-foreground |
+| `rounded-xl`（卡片/输入框）                              | 卡片 `rounded-lg`（16px）；输入框走共享套件（rounded-lg）；按钮 `rounded-md`（12px）        | 见 §4 圆角规则（v1.2：输入框以套件为准）    |
+| `focus:ring-amber-200`                                   | 表单字段走套件 `focus:ring-brand/30`；非表单交互元素 `focus:ring-ring`（`--ring: #D97706`） | v1.2 修订                                   |
+| `border-amber-200` 等                                    | `border-border`（`#e8e0d7`）                                                                |                                             |
+| 自定义阴影                                               | `shadow-card` / `shadow-card-hover` / `shadow-warm-sm`                                      | 禁止新造阴影值                              |
 
 ### 圆角规则（全模块统一）
 
-| 元素                 | token           | 值     |
-| -------------------- | --------------- | ------ |
-| 按钮、输入框、select | `--radius-md`   | 12px   |
-| 卡片、封面容器       | `--radius-lg`   | 16px   |
-| 弹窗（dialog）       | `--radius-2xl`  | 24px   |
-| 标签 pill、头像      | `--radius-full` | 9999px |
-| 徽章内小圆点         | `--radius-xs`   | 4px    |
+| 元素                         | token                                              | 值                             |
+| ---------------------------- | -------------------------------------------------- | ------------------------------ |
+| 按钮                         | `--radius-md`                                      | 12px                           |
+| **输入框、select、textarea** | **以共享套件 `form-input.tsx` 为准：`rounded-lg`** | **16px（v1.2 修订，见 §3.1）** |
+| 卡片、封面容器               | `--radius-lg`                                      | 16px                           |
+| 弹窗（dialog）               | `--radius-2xl`                                     | 24px                           |
+| 标签 pill、头像              | `--radius-full`                                    | 9999px                         |
+| 徽章内小圆点                 | `--radius-xs`                                      | 4px                            |
 
 **禁用**：`rounded-xl`（20px 仅限大展示卡片，本模块不用）、任何写死 px 的圆角。
 
@@ -62,7 +63,7 @@
 - **取消按钮**：`.btn-ghost` 或 `bg-secondary text-secondary-foreground`
 - **草稿恢复横幅**：`bg-accent text-accent-foreground` + `border border-border` + `rounded-md`，不再用 amber-50 整块突兀横幅；按钮用 `.btn-primary` 小号
 - **未保存提示**：移动端不得 `hidden`（见 §5 移动端）
-- **输入框（标题/摘要/地点）**：`bg-card` + `border border-input` + `rounded-md` + `focus:ring-2 focus:ring-ring focus:border-transparent`
+- **输入框（标题/摘要/地点）**：**一律使用共享套件 `frontend/src/components/ui/form-input.tsx`（FormField/Input/Textarea/Select），不另写样式**（v1.2 修订）。套件即 DS v2.0 表单唯一来源：`rounded-lg` + `focus:ring-2 focus:ring-brand/30 focus:border-brand` + `aria-invalid` 错误态（border/ring destructive）+ `shadow-warm-xs`。错误文案走 FormField 的 error 槽位（自带 AlertCircle 图标 + animate-fade-down），hint 走 hint 槽位
 - **标签选择**：选中态 `bg-primary text-primary-foreground`，未选中 `bg-secondary text-secondary-foreground`，均 `rounded-full`
 - **Vditor 编辑器容器**：`bg-card` + `border border-border` + `rounded-lg` + `shadow-card`
 - **三态一致**：loading 骨架、草稿提示条、正常编辑态全部按上述 token（Wen 验收会逐态测）
@@ -189,4 +190,4 @@
 
 ---
 
-_spec v1.1。核心：三个页面一套 DS v2.0 token，视觉零断裂。_
+_spec v1.2。核心：三个页面一套 DS v2.0 token，视觉零断裂；表单元素以共享套件 form-input.tsx 为唯一来源。_


### PR DESCRIPTION
## 改动范围

task #140（P0 弹窗 a11y）+ task #145（P1 title 重复，Martin 指定搭车）+ spec v1.2 入库。

**关键文件**
- `frontend/src/hooks/useModalA11y.ts`（新增）：弹窗 a11y hook，对齐 daily-book modal-a11y 已验证模式（spec §4.1）——打开焦点移入（最多 5×50ms 重试，避开渲染/过渡时序坑）、Tab/Shift+Tab 循环 trap（含焦点落出弹窗的兜底拦回）、Esc 关闭、关闭后焦点还原触发元素
- `story-edit-client.tsx`：取消确认弹窗接入 hook + `role="alertdialog"` + `aria-modal="true"` + `aria-labelledby/describedby`
- `discover/[id]/edit.astro` / `discover/create.astro`：去硬编码「- GoMate」后缀（Layout 统一追加 titleSuffix，修法同 PR #365），消除「编辑故事 - GoMate - GoMate」
- `notes/gomate-story-module-design-spec.md`：升 v1.2（@Steven 修订：表单元素以共享套件 form-input.tsx 为准，零 add/add 冲突路径入库）

## 本地验证

- type-check 0 errors / lint pass / build pass
- 焦点管理逻辑为 daily-book PR #67/#68 同款已验证模式（gomate 为 React hook 实现）

## Wen 需验证场景

1. **弹窗 aria**：取消弹窗 `role="alertdialog"` + `aria-modal="true"` 实测存在
2. **焦点流**（编辑页改内容 → 点返回）：打开焦点移入「继续编辑」→ Tab 循环 trap（末位 Tab 回首位、首位 Shift+Tab 回末位）→ Esc 关闭 → 焦点还原到返回按钮；「放弃」路径同样还原
3. **极端路径**：弹窗打开后程序化把焦点挪出弹窗 → Tab 拦回首位（PR #68 同款兜底）
4. **title**：编辑页/发布页 `<title>` 为「编辑故事 - GoMate」「发布故事 - GoMate」（不重复），双 locale 一致
5. **回归**：编辑页三态 + 双 locale + console 0 error（#418/#423/#425 不复发）

## 回滚

弹窗 aria/焦点为增量增强，title 为字符串修改，revert 即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
