### PR TITLE
feat(frontend): 编辑页保存失败内联 banner + 错误边界 + 校验对齐发布页 (task #149)

### DIFF
--- a/frontend/public/locales/en/content.json
+++ b/frontend/public/locales/en/content.json
@@ -363,7 +363,16 @@
       "continueEditing": "Keep editing",
       "discardConfirm": "Discard",
       "expandMore": "Show more (status/cover/location/tags)",
-      "collapseMore": "Show less"
+      "collapseMore": "Show less",
+      "saveSuccess": "Saved",
+      "saveFailed": "Save failed",
+      "saveNetworkError": "Save failed: network error",
+      "saveRetry": "Retry",
+      "coverTooLarge": "Image must be under 2MB",
+      "coverTypeError": "Only JPG or PNG images are supported",
+      "errorBoundaryTitle": "Something went wrong",
+      "errorBoundaryDesc": "Your changes may have been auto-saved as a local draft. Reload the page to restore them.",
+      "errorBoundaryReload": "Reload"
     }
   },
   "title": "GoMate - Discover Places, Team Up Together",

--- a/frontend/public/locales/zh-CN/content.json
+++ b/frontend/public/locales/zh-CN/content.json
@@ -363,7 +363,16 @@
       "continueEditing": "继续编辑",
       "discardConfirm": "放弃",
       "expandMore": "展开更多（状态/封面/地点/标签）",
-      "collapseMore": "收起"
+      "collapseMore": "收起",
+      "saveSuccess": "保存成功",
+      "saveFailed": "保存失败",
+      "saveNetworkError": "保存失败：网络错误",
+      "saveRetry": "重试",
+      "coverTooLarge": "图片不能超过 2MB",
+      "coverTypeError": "仅支持 JPG 或 PNG 格式",
+      "errorBoundaryTitle": "页面出现异常",
+      "errorBoundaryDesc": "你的修改可能已自动保存为本地草稿，重新加载后可恢复",
+      "errorBoundaryReload": "重新加载"
     }
   },
   "title": "GoMate - 发现趣处，组队同行",

--- a/frontend/src/components/features/discover/story-edit-client.tsx
+++ b/frontend/src/components/features/discover/story-edit-client.tsx
@@ -9,6 +9,7 @@ import { FormField, Input, Select, Textarea } from "@/components/ui/form-input";
 import { useModalA11y } from "@/hooks/useModalA11y";
 import { VditorEditor } from "./vditor-editor";
 import { StoryToast } from "./story-detail-toast";
+import { StoryEditErrorBoundary } from "./story-edit-error-boundary";
 import { useStoryForm } from "./use-story-form";
 import type { FormFields } from "./use-story-form";
 
