### PR TITLE
feat(stories): 发布页封面/标签改可选（spec §6，task #143）

### DIFF
--- a/api/src/__tests__/integration/stories.test.ts
+++ b/api/src/__tests__/integration/stories.test.ts
@@ -257,6 +257,48 @@ describe("Stories API 集成测试", () => {
       expect(story?.status).toBe("published");
     });
 
+    it("不带 coverImage/tags 也可创建（spec §6 契约放宽）", async () => {
+      currentSession = { user: { id: user.id, email: user.email, name: user.name } };
+
+      const res = await req(app, "/stories", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: "无封面无标签故事",
+          summary: "验证封面与标签改可选后的契约。",
+          content: "正文内容满足必填要求。",
+          locationId: location.id,
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const json = await res.json() as { success: boolean; data: { id: string } };
+      expect(json.success).toBe(true);
+
+      const story = await testDb.query.stories.findFirst({
+        where: eq(schema.stories.id, json.data.id),
+      });
+      expect(story?.coverImage).toBeNull();
+    });
+
+    it("非法 coverImage（非 URL）仍返回 400", async () => {
+      currentSession = { user: { id: user.id, email: user.email, name: user.name } };
+
+      const res = await req(app, "/stories", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: "非法封面故事",
+          summary: "optional 不等于不校验格式。",
+          content: "正文内容满足必填要求。",
+          coverImage: "not-a-url",
+          locationId: location.id,
+        }),
+      });
+
+      expect(res.status).toBe(400);
+    });
+
     it("创建带标签故事后可通过标签筛选并出现在热门标签", async () => {
       currentSession = { user: { id: user.id, email: user.email, name: user.name } };
 

--- a/api/src/lib/validation.ts
+++ b/api/src/lib/validation.ts
@@ -57,7 +57,8 @@ export const createStorySchema = z.object({
   title: z.string().min(1, "标题不能为空").max(100, "标题不能超过100字"),
   summary: z.string().min(1, "摘要不能为空").max(150, "摘要不能超过150字"),
   content: z.string().min(1, "内容不能为空").max(10000, "内容不能超过10000字"),
-  coverImage: z.string().url("封面图片必须是有效URL"),
+  // spec §6（task #143）：封面改可选，无封面时下游用默认样式展示
+  coverImage: z.string().url("封面图片必须是有效URL").optional(),
   locationId: z.string().min(1, "地点ID不能为空"),
   tags: z.array(z.string()).max(10, "最多10个标签").optional(),
 });

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -12,6 +12,7 @@
   "save": "Save",
   "saving": "Saving...",
   "share": "Share",
+  "optional": "(Optional)",
   "edit": "Edit",
   "confirm": "Confirm",
   "create": "Create",

--- a/frontend/public/locales/en/content.json
+++ b/frontend/public/locales/en/content.json
@@ -340,7 +340,9 @@
       "submit": "Publish story",
       "submitting": "Publishing...",
       "submitFailed": "Failed to publish story",
-      "coverPlaceholder": "Click to upload cover image"
+      "coverPlaceholder": "Click to upload cover image",
+      "coverEmptyTitle": "Upload cover (optional)",
+      "coverEmptyHint": "A default style will be shown if no cover is uploaded"
     },
     "edit": {
       "titlePlaceholder": "Story title",

--- a/frontend/public/locales/zh-CN/common.json
+++ b/frontend/public/locales/zh-CN/common.json
@@ -12,6 +12,7 @@
   "save": "保存",
   "saving": "保存中...",
   "share": "分享",
+  "optional": "（选填）",
   "edit": "编辑",
   "confirm": "确认",
   "create": "创建",

--- a/frontend/public/locales/zh-CN/content.json
+++ b/frontend/public/locales/zh-CN/content.json
@@ -340,7 +340,9 @@
       "submit": "发布故事",
       "submitting": "发布中...",
       "submitFailed": "发布故事失败",
-      "coverPlaceholder": "点击上传封面图"
+      "coverPlaceholder": "点击上传封面图",
+      "coverEmptyTitle": "上传封面（选填）",
+      "coverEmptyHint": "不上传将使用默认样式展示"
     },
     "edit": {
       "titlePlaceholder": "故事标题",

--- a/frontend/src/components/features/create-story-client.tsx
+++ b/frontend/src/components/features/create-story-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { AlertCircle, ArrowLeft, ImagePlus, Loader2, Plus, Send, X } from "lucide-react";
+import { AlertCircle, ArrowLeft, Loader2, Plus, Send, X } from "lucide-react";
 import { API_BASE, fetchAPI, fetchCurrentUser } from "@/lib/api";
 import { FormField, Input, Select, Textarea } from "@/components/ui/form-input";
 import { useI18n } from "@/hooks/useI18n";
@@ -120,17 +120,29 @@ export function CreateStoryClient() {
     }
   };
 
+  // spec §6.3：封面/标签不再参与校验；disabled 只看标题/摘要/正文
   const validate = () => {
     const nextErrors: StoryFormErrors = {};
     if (!form.title.trim()) nextErrors.title = t("content.discover.create.titleRequired");
     if (!form.summary.trim()) nextErrors.summary = t("content.discover.create.summaryRequired");
     if (!form.content.trim()) nextErrors.content = t("content.discover.create.contentRequired");
-    if (!form.coverImage.trim()) nextErrors.coverImage = t("content.discover.create.coverRequired");
     if (!form.locationId) nextErrors.locationId = t("content.discover.create.locationRequired");
     if (tags.length > 10) nextErrors.tags = t("content.discover.create.tagsMax");
     setErrors(nextErrors);
     return Object.keys(nextErrors).length === 0;
   };
+
+  // spec §6.3：onBlur 即时校验必填项，错误消除即恢复（恢复由 updateField 负责）
+  const validateRequiredOnBlur = (field: "title" | "summary" | "content") => {
+    const errorKey = {
+      title: "content.discover.create.titleRequired",
+      summary: "content.discover.create.summaryRequired",
+      content: "content.discover.create.contentRequired",
+    }[field];
+    setErrors((prev) => ({ ...prev, [field]: form[field].trim() ? undefined : t(errorKey) }));
+  };
+
+  const isRequiredEmpty = !form.title.trim() || !form.summary.trim() || !form.content.trim();
 
   const handleCoverUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -176,10 +188,6 @@ export function CreateStoryClient() {
     setFormError("");
 
     if (!validate()) return;
-    if (tags.length === 0) {
-      setErrors((prev) => ({ ...prev, tags: t("content.discover.create.tagsRequired") }));
-      return;
-    }
 
     setIsSubmitting(true);
 
@@ -248,13 +256,13 @@ export function CreateStoryClient() {
             <FormField
               label={t("content.discover.create.titleLabel")}
               htmlFor="story-title"
-              required
               error={errors.title}
             >
               <Input
                 id="story-title"
                 value={form.title}
                 onChange={(event) => updateField("title", event.target.value)}
+                onBlur={() => validateRequiredOnBlur("title")}
                 placeholder={t("content.discover.create.titlePlaceholder")}
                 disabled={isSubmitting}
               />
@@ -263,26 +271,33 @@ export function CreateStoryClient() {
             <FormField
               label={t("content.discover.create.coverLabel")}
               htmlFor="story-cover"
-              required
+              optional
               error={errors.coverImage}
               hint={t("content.discover.create.coverHint")}
             >
-              <div className="space-y-2">
-                {form.coverImage && (
-                  <div className="relative rounded-lg overflow-hidden border border-border">
-                    <img src={form.coverImage} alt="Cover" className="w-full aspect-video object-cover" />
-                    <button
-                      type="button"
-                      onClick={() => updateField("coverImage", "")}
-                      className="absolute top-2 right-2 p-1.5 rounded-full bg-black/50 text-white hover:bg-black/70"
-                    >
-                      <X className="h-3 w-3" />
-                    </button>
-                  </div>
-                )}
-                <label className="flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg border border-border bg-background text-sm text-muted-foreground cursor-pointer hover:bg-accent hover:text-foreground transition-colors">
-                  <ImagePlus className="h-4 w-4" />
-                  {isUploading ? t("content.discover.create.uploading") : t("content.discover.create.coverPlaceholder")}
+              {form.coverImage ? (
+                <div className="relative rounded-lg overflow-hidden border border-border">
+                  <img src={form.coverImage} alt="Cover" className="w-full aspect-video object-cover" />
+                  <button
+                    type="button"
+                    onClick={() => updateField("coverImage", "")}
+                    aria-label={t("content.discover.create.removeCover")}
+                    className="absolute top-2 right-2 p-1.5 rounded-full bg-black/50 text-white hover:bg-black/70"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </div>
+              ) : (
+                /* spec §6.2：空态虚线占位框，120px 移动 / 160px 桌面 */
+                <label className="flex h-[120px] cursor-pointer flex-col items-center justify-center gap-1.5 rounded-lg border-2 border-dashed border-border bg-secondary/50 transition-colors hover:border-primary/40 sm:h-40">
+                  {isUploading ? (
+                    <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                  ) : (
+                    <>
+                      <span className="text-sm font-medium text-foreground">{t("content.discover.create.coverEmptyTitle")}</span>
+                      <span className="text-xs text-muted-foreground">{t("content.discover.create.coverEmptyHint")}</span>
+                    </>
+                  )}
                   <input
                     id="story-cover"
                     type="file"
@@ -292,13 +307,12 @@ export function CreateStoryClient() {
                     disabled={isUploading || isSubmitting}
                   />
                 </label>
-              </div>
+              )}
             </FormField>
 
             <FormField
               label={t("content.discover.create.summaryLabel")}
               htmlFor="story-summary"
-              required
               error={errors.summary}
               hint={t("content.discover.create.summaryHint")}
             >
@@ -306,6 +320,7 @@ export function CreateStoryClient() {
                 id="story-summary"
                 value={form.summary}
                 onChange={(event) => updateField("summary", event.target.value)}
+                onBlur={() => validateRequiredOnBlur("summary")}
                 maxLength={150}
                 className="min-h-[84px]"
                 placeholder={t("content.discover.create.summaryPlaceholder")}
@@ -316,7 +331,6 @@ export function CreateStoryClient() {
             <FormField
               label={t("content.discover.create.locationLabel")}
               htmlFor="story-location"
-              required
               error={errors.locationId}
             >
               <Select
@@ -332,7 +346,7 @@ export function CreateStoryClient() {
             <FormField
               label={t("content.discover.create.tagsLabel")}
               htmlFor="story-tags"
-              required
+              optional
               error={errors.tags}
               hint={t("content.discover.create.tagsHint")}
             >
@@ -387,7 +401,7 @@ export function CreateStoryClient() {
               </a>
               <button
                 type="submit"
-                disabled={isSubmitting || isUploading}
+                disabled={isSubmitting || isUploading || isRequiredEmpty}
                 className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-5 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
               >
                 {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
@@ -401,11 +415,10 @@ export function CreateStoryClient() {
             <FormField
               label={t("content.discover.create.contentLabel")}
               htmlFor="story-content"
-              required
               error={errors.content}
               hint={t("content.discover.create.contentHint")}
             >
-              <div className="rounded-lg border border-border overflow-hidden" style={{ height: "calc(100vh - 10rem)", minHeight: "500px" }}>
+              <div className="rounded-lg border border-border overflow-hidden" style={{ height: "calc(100vh - 10rem)", minHeight: "500px" }} onBlur={() => validateRequiredOnBlur("content")}>
                 <VditorEditor
                   value={form.content}
                   onChange={(v) => updateField("content", v)}

--- a/frontend/src/components/features/discover/featured-story-card.tsx
+++ b/frontend/src/components/features/discover/featured-story-card.tsx
@@ -67,7 +67,7 @@ export function FeaturedStoryCard({ story, onClick, className }: FeaturedStoryCa
         className
       )}
     >
-      {/* 封面图 - 16:9 比例 */}
+      {/* 封面图 - 16:9 比例（spec §6.4：无封面/加载失败用 bg-secondary + 标题首字符占位） */}
       <div className="relative aspect-video overflow-hidden bg-muted">
         {story.coverImage ? (
           <img
@@ -81,18 +81,18 @@ export function FeaturedStoryCard({ story, onClick, className }: FeaturedStoryCa
               const parent = target.parentElement;
               if (parent) {
                 const fallback = document.createElement('div');
-                fallback.className = 'w-full h-full flex items-center justify-center bg-gradient-to-br from-muted/30 to-muted';
+                fallback.className = 'w-full h-full flex items-center justify-center bg-secondary';
                 const span = document.createElement('span');
-                span.className = 'text-4xl';
-                span.textContent = '🏔️';
+                span.className = 'text-2xl font-bold text-muted-foreground';
+                span.textContent = story.title.trim().charAt(0);
                 fallback.appendChild(span);
                 parent.appendChild(fallback);
               }
             }}
           />
         ) : (
-          <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-amber-50/50 to-stone-100">
-            <span className="text-4xl">🏔️</span>
+          <div className="w-full h-full flex items-center justify-center bg-secondary">
+            <span className="text-2xl font-bold text-muted-foreground">{story.title.trim().charAt(0)}</span>
           </div>
         )}
 

--- a/frontend/src/components/features/discover/story-card.tsx
+++ b/frontend/src/components/features/discover/story-card.tsx
@@ -80,7 +80,7 @@ export function StoryCard({ story, onClick, className }: StoryCardProps) {
         className
       )}
     >
-      {/* 封面图 */}
+      {/* 封面图（spec §6.4：无封面/加载失败用 bg-secondary + 标题首字符占位） */}
       <div className="relative aspect-[4/3] overflow-hidden bg-muted">
         {story.coverImage ? (
           <img
@@ -94,18 +94,18 @@ export function StoryCard({ story, onClick, className }: StoryCardProps) {
               const parent = target.parentElement;
               if (parent) {
                 const fallback = document.createElement('div');
-                fallback.className = 'w-full h-full flex items-center justify-center bg-gradient-to-br from-amber-50 to-stone-100';
+                fallback.className = 'w-full h-full flex items-center justify-center bg-secondary';
                 const span = document.createElement('span');
-                span.className = 'text-3xl';
-                span.textContent = '🏔️';
+                span.className = 'text-2xl font-bold text-muted-foreground';
+                span.textContent = story.title.trim().charAt(0);
                 fallback.appendChild(span);
                 parent.appendChild(fallback);
               }
             }}
           />
         ) : (
-          <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-amber-50 to-stone-100">
-            <span className="text-3xl">🏔️</span>
+          <div className="w-full h-full flex items-center justify-center bg-secondary">
+            <span className="text-2xl font-bold text-muted-foreground">{story.title.trim().charAt(0)}</span>
           </div>
         )}
         {/* 地点标签 */}

--- a/frontend/src/components/ui/form-input.tsx
+++ b/frontend/src/components/ui/form-input.tsx
@@ -20,6 +20,8 @@ interface FormFieldProps {
   error?: string;
   hint?: string;
   required?: boolean;
+  /** spec §6.1：只标可选不标必填，label 右侧跟（选填） */
+  optional?: boolean;
   children: React.ReactNode;
   className?: string;
 }
@@ -30,9 +32,11 @@ export function FormField({
   error,
   hint,
   required,
+  optional,
   children,
   className,
 }: FormFieldProps) {
+  const { t } = useI18n(["common"]);
   return (
     <div className={cn("flex flex-col gap-1.5", className)}>
       {label && (
@@ -43,6 +47,9 @@ export function FormField({
           {label}
           {required && (
             <span className="ml-1 text-destructive" aria-hidden="true">*</span>
+          )}
+          {optional && (
+            <span className="ml-1 text-xs font-normal text-muted-foreground">{t("common.optional")}</span>
           )}
         </label>
       )}


### PR DESCRIPTION
## ⚠️ API 契约变更披露（spec §6.5）

`createStorySchema.coverImage`：必填 `z.string().url()` → **`.optional()`**（api/src/lib/validation.ts:60）
- **后向兼容**：必填→可选，旧请求（带封面）仍合法，新请求（不带封面）从 400 变 200
- `tags` 本就 optional；DB `cover_image` 列 nullable，**无 schema 迁移**
- `updateStorySchema` 经 `.partial()` 继承，行为不变
- 集成测试 +2（stories.test.ts）：无 coverImage/tags 创建 → 200 且落库 `coverImage=NULL`；非法 coverImage（非 URL）仍 400。26/26 PASS

## 改动范围（spec §6，逐项对齐）

**§6.1 可选标记**
- `FormField` 新增 `optional` prop：label 右侧 `（选填）`/`(Optional)`（`common.optional` 双 locale），`text-xs text-muted-foreground font-normal` + `ml-1`（4px）
- 规则「只标可选，不标必填」：封面/标签加 `optional`；标题/摘要/正文/地点**去掉红 \***（校验不变，地点保持必填）

**§6.2 封面空态**
- 虚线占位框：`border-2 border-dashed border-border` + `rounded-lg` + `bg-secondary/50`，`h-[120px] sm:h-40`
- 双行文案：主行「上传封面（选填）」`text-sm font-medium` / 副行「不上传将使用默认样式展示」`text-xs muted`（新 key `coverEmptyTitle`/`coverEmptyHint`）；上传中显示 spinner
- 上传后：预览 + 删除按钮（补 `aria-label`）；原「上传条」并入空态框

**§6.3 发布按钮状态**
- `disabled` = 标题空 / 摘要空 / 正文空 / 提交中 / 上传中；封面、标签不再参与
- 标题/摘要/正文 `onBlur` 即时校验（Vditor 容器 focusout 捕获正文 blur），`text-xs text-destructive` 显示在字段下方，`updateField` 时即清除
- `validate()` 移除封面检查、`handleSubmit` 移除标签必填拦截

**§6.4 下游展示**
- 列表卡片（story-card + featured-story-card）：无封面及图片加载失败 fallback 统一为 `bg-secondary` + 标题首字符（`text-2xl font-bold text-muted-foreground`），替换原 amber 渐变 + 🏔️（顺带清除 DS 外色阶）
- 详情页：封面本就 `{story.coverImage && ...}` 条件渲染、无标签行，无需改动
- OG：沿用现有 fallback，未新增逻辑

## 本地验证

- `pnpm type-check` 0 errors / `eslint` 0 problems / `pnpm build` ✅
- API `vitest run stories.test.ts` 26/26 PASS（含 2 条新契约用例）
- 登录态实测缺本机账号 → 下列场景需 @Wen 验证

## @Wen 需验证场景（wen-qa，发布页 /discover/create）

1. **可选标记**：封面/标签 label 右侧「（选填）」muted 小字；标题/摘要/正文/地点无红 * 无任何标记；en 下显示 (Optional)
2. **封面空态**：虚线框 120px（移动）/160px（桌面），双行文案；上传后预览 + 删除（aria-label）；删除后回到空态
3. **disabled 逻辑**：初始发布按钮 disabled；填标题+摘要+正文后 enabled（封面/标签空也 enabled）；空标题 onBlur 显示错误文案、输入后消失
4. **空封面/空标签发布**：不选地点以外的可选项直接发布 → 成功跳详情页；详情页无封面区块（标题直接接正文）
5. **列表卡片**：新发布的无封面故事在发现页卡片显示 bg-secondary + 标题首字符；有封面故事不受影响
6. **契约复测**（API）：不带 coverImage/tags POST /stories → 200/201；`coverImage: "not-a-url"` → 400
7. **双 locale + console**：0 error，无 hydration 复发

## 已知风险与回滚

- 风险低：契约放宽后向兼容；前端纯视觉/校验交互
- 回滚：revert 单 commit `5813e48`（API 契约随 revert 恢复必填，无数据残留问题——已写入的 NULL 封面故事下游均能展示）