### PR TITLE
feat(api): locations.extra 回填主路线攻略 + 3 个对齐索引 (task #152 前置)

### DIFF
--- a/api/db/migrations/0011_locations_extra_backfill.sql
+++ b/api/db/migrations/0011_locations_extra_backfill.sql
@@ -1,0 +1,39 @@
+-- Migration: task #152 前置 —— locations.extra 回填主路线攻略内容 + 索引对齐
+-- 背景：
+--   1. #152 详情页「徒步攻略」区块改读 location.extra.hiking（Steven/Martin 2026-07-18 定稿，
+--      选项 A：主路线 guide/extra 进 location，非主路线仅名称+参数已在 0010 附录中）
+--   2. task #159 决策：schema 已声明但 DB 未建的 3 个索引随此迁移补齐（纯增量零数据风险）
+-- 规则：
+--   主路线 = MIN(created_at, rowid)（与 0010 同一规则）
+--   extra.hiking = { overview, tips, equipmentNeeded, warnings }
+--     overview = COALESCE(route_guide.overview, route.description)（保持今日 RouteInfoCard 显示语义）
+--   合并而非覆盖：json_patch 进现有 extra（31/35 地点已有 facilities/tips/warnings 等键，全部保留）
+--   无路线地点：extra 保持原值不动
+-- 幂等：已存在 $.hiking 的地点跳过；索引 IF NOT EXISTS
+-- 原子性：各语句独立原子（SQLite 单语句）；wrangler d1 migrations apply 逐文件应用
+
+CREATE INDEX IF NOT EXISTS `locations_created_at_idx` ON `locations` (`created_at`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `teams_title_idx` ON `teams` (`title`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `users_nickname_idx` ON `users` (`nickname`);
+--> statement-breakpoint
+UPDATE locations SET extra = json_patch(
+  COALESCE(locations.extra, '{}'),
+  (
+    SELECT json_object(
+      'hiking', json_object(
+        'overview', COALESCE(json_extract(r.route_guide, '$.overview'), r.description),
+        'tips', json_extract(r.route_guide, '$.tips'),
+        'equipmentNeeded', json_extract(r.extra, '$.equipmentNeeded'),
+        'warnings', json_extract(r.extra, '$.warnings')
+      )
+    )
+    FROM routes r
+    WHERE r.location_id = locations.id
+    ORDER BY r.created_at ASC, r.rowid ASC
+    LIMIT 1
+  )
+)
+WHERE EXISTS (SELECT 1 FROM routes r WHERE r.location_id = locations.id)
+  AND json_extract(COALESCE(locations.extra, '{}'), '$.hiking') IS NULL;

--- a/api/src/__tests__/migration/locations-extra-backfill.test.ts
+++ b/api/src/__tests__/migration/locations-extra-backfill.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { createTestDb } from "../helpers/db";
+import { seedCity, seedLocation } from "../helpers/seed";
+import * as schema from "../../db/schema";
+
+/**
+ * task #152 前置迁移 0011 测试：直接对 better-sqlite3 执行迁移文件里的语句，
+ * 验证 extra.hiking 回填（json_patch 合并）+ 3 个对齐索引的真实行为。
+ */
+
+// 从迁移文件中提取全部语句（去注释行），调用方按类型过滤
+function migrationStatements(prefix: "UPDATE" | "CREATE INDEX"): string[] {
+  const path = new URL("../../../db/migrations/0011_locations_extra_backfill.sql", import.meta.url).pathname;
+  const sql = readFileSync(path, "utf-8");
+  return sql
+    .split("--> statement-breakpoint")
+    .map((chunk) =>
+      chunk
+        .split("\n")
+        .filter((line) => !line.trim().startsWith("--"))
+        .join("\n")
+        .trim()
+    )
+    .filter((stmt) => stmt.toUpperCase().startsWith(prefix));
+}
+
+async function insertRoute(
+  db: ReturnType<typeof createTestDb>["db"],
+  overrides: Partial<schema.NewRoute> & { locationId: string; cityId: string }
+) {
+  const id = overrides.id ?? `route_${Math.random().toString(36).slice(2, 10)}`;
+  const ts = new Date();
+  await db.insert(schema.routes).values({
+    id,
+    name: `路线_${id}`,
+    difficulty: "easy",
+    durationMin: 60,
+    durationMax: 120,
+    distance: 5,
+    elevation: 100,
+    createdAt: ts,
+    updatedAt: ts,
+    ...overrides,
+  });
+  return id;
+}
+
+describe("0011_locations_extra_backfill 迁移", () => {
+  it("主路线 guide/extra 回填进 extra.hiking，并保留已有 extra 键", async () => {
+    const { db, sqlite } = createTestDb();
+    const city = await seedCity(db);
+    const loc = await seedLocation(db, city.id, {
+      name: "攻略山",
+      extra: JSON.stringify({ facilities: ["停车场"], tips: ["早出发"] }),
+    });
+    await insertRoute(db, {
+      locationId: loc.id, cityId: city.id, name: "主线",
+      description: "主线描述",
+      routeGuide: JSON.stringify({ overview: "从村口出发全程石阶", tips: ["前缓后陡", "山顶有补给"] }),
+      extra: JSON.stringify({ equipmentNeeded: ["登山鞋", "登山杖"], warnings: ["雨天路滑"] }),
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    for (const stmt of migrationStatements("UPDATE")) sqlite.exec(stmt);
+
+    const row = sqlite.prepare("SELECT extra FROM locations WHERE id = ?").get(loc.id) as { extra: string };
+    const extra = JSON.parse(row.extra);
+    // 回填内容
+    expect(extra.hiking).toEqual({
+      overview: "从村口出发全程石阶",
+      tips: ["前缓后陡", "山顶有补给"],
+      equipmentNeeded: ["登山鞋", "登山杖"],
+      warnings: ["雨天路滑"],
+    });
+    // 已有键保留
+    expect(extra.facilities).toEqual(["停车场"]);
+    expect(extra.tips).toEqual(["早出发"]);
+  });
+
+  it("created_at 并列时取 rowid 小者（与 0010 主路线规则一致）", async () => {
+    const { db, sqlite } = createTestDb();
+    const city = await seedCity(db);
+    const loc = await seedLocation(db, city.id, { name: "并列山" });
+    const sameTs = new Date("2026-01-01T00:00:00Z");
+    await insertRoute(db, {
+      locationId: loc.id, cityId: city.id, name: "第一条",
+      routeGuide: JSON.stringify({ overview: "第一条的攻略" }),
+      createdAt: sameTs,
+    });
+    await insertRoute(db, {
+      locationId: loc.id, cityId: city.id, name: "第二条",
+      routeGuide: JSON.stringify({ overview: "第二条的攻略" }),
+      createdAt: sameTs,
+    });
+
+    for (const stmt of migrationStatements("UPDATE")) sqlite.exec(stmt);
+
+    const row = sqlite.prepare("SELECT extra FROM locations WHERE id = ?").get(loc.id) as { extra: string };
+    expect(JSON.parse(row.extra).hiking.overview).toBe("第一条的攻略");
+  });
+
+  it("guide.overview 缺失时回退 route.description（保持今日显示语义）", async () => {
+    const { db, sqlite } = createTestDb();
+    const city = await seedCity(db);
+    const loc = await seedLocation(db, city.id, { name: "回退山" });
+    await insertRoute(db, {
+      locationId: loc.id, cityId: city.id, name: "无线",
+      description: "这条路线风景优美",
+      routeGuide: JSON.stringify({ tips: ["带够水"] }), // 无 overview
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    for (const stmt of migrationStatements("UPDATE")) sqlite.exec(stmt);
+
+    const row = sqlite.prepare("SELECT extra FROM locations WHERE id = ?").get(loc.id) as { extra: string };
+    const hiking = JSON.parse(row.extra).hiking;
+    expect(hiking.overview).toBe("这条路线风景优美");
+    expect(hiking.tips).toEqual(["带够水"]);
+  });
+
+  it("无路线地点 extra 保持原值不动", async () => {
+    const { db, sqlite } = createTestDb();
+    const city = await seedCity(db);
+    const loc = await seedLocation(db, city.id, {
+      name: "城市点",
+      extra: JSON.stringify({ facilities: ["地铁站"] }),
+    });
+
+    for (const stmt of migrationStatements("UPDATE")) sqlite.exec(stmt);
+
+    const row = sqlite.prepare("SELECT extra FROM locations WHERE id = ?").get(loc.id) as { extra: string };
+    expect(JSON.parse(row.extra)).toEqual({ facilities: ["地铁站"] });
+  });
+
+  it("幂等：重复执行不覆盖已有 hiking", async () => {
+    const { db, sqlite } = createTestDb();
+    const city = await seedCity(db);
+    const loc = await seedLocation(db, city.id, { name: "幂等山" });
+    await insertRoute(db, {
+      locationId: loc.id, cityId: city.id, name: "主线",
+      routeGuide: JSON.stringify({ overview: "原始攻略" }),
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    const updates = migrationStatements("UPDATE");
+    for (const stmt of updates) sqlite.exec(stmt);
+    // 模拟内容侧已润色 hiking
+    sqlite.prepare("UPDATE locations SET extra = json_set(extra, '$.hiking.overview', '人工润色后的攻略') WHERE id = ?").run(loc.id);
+    for (const stmt of updates) sqlite.exec(stmt); // 第二遍不得覆盖
+
+    const row = sqlite.prepare("SELECT extra FROM locations WHERE id = ?").get(loc.id) as { extra: string };
+    expect(JSON.parse(row.extra).hiking.overview).toBe("人工润色后的攻略");
+  });
+
+  it("三个对齐索引被创建（task #159 决策）", () => {
+    const { sqlite } = createTestDb();
+    for (const stmt of migrationStatements("CREATE INDEX")) sqlite.exec(stmt);
+
+    const names = (sqlite.prepare("SELECT name FROM sqlite_master WHERE type = 'index'").all() as { name: string }[])
+      .map((r) => r.name);
+    expect(names).toContain("locations_created_at_idx");
+    expect(names).toContain("teams_title_idx");
+    expect(names).toContain("users_nickname_idx");
+
+    // IF NOT EXISTS：重复执行不炸
+    for (const stmt of migrationStatements("CREATE INDEX")) sqlite.exec(stmt);
+  });
+});


### PR DESCRIPTION
## 改动范围

#152 前置迁移（Martin 编排：0011 迁移 PR 先行 → 前端切源 PR 随后）。两部分：
1. **extra.hiking 回填**（#152 选项 A，Steven/Martin 定稿）：主路线的 route_guide/extra 合并进 location.extra.hiking，供详情页「徒步攻略」区块改读 location 后渲染 overview/tips/装备/注意事项
2. **3 个对齐索引**（task #159 Martin 决策）：`locations_created_at_idx` / `teams_title_idx` / `users_nickname_idx`——schema 已声明但 DB 从未创建，CREATE INDEX IF NOT EXISTS 纯增量零数据风险

**关键文件**
- `api/db/migrations/0011_locations_extra_backfill.sql` — 3 × CREATE INDEX + 1 × UPDATE（json_patch 合并）
- `api/src/__tests__/migration/locations-extra-backfill.test.ts` — 6 例，直接执行迁移文件语句

**回填规则**
- 主路线 = MIN(created_at, rowid)（与 0010 同一规则）
- `extra.hiking = { overview, tips, equipmentNeeded, warnings }`；overview = COALESCE(route_guide.overview, route.description)（保持今日 RouteInfoCard `guide?.overview || description` 显示语义）
- **合并不覆盖**：json_patch 进现有 extra——prod 31/35 地点已有 facilities/tips/warnings 键，全部原样保留（hiking 是全新键，无碰撞）
- 无路线地点 extra 不动；已有 $.hiking 跳过（幂等，内容侧后续润色不会被重跑覆盖）

## 本地验证

- `pnpm vitest run`：**216/216 PASS**（新增 6 例：合并保留 / 并列 rowid tie-break / overview 回退 description / 无路线不动 / 幂等 / 索引创建+重复执行）
- `pnpm exec tsc --noEmit` PASS

## 三道闸执行记录

**① 原子性**：4 条单语句，无 BEGIN；wrangler migrations apply 逐文件应用。

**② staging 先验 + 核对**：0011 已应用 staging ✅——2/2 有路线地点有 hiking、0 无路线被回填、3 索引就位。staging 数据薄，另做 **prod 快照 dry-run**（35 地点/38 路线全列导出 → 内存 SQLite 执行 UPDATE）：
- 16/16 有路线地点回填 hiking ✅
- 31/31 已有 extra 键（facilities 等）全部保留 ✅
- 0 无路线地点被触碰 ✅

**③ prod 备份（迁移前）**：`wrangler d1 export` 已完成
- 文件：`backups/gomate-db-prod-pre-0011-20260718T1150.sql`（5.9MB，VictorMac 本地，含 PII 不上传）
- 回滚 SQL：
```sql
UPDATE locations SET extra = json_remove(extra, '$.hiking') WHERE json_extract(extra, '$.hiking') IS NOT NULL;
DROP INDEX IF EXISTS locations_created_at_idx;
DROP INDEX IF EXISTS teams_title_idx;
DROP INDEX IF EXISTS users_nickname_idx;
```

## 回填对照（prod 快照 dry-run，梧桐山）

| 项 | 回填前（主路线泰山涧线路） | 回填后 location.extra |
|---|---|---|
| overview | route_guide.overview「从梧桐山村出发，沿泰山涧步道上山…」 | extra.hiking.overview 逐字符一致 |
| tips | 3 条（前半段平缓…） | extra.hiking.tips 一致 |
| equipmentNeeded | 登山鞋/登山杖/充足饮用水/防晒用品 | extra.hiking.equipmentNeeded 一致 |
| warnings | 周末人流较多/雨天路滑注意安全 | extra.hiking.warnings 一致 |
| facilities | extra.facilities「停车场/卫生间/小卖部/观景台」 | **原样保留**（与 hiking 并存） |

## 生产资源

- D1 数据迁移 + 索引创建：属 #151 已批准的简化系列范围（决策 4）+ #159 Martin 决策；三道闸已执行
- merge 后 api-deploy.yml 自动对 prod 应用 0011
- 无环境变量 / R2 / KV 变更

## Wen 需验证场景（merge + prod 迁移后）

1. 梧桐山 location.extra 含 hiking 键，内容 = 泰山涧线路 guide/extra（对照上表）；facilities 等原键仍在
2. 跑核对 SQL：有路线地点 hiking 覆盖率 100%、无路线地点 0 回填
3. 详情页/首页无回归（本 PR 不改任何 API 响应与前端，纯数据回填——页面渲染应零变化，因为前端还没开始读 hiking）

## 后续

#152 前端切源 PR 紧随其后（基于本 PR 合并后的 main）：4 参数读 location 字段、notes 读 location.extra.hiking、选择器删除、空态整区块不渲染 + teams 筛选/推荐切源 + 卡片元数据切源。