### PR TITLE
feat(frontend): 编辑页移动端折叠 + story 模块 i18n 补全 (task #142/#146)

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -11,6 +11,7 @@
   "submit": "Submit",
   "save": "Save",
   "saving": "Saving...",
+  "share": "Share",
   "edit": "Edit",
   "confirm": "Confirm",
   "create": "Create",

--- a/frontend/public/locales/en/content.json
+++ b/frontend/public/locales/en/content.json
@@ -339,12 +339,35 @@
       "removeTag": "Remove {tag} tag",
       "submit": "Publish story",
       "submitting": "Publishing...",
-      "submitFailed": "Failed to publish story"
+      "submitFailed": "Failed to publish story",
+      "coverPlaceholder": "Click to upload cover image"
+    },
+    "edit": {
+      "titlePlaceholder": "Story title",
+      "summaryPlaceholder": "Short description...",
+      "contentPlaceholder": "Write your story in Markdown...",
+      "statusLabel": "Status",
+      "statusPublished": "Published",
+      "statusDraft": "Draft",
+      "coverFormatHint": "JPG/PNG, ≤2MB",
+      "locationSearchPlaceholder": "Search locations...",
+      "removeLocation": "Remove related location",
+      "tagsCountHint": "{count}/10 max",
+      "draftBanner": "Unsaved draft detected",
+      "restoreDraft": "Restore draft",
+      "discardDraft": "Discard",
+      "cancelTitle": "Discard changes?",
+      "cancelDesc": "Your current changes will not be saved",
+      "continueEditing": "Keep editing",
+      "discardConfirm": "Discard",
+      "expandMore": "Show more (status/cover/location/tags)",
+      "collapseMore": "Show less"
     }
   },
   "title": "GoMate - Discover Places, Team Up Together",
   "description": "GoMate is a minimalist \"location team-up\" platform, helping outdoor enthusiasts find like-minded hiking companions.",
   "titleSuffix": " - GoMate",
+  "writeStories": "Write your story in Markdown...",
   "seo_pages": {
     "home": "Home",
     "locations": "Explore Locations",
@@ -368,6 +391,8 @@
     "help": "Help Center",
     "privacy": "Privacy Policy",
     "terms": "Terms of Service",
-    "adminLocations": "Manage Locations"
+    "adminLocations": "Manage Locations",
+    "storyCreate": "Publish Story - GoMate",
+    "storyEdit": "Edit Story - GoMate"
   }
 }

--- a/frontend/public/locales/zh-CN/common.json
+++ b/frontend/public/locales/zh-CN/common.json
@@ -11,6 +11,7 @@
   "submit": "提交",
   "save": "保存",
   "saving": "保存中...",
+  "share": "分享",
   "edit": "编辑",
   "confirm": "确认",
   "create": "创建",

--- a/frontend/public/locales/zh-CN/content.json
+++ b/frontend/public/locales/zh-CN/content.json
@@ -339,12 +339,35 @@
       "removeTag": "移除 {tag} 标签",
       "submit": "发布故事",
       "submitting": "发布中...",
-      "submitFailed": "发布故事失败"
+      "submitFailed": "发布故事失败",
+      "coverPlaceholder": "点击上传封面图"
+    },
+    "edit": {
+      "titlePlaceholder": "故事标题",
+      "summaryPlaceholder": "简短描述...",
+      "contentPlaceholder": "用 Markdown 写下你的故事...",
+      "statusLabel": "状态",
+      "statusPublished": "已发布",
+      "statusDraft": "草稿",
+      "coverFormatHint": "JPG/PNG，≤2MB",
+      "locationSearchPlaceholder": "搜索地点...",
+      "removeLocation": "移除关联地点",
+      "tagsCountHint": "{count}/10 最多",
+      "draftBanner": "检测到未保存的草稿",
+      "restoreDraft": "恢复草稿",
+      "discardDraft": "丢弃",
+      "cancelTitle": "放弃编辑？",
+      "cancelDesc": "当前修改将不会保存",
+      "continueEditing": "继续编辑",
+      "discardConfirm": "放弃",
+      "expandMore": "展开更多（状态/封面/地点/标签）",
+      "collapseMore": "收起"
     }
   },
   "title": "GoMate - 发现趣处，组队同行",
   "description": "GoMate 是一个极简的「地点组队」平台，帮助户外爱好者找到志同道合的徒步伙伴。",
   "titleSuffix": " - GoMate",