@@ -24,10 +25,24 @@ function areFormsEqual(a: FormFields, b: FormFields): boolean {
 }
 
 export function StoryEditClient({ storyId }: StoryEditClientProps) {
+  const { t } = useI18n(["content"]);
+  // task #149 ②：island 渲染异常兜底，不再白屏
+  return (
+    <StoryEditErrorBoundary
+      title={t("content.discover.edit.errorBoundaryTitle")}
+      description={t("content.discover.edit.errorBoundaryDesc")}
+      reloadLabel={t("content.discover.edit.errorBoundaryReload")}
+    >
+      <StoryEditClientInner storyId={storyId} />
+    </StoryEditErrorBoundary>
+  );
+}
+
+function StoryEditClientInner({ storyId }: StoryEditClientProps) {
   const { t } = useI18n(["content", "common", "ui"]);
   const { toast, show: showToast, isExiting } = useToast();
   const {
-    form, initialForm, isLoading, isSaving, saveMessage, error,
+    form, initialForm, isLoading, isSaving, saveResult, uploadMessage, error,
     allTags, locationSearch, locationResults, isSearchingLocation, isUploadingCover, draftAvailable,
     updateField, handleCoverUpload, handleLocationSearch, handleSave,
     handleDiscardDraft, handleRestoreDraft,
@@ -41,6 +56,28 @@ export function StoryEditClient({ storyId }: StoryEditClientProps) {
   const closeCancelConfirm = React.useCallback(() => setShowCancelConfirm(false), []);
   // spec §4.1：role=alertdialog + 焦点 trap + Esc + 焦点还原
   useModalA11y(showCancelConfirm, cancelPanelRef, closeCancelConfirm);
+
+  // task #149 ③：字段级校验（与发布页 spec §6.2 同一套规则：标题/摘要/正文必填，onBlur 即时校验）
+  const [fieldErrors, setFieldErrors] = React.useState<{ title?: string; summary?: string; content?: string }>({});
+  // task #149 ①：保存失败 banner 的本地关闭态（新一次失败时重新弹出）
+  const [saveErrorDismissed, setSaveErrorDismissed] = React.useState(false);
+
+  const validateRequiredOnBlur = (field: "title" | "summary" | "content") => {
+    const errorKey = {
+      title: "content.discover.create.titleRequired",
+      summary: "content.discover.create.summaryRequired",
+      content: "content.discover.create.contentRequired",
+    }[field];
+    setFieldErrors((prev) => ({ ...prev, [field]: form[field].trim() ? undefined : t(errorKey) }));
+  };
+
+  const changeField = (key: "title" | "summary" | "content", value: string) => {
+    updateField(key, value);
+    setFieldErrors((prev) => (prev[key] ? { ...prev, [key]: undefined } : prev));
+  };
+
+  // spec §6.3 对齐发布页：必填项（标题/摘要/正文）为空时保存按钮 disabled
+  const isRequiredEmpty = !form.title.trim() || !form.summary.trim() || !form.content.trim();
 
   // Dirty detection
   const isDirty = React.useMemo(() => {
@@ -56,15 +93,21 @@ export function StoryEditClient({ storyId }: StoryEditClientProps) {
     return () => window.removeEventListener("beforeunload", handler);
   }, [isDirty]);
 
-  // Sync saveMessage to toast
+  // 保存成功 → toast；失败 → 内联 banner（持续可见 + 重试，不用易消失的 toast）
   React.useEffect(() => {
-    if (saveMessage) {
-      showToast({
-        type: saveMessage.includes("成功") ? "success" : "error",
-        message: saveMessage,
-      });
+    if (saveResult?.type === "success") {
+      showToast({ type: "success", message: saveResult.message });
+    } else if (saveResult?.type === "error") {
+      setSaveErrorDismissed(false);
     }
-  }, [saveMessage, showToast]);
+  }, [saveResult, showToast]);
+
+  // 封面上传提示 → toast
+  React.useEffect(() => {
+    if (uploadMessage) {
+      showToast({ type: "error", message: uploadMessage });
+    }
+  }, [uploadMessage, showToast]);
 
   const handleBack = () => {
     if (isDirty) {
@@ -90,7 +133,7 @@ export function StoryEditClient({ storyId }: StoryEditClientProps) {
   if (error) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-background">
-        <p className="text-muted-foreground">{error}</p>
+        <p className="text-muted-foreground">{t(error)}</p>
       </div>
     );
   }
@@ -107,7 +150,7 @@ export function StoryEditClient({ storyId }: StoryEditClientProps) {
             {t("common.back")}
           </button>
           <div className="flex flex-1 items-center justify-end gap-3 sm:flex-none">
-            <button onClick={handleSave} disabled={isSaving}
+            <button onClick={handleSave} disabled={isSaving || isRequiredEmpty}
               className="btn-primary flex-1 justify-center gap-1.5 px-4 py-2 text-sm disabled:opacity-50 sm:flex-none">
               {isSaving && <Loader2 className="h-4 w-4 animate-spin" />}
               {isDirty && !isSaving && (
@@ -134,23 +177,36 @@ export function StoryEditClient({ storyId }: StoryEditClientProps) {
           </div>
         )}
 
+        {/* task #149 ①：保存失败内联 banner（DS v2.0 bg-accent 草稿条同款）+ 重试；内容保留在表单中不丢失 */}
+        {saveResult?.type === "error" && !saveErrorDismissed && !isSaving && (
+          <div className="mb-6 flex items-center justify-between gap-3 rounded-md border border-border bg-accent px-4 py-3">
+            <p className="text-sm text-accent-foreground">{saveResult.message}</p>
+            <div className="flex gap-2">
+              <button onClick={handleSave} className="btn-primary px-3 py-1 text-xs">{t("content.discover.edit.saveRetry")}</button>
+              <button onClick={() => setSaveErrorDismissed(true)} className="btn-ghost px-3 py-1 text-xs">{t("common.close")}</button>
+            </div>
+          </div>
+        )}
+
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
           {/* Left: Form fields */}
           <div className="lg:col-span-4 space-y-6">
-            <FormField label={t("content.discover.create.titleLabel")} htmlFor="story-edit-title">
+            <FormField label={t("content.discover.create.titleLabel")} htmlFor="story-edit-title" error={fieldErrors.title}>
               <Input
                 id="story-edit-title"
                 type="text"
                 value={form.title}
-                onChange={(e) => updateField("title", e.target.value)}
+                onChange={(e) => changeField("title", e.target.value)}
+                onBlur={() => validateRequiredOnBlur("title")}
                 placeholder={t("content.discover.edit.titlePlaceholder")}
               />
             </FormField>
-            <FormField label={t("content.discover.create.summaryLabel")} htmlFor="story-edit-summary" hint={`${form.summary.length}/150`}>
+            <FormField label={t("content.discover.create.summaryLabel")} htmlFor="story-edit-summary" hint={`${form.summary.length}/150`} error={fieldErrors.summary}>
               <Textarea
                 id="story-edit-summary"
                 value={form.summary}
-                onChange={(e) => updateField("summary", e.target.value)}
+                onChange={(e) => changeField("summary", e.target.value)}
+                onBlur={() => validateRequiredOnBlur("summary")}
                 maxLength={150}
                 rows={3}
                 placeholder={t("content.discover.edit.summaryPlaceholder")}
@@ -277,13 +333,20 @@ export function StoryEditClient({ storyId }: StoryEditClientProps) {
 
           {/* Right: VditorEditor (SV 分屏自带预览) */}
           <div className="lg:col-span-8">
-            <div className="sticky top-20 rounded-lg border border-border bg-card shadow-card overflow-hidden" style={{ height: "calc(100vh - 7rem)" }}>
+            <div
+              className="sticky top-20 rounded-lg border border-border bg-card shadow-card overflow-hidden"
+              style={{ height: "calc(100vh - 7rem)" }}
+              onBlur={() => validateRequiredOnBlur("content")}
+            >
               <VditorEditor
                 value={form.content}
-                onChange={(v) => updateField("content", v)}
+                onChange={(v) => changeField("content", v)}
                 placeholder={t("content.discover.edit.contentPlaceholder")}
               />
             </div>
+            {fieldErrors.content && (
+              <p className="mt-2 text-xs text-destructive">{fieldErrors.content}</p>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/components/features/discover/story-edit-error-boundary.tsx
+++ b/frontend/src/components/features/discover/story-edit-error-boundary.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import * as React from "react";
+
+interface StoryEditErrorBoundaryProps {
+  /** i18n 文案由调用方（函数组件可 useI18n）注入 */
+  title: string;
+  description: string;
+  reloadLabel: string;
+  children: React.ReactNode;
+}
+
+interface StoryEditErrorBoundaryState {
+  hasError: boolean;
+}
+
+/**
+ * task #149 ②：编辑页 island 崩溃兜底。
+ * 任何渲染期异常（如 #147 期间 saveMessage.includes 的 TypeError）不再白屏，
+ * 展示恢复 UI 引导重载——草稿自动保存（30s 间隔）通常能挽回未保存修改。
+ */
+export class StoryEditErrorBoundary extends React.Component<
+  StoryEditErrorBoundaryProps,
+  StoryEditErrorBoundaryState
+> {
+  state: StoryEditErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): StoryEditErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    console.error("StoryEditClient crashed:", error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen bg-background flex items-center justify-center px-4">
+          <div className="w-full max-w-sm rounded-2xl border border-border bg-card p-6 text-center space-y-4">
+            <h2 className="font-semibold text-foreground">{this.props.title}</h2>
+            <p className="text-sm text-muted-foreground">{this.props.description}</p>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="btn-primary px-4 py-2 text-sm"
+            >
+              {this.props.reloadLabel}
+            </button>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/features/discover/use-story-form.ts
+++ b/frontend/src/components/features/discover/use-story-form.ts
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { fetchAPI, fetchCurrentUser } from "@/lib/api";
+import { useI18n } from "@/hooks/useI18n";
 import type { SessionUser } from "@/lib/types";
 
 export interface FormFields {
@@ -40,13 +41,22 @@ interface StoryEditData {
   author: { id: string } | null;
 }
 
+/** task #149：保存结果结构化，替代旧的字符串 saveMessage（旧实现把 API error 对象塞进字符串，下游 .includes 直接 TypeError 白屏） */
+export interface SaveResult {
+  type: "success" | "error";
+  message: string;
+}
+
 export interface UseStoryFormReturn {
   form: FormFields;
   initialForm: React.MutableRefObject<FormFields | null>;
   currentUser: SessionUser | null;
   isLoading: boolean;
   isSaving: boolean;
-  saveMessage: string | null;
+  /** 仅由 handleSave 产生；成功 → toast，失败 → 内联 banner + 重试 */
+  saveResult: SaveResult | null;
+  /** 封面上传相关提示（走 toast） */
+  uploadMessage: string | null;
   error: string | null;
   canEdit: boolean;
   allTags: TagOption[];
@@ -87,10 +97,12 @@ function clearDraft(storyId: string): void {
 }
 
 export function useStoryForm(storyId: string): UseStoryFormReturn {
+  const { t } = useI18n(["content"]);
   const [currentUser, setCurrentUser] = React.useState<SessionUser | null>(null);
   const [isLoading, setIsLoading] = React.useState(true);
   const [isSaving, setIsSaving] = React.useState(false);
-  const [saveMessage, setSaveMessage] = React.useState<string | null>(null);
+  const [saveResult, setSaveResult] = React.useState<SaveResult | null>(null);
+  const [uploadMessage, setUploadMessage] = React.useState<string | null>(null);
   const [error, setError] = React.useState<string | null>(null);
 
   const [form, setForm] = React.useState<FormFields>({
@@ -134,7 +146,8 @@ export function useStoryForm(storyId: string): UseStoryFormReturn {
         setAllTags(tagsRes.tags ?? []);
 
         if (!storyRes.success || !storyRes.data) {
-          setError("故事不存在");
+          // 存 i18n key，渲染层 t()（避免 load effect 依赖 t 重复拉取）
+          setError("content.discover.storyNotFound");
           return;
         }
 
@@ -173,7 +186,7 @@ export function useStoryForm(storyId: string): UseStoryFormReturn {
         initialForm.current = { ...f };
       } catch (err) {
         if (!cancelled) {
-          setError("加载故事失败");
+          setError("content.discover.loadStoryError");
           console.error("Load story error:", err);
         }
       } finally {
@@ -220,12 +233,13 @@ export function useStoryForm(storyId: string): UseStoryFormReturn {
   }, []);
 
   const handleCoverUpload = React.useCallback(async (file: File) => {
+    setUploadMessage(null);
     if (file.size > 2 * 1024 * 1024) {
-      setSaveMessage("图片不能超过 2MB");
+      setUploadMessage(t("content.discover.edit.coverTooLarge"));
       return;
     }
     if (!["image/jpeg", "image/png"].includes(file.type)) {
-      setSaveMessage("仅支持 JPG 或 PNG 格式");
+      setUploadMessage(t("content.discover.edit.coverTypeError"));
       return;
     }
     try {
@@ -237,19 +251,19 @@ export function useStoryForm(storyId: string): UseStoryFormReturn {
       if (data.success && data.url) {
         setForm((prev) => ({ ...prev, coverImage: data.url }));
       } else {
-        setSaveMessage("上传失败");
+        setUploadMessage(t("content.discover.create.uploadFailed"));
       }
     } catch {
-      setSaveMessage("上传失败");
+      setUploadMessage(t("content.discover.create.uploadFailed"));
     } finally {
       setIsUploadingCover(false);
     }
-  }, []);
+  }, [t]);
 
   const handleSave = React.useCallback(async () => {
     try {
       setIsSaving(true);
-      setSaveMessage(null);
+      setSaveResult(null);
 
       const res = await fetchAPI(`/stories/${storyId}`, {
         method: "PUT",
@@ -266,18 +280,26 @@ export function useStoryForm(storyId: string): UseStoryFormReturn {
       });
       const data = await res.json();
       if (data.success) {
-        setSaveMessage("保存成功");
+        setSaveResult({ type: "success", message: t("content.discover.edit.saveSuccess") });
         clearDraft(storyId);
         initialForm.current = { ...form };
       } else {
-        setSaveMessage(data.error || "保存失败");
+        // API 错误契约 {success:false, error:{code,message}}；容错 string 形 error
+        const apiMessage =
+          typeof data.error === "string"
+            ? data.error
+            : data.error?.message;
+        setSaveResult({
+          type: "error",
+          message: apiMessage || t("content.discover.edit.saveFailed"),
+        });
       }
     } catch {
-      setSaveMessage("保存失败: 网络错误");
+      setSaveResult({ type: "error", message: t("content.discover.edit.saveNetworkError") });
     } finally {
       setIsSaving(false);
     }
-  }, [storyId, form]);
+  }, [storyId, form, t]);
 
   const handleDiscardDraft = React.useCallback(() => {
     clearDraft(storyId);
@@ -294,7 +316,7 @@ export function useStoryForm(storyId: string): UseStoryFormReturn {
   }, [storyId]);
 
   return {
-    form, initialForm, currentUser, isLoading, isSaving, saveMessage, error, canEdit,
+    form, initialForm, currentUser, isLoading, isSaving, saveResult, uploadMessage, error, canEdit,
     allTags, locationSearch, locationResults, isSearchingLocation, isUploadingCover, draftAvailable,
     updateField, handleCoverUpload, handleLocationSearch, handleSave, handleDiscardDraft, handleRestoreDraft,
   };


### PR DESCRIPTION
## 背景

task #149（P2）。#147 期间 @Wen 实测：PUT 保存 500 后**编辑页 island 崩溃白屏**（`TypeError: p.includes is not a function`），整页卸载只剩导航栏，用户无任何错误提示。

**白屏根因**：`useStoryForm.handleSave` 失败分支 `setSaveMessage(data.error || "保存失败")` —— API 错误契约是 `{success:false, error:{code,message}}`（**对象**），被塞进 string state；下游 toast effect `saveMessage.includes("成功")` 对对象调 `.includes` → TypeError → React 卸载 island。

范围按 @Martin/@Steven 定稿三点：① 保存失败不卸载 + 内容保留 + 内联 banner 重试（主修复）② 错误边界兜底 ③ 编辑页校验交互与发布页对齐（spec §6 同一套规则）。

## 改动

| 文件 | 改动 |
|------|------|
| `use-story-form.ts` | `saveMessage: string` → **结构化 `saveResult: {type, message}`**（按 API 契约取 `error.message`，根除 TypeError）；上传提示拆为 `uploadMessage`；hook 内硬编码中文全部走 i18n |
| `story-edit-client.tsx` | 保存失败 → **内联 banner**（DS v2.0 bg-accent 草稿条同款，持续可见）+ **重试按钮** + 关闭；成功仍走 toast。新增 onBlur 即时校验（标题/摘要/正文，FormField error 槽位）+ 必填为空时保存按钮 disabled |
| `story-edit-error-boundary.tsx`（新增） | 渲染异常兜底：恢复 UI（说明草稿可能已自动保存）+ 重新加载按钮，替代白屏 |
| `locales zh-CN/en content.json` | 新增 `discover.edit.*` 9 键（saveSuccess/saveFailed/saveNetworkError/saveRetry/coverTooLarge/coverTypeError/errorBoundary×3）；校验文案复用 `create.*Required` |

## 设计决策记录

- **错误反馈分流**：保存失败走内联 banner（Steven：持续可见 + 重试），上传/成功提示走 toast（瞬时）
- **重试语义**：banner 重试直接重发 PUT；表单 state 失败时不动，内容天然保留
- **校验字段**：标题/摘要/正文三项必填（PUT schema 对三者均 min(1)，留空保存必 400）——与发布页 spec §6.3 完全同规则
- **加载错误改存 i18n key**（`content.discover.storyNotFound` 等既有键），渲染层 t()，避免 load effect 依赖 t 重复拉取

## 本地验证

- `pnpm i18n:build` + `i18n:validate` ✅ 0 errors
- `pnpm --filter @gomate/frontend type-check` ✅ 0 errors
- `pnpm --filter @gomate/frontend build` ✅

## @Wen 需验证场景

1. **白屏根除**：编辑页保存失败（可断网/制造 500）→ 页面不卸载，顶部出现内联 banner（错误文案 + 重试/关闭），表单内容原样保留
2. **重试恢复**：banner 点重试 → 恢复网络后保存成功 → banner 消失 + 成功 toast
3. **校验对齐**：标题/摘要清空失焦 → 字段下红字错误（与发布页同款）；任一必填为空 → 保存按钮 disabled；输入后错误即时消失
4. **错误边界**（可选）：dev 下可临时在组件里 `throw new Error()` 验证兜底 UI（文案 + 重新加载）
5. **i18n**：en locale 下 banner/toast/校验文案均为英文，无原始 key 渲染