### PR TITLE
fix(api): PUT /stories/:id tags 更新改 D1 batch，修线上编辑保存 500 (task #147/#148)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,7 @@ pnpm --filter @gomate/frontend build
 ## API 规则
 
 - 遵循 `api/src/` 下现有路由、lib、schema 组织方式。
+- **D1 环境禁止 `db.transaction()`**：D1 拒绝 SQL `BEGIN`/`COMMIT`（code 7500），多步原子写入一律用 `db.batch([...])`（D1 唯一原子原语）。集成测试的 better-sqlite3 mock 不会暴露此问题，CR 时必须人工核对。（task #147 教训）
 - API 请求、响应、认证或数据库行为变化时，同步更新 `docs/backend-api.md`。
 - API 变更的最低检查通常是：
 

--- a/api/src/__tests__/helpers/db.ts
+++ b/api/src/__tests__/helpers/db.ts
@@ -266,6 +266,14 @@ export function createTestDb() {
   `);
 
   const db = drizzle(sqlite, { schema });
+
+  // D1 batch shim：路由在 prod 用 db.batch（D1 唯一原子写入原语，BEGIN 在 D1 被拒）。
+  // better-sqlite3 驱动没有 batch API，这里用事务包一层保持语义一致，
+  // 否则测试环境会因 db.batch is not a function 误炸。
+  (db as unknown as Record<string, unknown>).batch = async (
+    items: Array<{ run: () => unknown }>,
+  ) => db.transaction(() => items.map((item) => item.run()));
+
   return { db, sqlite };
 }
 

--- a/api/src/__tests__/integration/stories.test.ts
+++ b/api/src/__tests__/integration/stories.test.ts
@@ -343,6 +343,88 @@ describe("Stories API 集成测试", () => {
     });
   });
 
+  describe("PUT /stories/:id - 更新故事", () => {
+    it("带 tags 更新成功并替换标签关联（task #147 回归用例）", async () => {
+      currentSession = { user: { id: user.id, email: user.email, name: user.name } };
+      const story = await seedStory(testDb, user.id, { title: "原标题" });
+      const oldTag = await seedTag(testDb, { name: "旧标签", type: "activity" });
+      await seedEntityTag(testDb, story.id, "story", oldTag.id);
+
+      const res = await req(app, `/stories/${story.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "新标题", tags: ["新标签", "旧标签"] }),
+      });
+
+      expect(res.status).toBe(200);
+
+      const updated = await testDb.query.stories.findFirst({
+        where: eq(schema.stories.id, story.id),
+      });
+      expect(updated?.title).toBe("新标题");
+
+      // 旧关联被替换：新标签 + 旧标签各一条，无残留重复
+      const links = await testDb.query.entityToTags.findMany({
+        where: and(
+          eq(schema.entityToTags.entityId, story.id),
+          eq(schema.entityToTags.entityType, "story")
+        ),
+      });
+      expect(links).toHaveLength(2);
+
+      const newTag = await testDb.query.tags.findFirst({
+        where: eq(schema.tags.name, "新标签"),
+      });
+      expect(newTag).toBeDefined();
+    });
+
+    it("tags 传空数组清除全部标签关联（task #147 回归用例）", async () => {
+      currentSession = { user: { id: user.id, email: user.email, name: user.name } };
+      const story = await seedStory(testDb, user.id, { title: "带标签故事" });
+      const tag = await seedTag(testDb, { name: "待清除", type: "activity" });
+      await seedEntityTag(testDb, story.id, "story", tag.id);
+
+      const res = await req(app, `/stories/${story.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "带标签故事", tags: [] }),
+      });
+
+      expect(res.status).toBe(200);
+
+      const links = await testDb.query.entityToTags.findMany({
+        where: and(
+          eq(schema.entityToTags.entityId, story.id),
+          eq(schema.entityToTags.entityType, "story")
+        ),
+      });
+      expect(links).toHaveLength(0);
+    });
+
+    it("不传 tags 字段只更新正文，标签关联保持不变", async () => {
+      currentSession = { user: { id: user.id, email: user.email, name: user.name } };
+      const story = await seedStory(testDb, user.id, { title: "保留标签故事" });
+      const tag = await seedTag(testDb, { name: "保留", type: "activity" });
+      await seedEntityTag(testDb, story.id, "story", tag.id);
+
+      const res = await req(app, `/stories/${story.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "保留标签故事（改）" }),
+      });
+
+      expect(res.status).toBe(200);
+
+      const links = await testDb.query.entityToTags.findMany({
+        where: and(
+          eq(schema.entityToTags.entityId, story.id),
+          eq(schema.entityToTags.entityType, "story")
+        ),
+      });
+      expect(links).toHaveLength(1);
+    });
+  });
+
   describe("POST /stories/:id/like - 点赞 toggle", () => {
     it("未登录点赞 → 401", async () => {
       const story = await seedStory(testDb, user.id, { title: "测试故事", status: "published" });

--- a/api/src/routes/stories.ts
+++ b/api/src/routes/stories.ts
@@ -501,51 +501,50 @@ stories.put("/:id", async (c) => {
     if (data.locationId !== undefined) updateData.locationId = data.locationId;
     if (data.status !== undefined) updateData.status = data.status;
 
-    await db.update(schema.stories).set(updateData).where(eq(schema.stories.id, id));
-
-    // 如果传了 tags，在事务内更新标签关联
+    // 如果传了 tags，故事更新 + 标签关联放进同一个 D1 batch 保证原子性。
+    // 注意：D1 不支持 SQL BEGIN/COMMIT（drizzle db.transaction 在 D1 上会发 BEGIN 被
+    // 拒绝，code 7500），batch 是 D1 唯一的原子写入原语。
     if (data.tags !== undefined) {
-      const newTags = data.tags;
-      await db.transaction(async (tx) => {
+      const newTags = normalizeStoryTags(data.tags);
+
+      // find-or-create：先查已存在的 tag，再补插缺失的（与 POST 创建路径同一模式）
+      const existingTags = newTags.length > 0
+        ? await db.select().from(schema.tags).where(inArray(schema.tags.name, newTags))
+        : [];
+      const existingNames = new Set(existingTags.map((tag) => tag.name));
+      const missingTags = newTags
+        .filter((name) => !existingNames.has(name))
+        .map((name) => ({ id: generateId(), name, type: "activity", createdAt: new Date() }));
+      if (missingTags.length > 0) {
+        await db.insert(schema.tags).values(missingTags);
+      }
+      const tagIdByName = new Map(
+        [...existingTags, ...missingTags].map((tag) => [tag.name, tag.id] as const)
+      );
+
+      await db.batch([
+        db.update(schema.stories).set(updateData).where(eq(schema.stories.id, id)),
         // 先删除旧关联
-        await tx
+        db
           .delete(schema.entityToTags)
           .where(
             and(
               eq(schema.entityToTags.entityId, id),
               eq(schema.entityToTags.entityType, "story")
             )
-          );
-
-        // 插入新关联（空数组则清除所有）
-        if (newTags.length > 0) {
-          const tagEntries: (typeof schema.entityToTags.$inferInsert)[] = [];
-          for (const tagName of newTags) {
-            let tag = await tx.query.tags.findFirst({
-              where: eq(schema.tags.name, tagName),
-            });
-            if (!tag) {
-              const tagId = generateId();
-              await tx.insert(schema.tags).values({
-                id: tagId,
-                name: tagName,
-                type: "activity",
-                createdAt: new Date(),
-              });
-              tag = { id: tagId, name: tagName, type: "activity", createdAt: new Date() };
-            }
-            tagEntries.push({
-              id: generateId(),
-              entityId: id,
-              entityType: "story",
-              tagId: tag.id,
-            });
-          }
-          if (tagEntries.length > 0) {
-            await tx.insert(schema.entityToTags).values(tagEntries);
-          }
-        }
-      });
+          ),
+        // 插入新关联（空数组则只清除）
+        ...newTags.map((name) =>
+          db.insert(schema.entityToTags).values({
+            id: generateId(),
+            entityId: id,
+            entityType: "story",
+            tagId: tagIdByName.get(name)!,
+          })
+        ),
+      ]);
+    } else {
+      await db.update(schema.stories).set(updateData).where(eq(schema.stories.id, id));
     }
 
     return c.json({


### PR DESCRIPTION
## 🔴 P1 热修：线上故事编辑保存 100% 失败

**现象**：PUT /stories/:id body 只要带 `tags` 字段（空数组也炸）→ 500 INTERNAL_ERROR「更新失败」；编辑页保存总是带 tags → 全量失败。

**根因**（prod 实测证据链）：
1. PUT tags 分支调用 `db.transaction()` → drizzle D1 driver（0.36.4）的 transaction 实现发原生 `BEGIN`
2. **D1 拒绝 SQL BEGIN**（wrangler d1 execute 对 prod 实测 code 7500；D1 唯一原子原语是 `batch`）
3. 三条控制变量全部解释：PUT 不带 tags 正常（跳过分支）、POST 带 tags 正常（不用 transaction）、`tags:[]` 也炸（进分支即 BEGIN）
4. 测试盲区双因素：集成测试 mock createDb 到 better-sqlite3（BEGIN 合法）+ 无 PUT-with-tags 用例
5. 该雷 07-13 随 #337（8408ecd）引入 stories.ts，API 自 07-16（#363）后未部署，今日随 #372 部署激活——**非 #372 validation.ts 代码变更引入**（tags 链路不读 coverImage），不建议 revert（revert 治本无效）

## 改动范围

- `api/src/routes/stories.ts` PUT：tags 更新重写为 find-or-create（与 POST 路径同模式）+ 单个 `db.batch([story update, delete 旧关联, insert 新关联])`；tags 走 `normalizeStoryTags`（trim/去重/上限 10，与 POST 对齐）
- **#148 顺带修复**：原实现 story UPDATE 先于 transaction 提交，500 时字段已落库（Wen 实测 content/status 部分写入）；batch 化后 story + tags 写入同生共死
- `api/src/__tests__/integration/stories.test.ts` +3 用例：PUT 带 tags 替换关联 / `tags:[]` 清空 / 不传 tags 关联不变
- `api/src/__tests__/helpers/db.ts`：batch shim（better-sqlite3 无 batch API，事务包一层保持语义一致）
- `AGENTS.md`：API 规则加铁律「D1 禁止 db.transaction()，原子写入一律 db.batch()」（Martin 建议）

**API schema**：无变更（请求/响应契约不变，仅内部写入方式）。

## 本地验证

- `vitest run` 全量 **193/193 PASS**（含 3 条新 PUT 用例）
- `tsc --noEmit` 0 error
- Martin 全仓扫描确认 `db.transaction(` 仅此一处，无其他 latent 雷

## @Wen 需验证场景

1. **功能复测**（合并部署后）：编辑页保存（带 tags 修改）→ 200，title/tags 均持久化；控制变量四条重跑全 200
2. **原子性核对**：body 含 tags 时若再遇 500 → 全字段不得变更（story 与 tags 同生共死）；公开列表/详情页数据一致性
3. **契约无回归**：PUT 响应 shape 不变；不带 tags 的 PUT 行为不变

## 回滚

revert 单 commit `89501cc` 即恢复旧代码路径（注意：旧路径在当前 prod D1 上必炸，回滚仅适用于本修复引入新问题的场景）。