+  "writeStories": "用 Markdown 写下你的故事...",
   "seo_pages": {
     "home": "首页",
     "locations": "探索地点",
@@ -368,6 +391,8 @@
     "help": "帮助中心",
     "privacy": "隐私政策",
     "terms": "服务条款",
-    "adminLocations": "管理地点"
+    "adminLocations": "管理地点",
+    "storyCreate": "发布故事 - GoMate",
+    "storyEdit": "编辑故事 - GoMate"
   }
 }

--- a/frontend/src/components/features/discover/story-edit-client.tsx
+++ b/frontend/src/components/features/discover/story-edit-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { ArrowLeft, ImagePlus, Loader2, MapPin, Search, X, AlertTriangle } from "lucide-react";
+import { ArrowLeft, ChevronDown, ChevronUp, ImagePlus, Loader2, MapPin, Search, X, AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useI18n } from "@/hooks/useI18n";
 import { useToast } from "@/hooks/useToast";
@@ -35,6 +35,8 @@ export function StoryEditClient({ storyId }: StoryEditClientProps) {
 
   const coverInputRef = React.useRef<HTMLInputElement>(null);
   const [showCancelConfirm, setShowCancelConfirm] = React.useState(false);
+  // spec §5：移动端「基本信息」区折叠（默认只展开标题+摘要），桌面端始终全部展开
+  const [basicExpanded, setBasicExpanded] = React.useState(false);
   const cancelPanelRef = React.useRef<HTMLDivElement>(null);
   const closeCancelConfirm = React.useCallback(() => setShowCancelConfirm(false), []);
   // spec §4.1：role=alertdialog + 焦点 trap + Esc + 焦点还原
@@ -104,12 +106,16 @@ export function StoryEditClient({ storyId }: StoryEditClientProps) {
             <ArrowLeft className="h-4 w-4" />
             {t("common.back")}
           </button>
-          <div className="flex items-center gap-3">
-            {isDirty && <span className="text-xs text-accent-foreground hidden sm:inline">有未保存的修改</span>}
+          <div className="flex flex-1 items-center justify-end gap-3 sm:flex-none">
             <button onClick={handleSave} disabled={isSaving}
-              className="btn-primary gap-1.5 px-4 py-2 text-sm disabled:opacity-50">
+              className="btn-primary flex-1 justify-center gap-1.5 px-4 py-2 text-sm disabled:opacity-50 sm:flex-none">
               {isSaving && <Loader2 className="h-4 w-4 animate-spin" />}
+              {isDirty && !isSaving && (
+                // spec §5：未保存提示改为保存按钮上的状态点（移动端不得 hidden）
+                <span aria-hidden="true" className="h-2 w-2 rounded-full bg-primary-foreground" />
+              )}
               {t("common.save")}
+              {isDirty && <span className="sr-only">{t("common.unsavedChanges")}</span>}
             </button>
           </div>
         </div>
@@ -120,10 +126,10 @@ export function StoryEditClient({ storyId }: StoryEditClientProps) {
         {/* Draft Banner */}
         {draftAvailable && (
           <div className="mb-6 flex items-center justify-between gap-3 rounded-md border border-border bg-accent px-4 py-3">
-            <p className="text-sm text-accent-foreground">检测到未保存的草稿</p>
+            <p className="text-sm text-accent-foreground">{t("content.discover.edit.draftBanner")}</p>
             <div className="flex gap-2">
-              <button onClick={handleRestoreDraft} className="btn-primary px-3 py-1 text-xs">恢复草稿</button>
-              <button onClick={handleDiscardDraft} className="btn-ghost px-3 py-1 text-xs">丢弃</button>
+              <button onClick={handleRestoreDraft} className="btn-primary px-3 py-1 text-xs">{t("content.discover.edit.restoreDraft")}</button>
+              <button onClick={handleDiscardDraft} className="btn-ghost px-3 py-1 text-xs">{t("content.discover.edit.discardDraft")}</button>
             </div>
           </div>
         )}
@@ -131,38 +137,53 @@ export function StoryEditClient({ storyId }: StoryEditClientProps) {
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
           {/* Left: Form fields */}
           <div className="lg:col-span-4 space-y-6">
-            <FormField label="标题" htmlFor="story-edit-title">
+            <FormField label={t("content.discover.create.titleLabel")} htmlFor="story-edit-title">
               <Input
                 id="story-edit-title"
                 type="text"
                 value={form.title}
                 onChange={(e) => updateField("title", e.target.value)}
-                placeholder="故事标题"
+                placeholder={t("content.discover.edit.titlePlaceholder")}
               />
             </FormField>
-            <FormField label="摘要" htmlFor="story-edit-summary" hint={`${form.summary.length}/150`}>
+            <FormField label={t("content.discover.create.summaryLabel")} htmlFor="story-edit-summary" hint={`${form.summary.length}/150`}>
               <Textarea
                 id="story-edit-summary"
                 value={form.summary}
                 onChange={(e) => updateField("summary", e.target.value)}
                 maxLength={150}
                 rows={3}
-                placeholder="简短描述..."
+                placeholder={t("content.discover.edit.summaryPlaceholder")}
                 className="min-h-[84px]"
               />
             </FormField>
-            <FormField label="状态" htmlFor="story-edit-status">
+            {/* spec §5：移动端折叠开关（桌面端隐藏，始终全展开） */}
+            <button
+              type="button"
+              aria-expanded={basicExpanded}
+              aria-controls="story-edit-basic-more"
+              onClick={() => setBasicExpanded((v) => !v)}
+              className="flex w-full items-center justify-between rounded-md border border-border bg-card px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground lg:hidden"
+            >
+              {basicExpanded ? t("content.discover.edit.collapseMore") : t("content.discover.edit.expandMore")}
+              {basicExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+            </button>
+            <div
+              id="story-edit-basic-more"
+              className={cn("space-y-6", !basicExpanded && "max-lg:hidden")}
+            >
+            <FormField label={t("content.discover.edit.statusLabel")} htmlFor="story-edit-status">
               <Select
                 id="story-edit-status"
                 value={form.status}
                 onChange={(e) => updateField("status", e.target.value)}
                 options={[
-                  { value: "published", label: "已发布" },
-                  { value: "draft", label: "草稿" },
+                  { value: "published", label: t("content.discover.edit.statusPublished") },
+                  { value: "draft", label: t("content.discover.edit.statusDraft") },
                 ]}
               />
             </FormField>
-            <FormField label="封面图" htmlFor="story-edit-cover">
+            <FormField label={t("content.discover.create.coverLabel")} htmlFor="story-edit-cover">
               {form.coverImage ? (
                 <div className="relative rounded-lg overflow-hidden border border-border">
                   <img src={form.coverImage} alt="Cover" className="w-full aspect-video object-cover" />
@@ -184,18 +205,18 @@ export function StoryEditClient({ storyId }: StoryEditClientProps) {
                   {isUploadingCover
                     ? <Loader2 className="h-6 w-6 animate-spin" />
                     : <ImagePlus className="h-6 w-6" />}
-                  <span className="text-sm">点击上传封面图</span>
-                  <span className="text-xs">JPG/PNG，≤2MB</span>
+                  <span className="text-sm">{t("content.discover.create.coverPlaceholder")}</span>
+                  <span className="text-xs">{t("content.discover.edit.coverFormatHint")}</span>
                 </button>
               )}
               <input ref={coverInputRef} id="story-edit-cover" type="file" accept="image/jpeg,image/png" className="hidden" onChange={(e) => { const f = e.target.files?.[0]; if (f) handleCoverUpload(f); }} />
             </FormField>
-            <FormField label="关联地点" htmlFor="story-edit-location">
+            <FormField label={t("content.discover.create.locationLabel")} htmlFor="story-edit-location">
               {form.locationName ? (
                 <div className="flex items-center gap-2 px-3 py-2 rounded-md bg-accent border border-border">
                   <MapPin className="h-4 w-4 text-primary" />
                   <span className="flex-1 text-sm text-accent-foreground">{form.locationName}</span>
-                  <button onClick={() => { updateField("locationId", ""); updateField("locationName", ""); }} className="text-muted-foreground hover:text-destructive" aria-label="移除关联地点">
+                  <button onClick={() => { updateField("locationId", ""); updateField("locationName", ""); }} className="text-muted-foreground hover:text-destructive" aria-label={t("content.discover.edit.removeLocation")}>
                     <X className="h-4 w-4" />
                   </button>
                 </div>
@@ -206,7 +227,7 @@ export function StoryEditClient({ storyId }: StoryEditClientProps) {
                     type="text"
                     value={locationSearch}
                     onChange={(e) => handleLocationSearch(e.target.value)}
-                    placeholder="搜索地点..."
+                    placeholder={t("content.discover.edit.locationSearchPlaceholder")}
                     leftIcon={<Search className="h-4 w-4" />}
                     rightIcon={isSearchingLocation ? <Loader2 className="h-4 w-4 animate-spin" /> : undefined}
                   />
@@ -228,7 +249,7 @@ export function StoryEditClient({ storyId }: StoryEditClientProps) {
                 </div>
               )}
             </FormField>
-            <FormField label="标签" hint={`${form.tags.length}/10 最多`}>
+            <FormField label={t("content.discover.create.tagsLabel")} hint={t("content.discover.edit.tagsCountHint", { count: form.tags.length })}>
               <div className="flex flex-wrap gap-2">
                 {allTags.map((tag) => {
                   const selected = form.tags.includes(tag.name);
@@ -251,6 +272,7 @@ export function StoryEditClient({ storyId }: StoryEditClientProps) {
                 })}
               </div>
             </FormField>
+            </div>
           </div>
 
           {/* Right: VditorEditor (SV 分屏自带预览) */}
@@ -259,7 +281,7 @@ export function StoryEditClient({ storyId }: StoryEditClientProps) {
               <VditorEditor
                 value={form.content}
                 onChange={(v) => updateField("content", v)}
-                placeholder="用 Markdown 写下你的故事..."
+                placeholder={t("content.discover.edit.contentPlaceholder")}
               />
             </div>
           </div>
@@ -283,16 +305,16 @@ export function StoryEditClient({ storyId }: StoryEditClientProps) {
                 <AlertTriangle className="h-5 w-5 text-destructive" />
               </div>
               <div>
-                <h3 id="cancel-edit-title" className="font-semibold text-foreground">放弃编辑？</h3>
-                <p id="cancel-edit-desc" className="text-sm text-muted-foreground">当前修改将不会保存</p>
+                <h3 id="cancel-edit-title" className="font-semibold text-foreground">{t("content.discover.edit.cancelTitle")}</h3>
+                <p id="cancel-edit-desc" className="text-sm text-muted-foreground">{t("content.discover.edit.cancelDesc")}</p>
               </div>
             </div>
             <div className="flex gap-2 justify-end">
               <button onClick={closeCancelConfirm} className="px-4 py-2 rounded-md border border-border text-sm font-medium text-foreground hover:bg-accent transition-colors">
-                继续编辑
+                {t("content.discover.edit.continueEditing")}
               </button>
               <button onClick={confirmDiscard} className="px-4 py-2 rounded-md bg-destructive text-destructive-foreground text-sm font-medium hover:bg-destructive/90 transition-colors">
-                放弃
+                {t("content.discover.edit.discardConfirm")}
               </button>
             </div>
           </div>

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -152,6 +152,8 @@ const titleMap: Record<string, string> = {
   "隐私政策 - GoMate": "content.seo_pages.privacy",
   "服务条款 - GoMate": "content.seo_pages.terms",
   "管理地点 - GoMate": "content.seo_pages.adminLocations",
+  "发布故事": "content.seo_pages.storyCreate",
+  "编辑故事": "content.seo_pages.storyEdit",
 };
 
 const titleKey = titleMap[propTitle];


### PR DESCRIPTION
## 改动范围

**task #142 — 编辑页移动端优化（spec §5）**
- `story-edit-client.tsx`：
  - 基本信息区移动端可折叠：默认只展开标题+摘要；状态/封面/地点/标签收进 `aria-expanded` + `aria-controls` 开关（chevron 图标），`max-lg:hidden` 折叠、`lg:hidden` 隐藏开关 → 桌面端布局完全不变
  - 375px 视口编辑器不被表单挤出首屏（折叠后表单区仅标题+摘要+开关）
  - 「未保存的修改」从 `hidden sm:inline` 文本（Martin 标记的那行）改为保存按钮内状态点（`bg-primary-foreground` 圆点，`aria-hidden`）+ `sr-only` 文案，全端可见
  - 保存按钮移动端 `flex-1` 撑满 sticky 栏可用宽度，桌面端 `sm:flex-none` 不变

**task #146 — i18n 四项搭车**
1. `content.discover.create.coverPlaceholder`（zh/en）：补 `create-story-client.tsx:285` 在用的缺失 key
2. `common.share`（zh/en）：补 `share-story-sheet.tsx:79`、`story-poster-preview.tsx:88/105` 三处在用的缺失 key（Wen 在 #368 回归中发现）
3. 编辑页表单硬编码中文 → useI18n：新增 `content.discover.edit.*` 18 键（状态/封面格式/地点搜索/标签计数/草稿横幅/取消弹窗/折叠开关等），标题/摘要/封面/地点/标签 label 复用 `create.*` 既有键，未保存提示复用 `common.unsavedChanges`
4. `Layout.astro` titleMap 增加「发布故事」「编辑故事」→ `seo_pages.storyCreate/storyEdit`（值含 ` - GoMate` 后缀，与现有回落路径 zh 输出完全一致），修 en locale 下编辑/发布页 `<title>` 显示中文的问题

顺带：`content.writeStories` 兜底 key 补齐（`vditor-editor.tsx:104` 引用但一直缺失）。

**API schema**：无变更。**功能逻辑**：无变更（只视觉/文案/a11y）。

## 本地验证

- `pnpm type-check` 0 errors / `eslint` 0 problems / `pnpm build` ✅
- 构建产物 CSS 确认 `max-lg:hidden` 正确包在 `@media not all and (min-width:64rem)` 内（桌面端不折叠）；状态点类已生成（初版 `/80` 透明度修饰符对本仓 CSS var 色值不生效，已改实色）
- 登录态实测缺本机账号 → 下列场景需 @Wen 验证

## @Wen 需验证场景（wen-qa + fixture 故事 8cL9s8WLmSksmUv_vwKzv）

1. **375px 折叠**：编辑页默认只见标题+摘要+「展开更多」开关；开关 `aria-expanded=false`；状态/封面/地点/标签隐藏；编辑器（Vditor）首屏可见
2. **展开/收起**：点开关展开四项字段，`aria-expanded` 翻转；再点收起；编辑器始终可输入
3. **桌面端（≥1024px）**：无折叠开关，全部字段直接可见，布局与线上现状一致
4. **脏状态点**：改标题一个字 → 保存按钮出现圆点（移动端同样可见）；保存后消失；点返回 → 取消弹窗文案/焦点流不回归（#140 已验项）
5. **保存按钮移动端撑满**：375px 下保存按钮拉伸填满返回按钮右侧区域
6. **双 locale**：en cookie 下编辑页全部标签/占位/弹窗英文；`<title>` 为「Edit Story - GoMate」；发布页 `<title>` 为「Publish Story - GoMate」；zh 下 `<title>` 与线上一致（「编辑故事 - GoMate」无重复后缀）
7. **common.share**：故事详情底部分享 → ShareStorySheet 底部小字显示「分享」/「Share」而非 key 字面量；发布页封面上传按钮显示「点击上传封面图」

## 已知风险与回滚

- 风险低：纯前端视觉/文案，无 API/数据变更
- 回滚：revert 本 PR 单 commit（`21573b2`）