### PR TITLE
feat: 前端/teams 徒步参数切源到 location 字段 (task #152)

### DIFF
--- a/api/src/__tests__/integration/locations.test.ts
+++ b/api/src/__tests__/integration/locations.test.ts
@@ -129,4 +129,66 @@ describe("Locations API 集成测试", () => {
       expect(res.status).toBe(404);
     });
   });
+
+  describe("task #152 切源：徒步参数读 location 字段", () => {
+    it("view=card 返回 location 扁平化字段，routes[0] 镜像同值", async () => {
+      await seedLocation(testDb, city.id, {
+        name: "梧桐山",
+        difficulty: "moderate",
+        durationMin: 120,
+        durationMax: 180,
+        distance: 5.5,
+        elevation: 700,
+      });
+      await seedLocation(testDb, city.id, { name: "昆明湖" }); // 无参数
+
+      const res = await req(app, "/locations?view=card");
+      expect(res.status).toBe(200);
+      const json = await res.json() as {
+        locations: {
+          name: string; difficulty: string | null;
+          durationMin: number | null; durationMax: number | null;
+          distance: number | null; elevation: number | null;
+          routes: { difficulty: string | null; durationMin: number | null }[];
+        }[];
+      };
+      const wts = json.locations.find((l) => l.name === "梧桐山")!;
+      expect(wts.difficulty).toBe("moderate");
+      expect(wts.durationMin).toBe(120);
+      expect(wts.durationMax).toBe(180);
+      expect(wts.distance).toBe(5.5);
+      expect(wts.elevation).toBe(700);
+      expect(wts.routes).toHaveLength(1);
+      expect(wts.routes[0].difficulty).toBe("moderate");
+      expect(wts.routes[0].durationMin).toBe(120);
+
+      const km = json.locations.find((l) => l.name === "昆明湖")!;
+      expect(km.difficulty).toBeNull();
+      expect(km.durationMin).toBeNull();
+      expect(km.routes).toHaveLength(0);
+    });
+
+    it("完整列表 difficulty 读 location 字段而非 routes join", async () => {
+      const loc = await seedLocation(testDb, city.id, {
+        name: "切源山", difficulty: "hard", durationMin: 300, durationMax: 420,
+      });
+      // 故意插入一条 difficulty 不同的路线，证明数据源是 location 而非 routes
+      const ts = new Date();
+      await testDb.insert(schema.routes).values({
+        id: "route_distractor", locationId: loc.id, cityId: city.id, name: "干扰路线",
+        difficulty: "easy", durationMin: 10, durationMax: 20, distance: 1,
+        createdAt: ts, updatedAt: ts,
+      });
+
+      const res = await req(app, "/locations");
+      expect(res.status).toBe(200);
+      const json = await res.json() as {
+        locations: { name: string; difficulty: string; durationMin: number; durationMax: number }[];
+      };
+      const item = json.locations.find((l) => l.name === "切源山")!;
+      expect(item.difficulty).toBe("hard");
+      expect(item.durationMin).toBe(300);
+      expect(item.durationMax).toBe(420);
+    });
+  });
 });

--- a/api/src/__tests__/integration/teams.test.ts
+++ b/api/src/__tests__/integration/teams.test.ts
@@ -513,4 +513,43 @@ describe("Teams API 集成测试", () => {
       expect(json.status).toBeNull();
     });
   });
+
+  describe("task #152 切源：teams 难度筛选读 location 字段", () => {
+    it("?difficulty= 按 location.difficulty 过滤", async () => {
+      const locModerate = await seedLocation(testDb, city.id, { name: "适中山", difficulty: "moderate" });
+      const locEasy = await seedLocation(testDb, city.id, { name: "轻松山", difficulty: "easy" });
+      await seedTeam(testDb, leader.id, locModerate.id, { title: "适中队" });
+      await seedTeam(testDb, leader.id, locEasy.id, { title: "轻松队" });
+
+      const res = await req(app, "/teams?difficulty=moderate");
+      expect(res.status).toBe(200);
+      const json = await res.json() as { teams: { title: string }[] };
+      expect(json.teams).toHaveLength(1);
+      expect(json.teams[0].title).toBe("适中队");
+    });
+
+    it("队伍详情 location 携带徒步参数字段", async () => {
+      const loc = await seedLocation(testDb, city.id, {
+        name: "参数山", difficulty: "hard", durationMin: 300, durationMax: 420,
+        distance: 8.5, elevation: 1200,
+      });
+      const team = await seedTeam(testDb, leader.id, loc.id, { title: "参数队" });
+
+      const res = await req(app, `/teams/${team.id}`);
+      expect(res.status).toBe(200);
+      const json = await res.json() as {
+        team: {
+          location: {
+            name: string; difficulty: string; durationMin: number;
+            durationMax: number; distance: number; elevation: number;
+          };
+        };
+      };
+      expect(json.team.location.difficulty).toBe("hard");
+      expect(json.team.location.durationMin).toBe(300);
+      expect(json.team.location.durationMax).toBe(420);
+      expect(json.team.location.distance).toBe(8.5);
+      expect(json.team.location.elevation).toBe(1200);
+    });
+  });
 });

--- a/api/src/routes/locations/queries.ts
+++ b/api/src/routes/locations/queries.ts
@@ -98,7 +98,7 @@ queries.get("/", async (c) => {
 
     // ==================== view=card 轻量模式 ====================
     if (view === "card") {
-      // 只查询卡片需要的字段，不 join city/routes
+      // 只查询卡片需要的字段，不 join city；徒步参数读 location 自身字段（task #152 切源，不再 join routes）
       const locationList = await db
         .select({
           id: schema.locations.id,
@@ -110,6 +110,11 @@ queries.get("/", async (c) => {
           address: schema.locations.address,
           cityName: schema.locations.cityName,
           coverImage: schema.locations.coverImage,
+          difficulty: schema.locations.difficulty,
+          durationMin: schema.locations.durationMin,
+          durationMax: schema.locations.durationMax,
+          distance: schema.locations.distance,
+          elevation: schema.locations.elevation,
           createdAt: schema.locations.createdAt,
         })
         .from(schema.locations)
@@ -118,26 +123,6 @@ queries.get("/", async (c) => {
         .offset(offset);
 
       const locationIds = locationList.map((l) => l.id);
-
-      // 只取每个地点的第一条路线（难度和耗时用）
-      const firstRoutes = locationIds.length > 0
-        ? await db
-            .select({
-              locationId: schema.routes.locationId,
-              difficulty: schema.routes.difficulty,
-              durationMin: schema.routes.durationMin,
-              durationMax: schema.routes.durationMax,
-              distance: schema.routes.distance,
-              elevation: schema.routes.elevation,
-            })
-            .from(schema.routes)
-            .where(inArray(schema.routes.locationId, locationIds))
-        : [];
-
-      const routeByLocation: Record<string, typeof firstRoutes[0]> = {};
-      for (const r of firstRoutes) {
-        if (!routeByLocation[r.locationId]) routeByLocation[r.locationId] = r;
-      }
 
       // 只取每个地点第一个标签
       const firstTags = locationIds.length > 0
@@ -161,8 +146,8 @@ queries.get("/", async (c) => {
       }
 
       const formattedLocations = locationList.map((loc) => {
-        const route = routeByLocation[loc.id];
         const tag = firstTagByLocation[loc.id];
+        const hasParams = loc.difficulty != null || loc.durationMin != null || loc.distance != null;
         return {
           id: loc.id,
           name: loc.name,
@@ -173,14 +158,19 @@ queries.get("/", async (c) => {
           address: loc.address,
           cityName: loc.cityName,
           coverImage: loc.coverImage,
-          difficulty: route?.difficulty ?? null,
+          difficulty: loc.difficulty ?? null,
+          durationMin: loc.durationMin ?? null,
+          durationMax: loc.durationMax ?? null,
+          distance: loc.distance ?? null,
+          elevation: loc.elevation ?? null,
           tags: tag ? [{ name: tag.name, type: tag.type }] : [],
-          routes: route ? [{
-            difficulty: route.difficulty,
-            durationMin: route.durationMin,
-            durationMax: route.durationMax,
-            distance: route.distance,
-            elevation: route.elevation,
+          // 兼容字段：保持 routes[0] 形状与键不变，值改由 location 字段提供（值与 0010 回填的主路线一致）
+          routes: hasParams ? [{
+            difficulty: loc.difficulty,
+            durationMin: loc.durationMin,
+            durationMax: loc.durationMax,
+            distance: loc.distance,
+            elevation: loc.elevation,
           }] : [],
           createdAt: loc.createdAt,
         };
@@ -218,7 +208,6 @@ queries.get("/", async (c) => {
     }
 
     const formattedLocations = locationList.map((location) => {
-      const firstRoute = location.routes?.[0];
       return {
         id: location.id, name: location.name, slug: location.slug,
         type: location.type,
@@ -240,7 +229,12 @@ queries.get("/", async (c) => {
           createdAt: route.createdAt, updatedAt: route.updatedAt,
         })) || [],
         tags: tagsByLocation[location.id] || [],
-        difficulty: firstRoute?.difficulty,
+        // task #152 切源：徒步参数读 location 自身字段（0010 已回填，与主路线一致）
+        difficulty: location.difficulty,
+        durationMin: location.durationMin,
+        durationMax: location.durationMax,
+        distance: location.distance,
+        elevation: location.elevation,
         createdAt: location.createdAt, updatedAt: location.updatedAt,
       };
     });

--- a/api/src/routes/teams/queries.ts
+++ b/api/src/routes/teams/queries.ts
@@ -82,6 +82,7 @@ queries.get("/", async (c) => {
       leaderLevel: schema.users.level,
       locationName: schema.locations.name,
       locationCoverImage: schema.locations.coverImage,
+      locationDifficulty: schema.locations.difficulty,
     };
 
     type TeamRow = {
@@ -92,6 +93,7 @@ queries.get("/", async (c) => {
       currentMembers: number; leaderImage: string | null; leaderName: string;
       leaderNickname: string | null; leaderLevel: string | null;
       locationName: string | null; locationCoverImage: string | null;
+      locationDifficulty: string | null;
     };
 
     let result: TeamRow[];
@@ -261,7 +263,8 @@ queries.get("/", async (c) => {
         const allConditions = [];
         if (whereClause) allConditions.push(whereClause);
         if (difficultyList.length > 0) {
-          allConditions.push(inArray(schema.routes.difficulty, difficultyList));
+          // task #152 切源：难度筛选改指 location 字段（0010 已回填，与主路线一致）
+          allConditions.push(inArray(schema.locations.difficulty, difficultyList));
         }
         if (filteredTeamIds) {
           allConditions.push(inArray(schema.teams.id, filteredTeamIds));
@@ -273,7 +276,7 @@ queries.get("/", async (c) => {
       const [{ cnt }] = await db
         .select({ cnt: sql<number>`count(distinct ${schema.teams.id})` })
         .from(schema.teams)
-        .leftJoin(schema.routes, eq(schema.routes.id, schema.teams.routeId))
+        .leftJoin(schema.locations, eq(schema.locations.id, schema.teams.locationId))
         .where(finalWhereClause);
       const total = cnt;
 
@@ -288,7 +291,6 @@ queries.get("/", async (c) => {
         .from(schema.teams)
         .innerJoin(schema.users, eq(schema.users.id, schema.teams.leaderId))
         .leftJoin(schema.locations, eq(schema.locations.id, schema.teams.locationId))
-        .leftJoin(schema.routes, eq(schema.routes.id, schema.teams.routeId))
         .leftJoin(teamMemberCounts, eq(teamMemberCounts.teamId, schema.teams.id))
         .where(finalWhereClause)
         .orderBy(desc(schema.teams.startTime))
@@ -318,6 +320,7 @@ function formatTeams(result: {
   currentMembers: number; leaderImage: string | null; leaderName: string;
   leaderNickname: string | null; leaderLevel: string | null;
   locationName: string | null; locationCoverImage: string | null;
+  locationDifficulty: string | null;
 }[]) {
   return result.map((row) => {
     const startDate = new Date(row.startTime);
@@ -338,6 +341,7 @@ function formatTeams(result: {
       location: row.locationName ? {
         name: row.locationName,
         coverImage: row.locationCoverImage || "",
+        difficulty: row.locationDifficulty ?? undefined,
       } : undefined,
       leader: {
         id: row.leaderId, name: row.leaderName,
@@ -459,6 +463,12 @@ queries.get("/:id", async (c) => {
           id: teamWithRelations.location.id,
           name: teamWithRelations.location.name,
           coverImage: teamWithRelations.location.coverImage,
+          // task #152 切源：徒步参数随 location 下发（0010 已回填）
+          difficulty: teamWithRelations.location.difficulty,
+          durationMin: teamWithRelations.location.durationMin,
+          durationMax: teamWithRelations.location.durationMax,
+          distance: teamWithRelations.location.distance,
+          elevation: teamWithRelations.location.elevation,
         } : undefined,
         leader: leader ? {
           id: leader.id, name: leader.name, nickname: leader.nickname || null,

--- a/frontend/public/locales/en/locations.json
+++ b/frontend/public/locales/en/locations.json
@@ -5,7 +5,7 @@
   "locationList": "Locations",
   "defaultCity": "All",
   "viewDetail": "View Details",
-  "routeInfo": "Route Info",
+  "routeInfo": "Hiking Guide",
   "routeTags": "Route Tags",
   "facilities": "Facilities",
   "estimatedTime": "Estimated Time",
@@ -83,13 +83,37 @@
     "campsite": "Campsite"
   },
   "seasons": {
-    "spring": { "label": "Spring", "months": "Mar-May" },
-    "summer": { "label": "Summer", "months": "Jun-Aug" },
-    "autumn": { "label": "Autumn", "months": "Sep-Nov" },
-    "winter": { "label": "Winter", "months": "Dec-Feb" },
-    "春季": { "label": "Spring", "months": "Mar-May" },
-    "夏季": { "label": "Summer", "months": "Jun-Aug" },
-    "秋季": { "label": "Autumn", "months": "Sep-Nov" },
-    "冬季": { "label": "Winter", "months": "Dec-Feb" }
+    "spring": {
+      "label": "Spring",
+      "months": "Mar-May"
+    },
+    "summer": {
+      "label": "Summer",
+      "months": "Jun-Aug"
+    },
+    "autumn": {
+      "label": "Autumn",
+      "months": "Sep-Nov"
+    },
+    "winter": {
+      "label": "Winter",
+      "months": "Dec-Feb"
+    },
+    "春季": {
+      "label": "Spring",
+      "months": "Mar-May"
+    },
+    "夏季": {
+      "label": "Summer",
+      "months": "Jun-Aug"
+    },
+    "秋季": {
+      "label": "Autumn",
+      "months": "Sep-Nov"
+    },
+    "冬季": {
+      "label": "Winter",
+      "months": "Dec-Feb"
+    }
   }
 }

--- a/frontend/public/locales/ja/locations.json
+++ b/frontend/public/locales/ja/locations.json
@@ -5,7 +5,7 @@
   "locationList": "スポット一覧",
   "defaultCity": "すべて",
   "viewDetail": "詳細を見る",
-  "routeInfo": "ルート情報",
+  "routeInfo": "ハイキング攻略",
   "routeTags": "ルートタグ",
   "facilities": "付帯施設",
   "estimatedTime": "所要時間の目安",
@@ -83,13 +83,37 @@
     "campsite": "キャンプ場"
   },
   "seasons": {
-    "spring": { "label": "春", "months": "3〜5月" },
-    "summer": { "label": "夏", "months": "6〜8月" },
-    "autumn": { "label": "秋", "months": "9〜11月" },
-    "winter": { "label": "冬", "months": "12〜2月" },
-    "春季": { "label": "春", "months": "3〜5月" },
-    "夏季": { "label": "夏", "months": "6〜8月" },
-    "秋季": { "label": "秋", "months": "9〜11月" },
-    "冬季": { "label": "冬", "months": "12〜2月" }
+    "spring": {
+      "label": "春",
+      "months": "3〜5月"
+    },
+    "summer": {
+      "label": "夏",
+      "months": "6〜8月"
+    },
+    "autumn": {
+      "label": "秋",
+      "months": "9〜11月"
+    },
+    "winter": {
+      "label": "冬",
+      "months": "12〜2月"
+    },
+    "春季": {
+      "label": "春",
+      "months": "3〜5月"
+    },
+    "夏季": {
+      "label": "夏",
+      "months": "6〜8月"
+    },
+    "秋季": {
+      "label": "秋",
+      "months": "9〜11月"
+    },
+    "冬季": {
+      "label": "冬",
+      "months": "12〜2月"
+    }
   }
 }

--- a/frontend/public/locales/zh-CN/locations.json
+++ b/frontend/public/locales/zh-CN/locations.json
@@ -5,7 +5,7 @@
   "locationList": "地点列表",
   "defaultCity": "全部",
   "viewDetail": "查看详情",
-  "routeInfo": "路线信息",
+  "routeInfo": "徒步攻略",
   "routeTags": "路线标签",
   "facilities": "配套设施",
   "estimatedTime": "预计用时",
@@ -83,13 +83,37 @@
     "campsite": "露营地"
   },
   "seasons": {
-    "spring": { "label": "春季", "months": "3-5月" },
-    "summer": { "label": "夏季", "months": "6-8月" },
-    "autumn": { "label": "秋季", "months": "9-11月" },
-    "winter": { "label": "冬季", "months": "12-2月" },
-    "春季": { "label": "春季", "months": "3-5月" },
-    "夏季": { "label": "夏季", "months": "6-8月" },
-    "秋季": { "label": "秋季", "months": "9-11月" },
-    "冬季": { "label": "冬季", "months": "12-2月" }
+    "spring": {
+      "label": "春季",
+      "months": "3-5月"
+    },
+    "summer": {
+      "label": "夏季",
+      "months": "6-8月"
+    },
+    "autumn": {
+      "label": "秋季",
+      "months": "9-11月"
+    },
+    "winter": {
+      "label": "冬季",
+      "months": "12-2月"
+    },
+    "春季": {
+      "label": "春季",
+      "months": "3-5月"
+    },
+    "夏季": {
+      "label": "夏季",
+      "months": "6-8月"
+    },
+    "秋季": {
+      "label": "秋季",
+      "months": "9-11月"
+    },
+    "冬季": {
+      "label": "冬季",
+      "months": "12-2月"
+    }
   }
 }

--- a/frontend/src/components/features/create-team-client.tsx
+++ b/frontend/src/components/features/create-team-client.tsx
@@ -29,7 +29,6 @@ export function CreateTeamClient() {
   const [locations, setLocations] = React.useState<Location[]>([]);
   const [_selectedLocation, setSelectedLocation] = React.useState<Location | null>(null);
   const [_routes, setRoutes] = React.useState<Route[]>([]);
-  const [selectedRoute, setSelectedRoute] = React.useState<Route | null>(null);
   const [recommendedDuration, setRecommendedDuration] = React.useState<number | null>(null);
   const [isAuthenticated, setIsAuthenticated] = React.useState<boolean | null>(null);
   const [hasWechat, setHasWechat] = React.useState(false);
@@ -80,7 +79,6 @@ export function CreateTeamClient() {
     if (!formData.locationId) {
       setSelectedLocation(null);
       setRoutes([]);
-      setSelectedRoute(null);
       setRecommendedDuration(null);
       durationManuallyEditedRef.current = false;
       return;
@@ -96,43 +94,27 @@ export function CreateTeamClient() {
           setRoutes(loc.routes || []);
           durationManuallyEditedRef.current = false; // 新地点，重置手动编辑标记
 
-          // 如果有路线，根据路线难度推荐时长
+          // routeId 仍默认第一条路线（teams.routeId 移除在 #154，选择器当前隐藏）
           if (loc.routes && loc.routes.length > 0) {
-            // 默认选择第一条路线
             const firstRoute = loc.routes[0];
-            setSelectedRoute(firstRoute);
             setFormData((prev) => ({ ...prev, routeId: firstRoute.id }));
+          } else {
+            setFormData((prev) => ({ ...prev, routeId: "" }));
+          }
 
-            // 计算推荐时长
-            const recommended = calculateRecommendedDuration(firstRoute);
+          // task #152 切源：时长推荐改读 location 自身字段（0010 回填）
+          const recommended = calculateRecommendedDuration(loc);
+          if (recommended != null) {
             setRecommendedDuration(recommended);
             setFormData((prev) => ({ ...prev, durationMin: String(recommended) }));
           } else {
-            // 无路线时，重置为默认值
             setRecommendedDuration(null);
-            setFormData((prev) => ({ ...prev, durationMin: String(defaultDuration), routeId: "" }));
-            setSelectedRoute(null);
+            setFormData((prev) => ({ ...prev, durationMin: String(defaultDuration) }));
           }
         }
       })
       .catch(() => {});
   }, [formData.locationId]);
-
-  // 当路线变化时，重新计算推荐时长
-  React.useEffect(() => {
-    if (!selectedRoute) {
-      durationManuallyEditedRef.current = false;
-      return;
-    }
-
-    const recommended = calculateRecommendedDuration(selectedRoute);
-    setRecommendedDuration(recommended);
-
-    // 如果用户没有手动修改时长，则自动更新为推荐值
-    if (!durationManuallyEditedRef.current) {
-      setFormData((prev) => ({ ...prev, durationMin: String(recommended) }));
-    }
-  }, [selectedRoute]);
 
   // 当用户手动修改时长时，标记为已手动编辑
   const handleDurationChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -147,34 +129,17 @@ export function CreateTeamClient() {
   };
 
   /**
-   * 根据路线难度和时长推荐合适的活动时长（分钟）
+   * 根据地点的徒步参数推荐合适的活动时长（分钟）
+   * task #152 切源：读 location.durationMin/durationMax/difficulty（0010 回填）
+   * 无任何参数时返回 null（回退默认值 4 小时）
    */
-  const calculateRecommendedDuration = (route: Route): number => {
-    // 优先使用 durationMin/durationMax（如果有）
-    const routeWithDuration = route as Route & { durationMin?: number; durationMax?: number };
-    if (routeWithDuration.durationMin && routeWithDuration.durationMax) {
+  const calculateRecommendedDuration = (loc: Location): number | null => {
+    if (loc.durationMin && loc.durationMax) {
       // 取平均值
-      return Math.round((routeWithDuration.durationMin + routeWithDuration.durationMax) / 2);
+      return Math.round((loc.durationMin + loc.durationMax) / 2);
     }
-    if (routeWithDuration.durationMin) {
-      return routeWithDuration.durationMin;
-    }
-
-    // 从 route.duration 解析（格式如 "2-3 小时" 或 "4 小时"）
-    const durationStr = route.duration;
-    if (durationStr) {
-      const match = durationStr.match(/(\d+(?:\.\d+)?)\s*(-|~|至)\s*(\d+(?:\.\d+)?)\s*小时/);
-      if (match) {
-        const minHours = parseFloat(match[1]);
-        const maxHours = parseFloat(match[3]);
-        // 取平均值，转换为分钟
-        return Math.round(((minHours + maxHours) / 2) * 60);
-      }
-      // 单一值格式
-      const singleMatch = durationStr.match(/(\d+(?:\.\d+)?)\s*小时/);
-      if (singleMatch) {
-        return Math.round(parseFloat(singleMatch[1]) * 60);
-      }
+    if (loc.durationMin) {
+      return loc.durationMin;
     }
 
     // 根据难度推荐
@@ -184,7 +149,7 @@ export function CreateTeamClient() {
       hard: 420,      // 困难：7 小时
       expert: 600,    // 专家：10 小时
     };
-    return difficultyDuration[route.difficulty] || 240;
+    return (loc.difficulty && difficultyDuration[loc.difficulty]) || null;
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {

--- a/frontend/src/components/features/home/home-location-card.tsx
+++ b/frontend/src/components/features/home/home-location-card.tsx
@@ -3,6 +3,7 @@ import { MapPin, Mountain, ArrowRight, Clock, Route } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import { DIFFICULTY_CONFIG } from "@/lib/constants";
 import { LocationCoverImage } from "@/components/ui/lazy-image";
+import { formatRouteMetric, normalizeLocationHiking } from "@/components/features/location-detail/route-utils";
 import type { Location } from "@/lib/types";
 
 interface LocationCardProps {
@@ -17,8 +18,9 @@ interface LocationCardProps {
  * 仅当 location.id 变化时重新渲染
  */
 export const LocationCard = memo(function LocationCard({ location, index = 0 }: LocationCardProps) {
-  const { t } = useI18n(["locations"]);
-  const difficulty = location.difficulty ?? location.routes?.[0]?.difficulty;
+  const { t } = useI18n(["locations", "locationDetail"]);
+  // task #152 切源：徒步参数读 location 自身字段（0010 回填），不再读 routes[0]
+  const difficulty = location.difficulty;
   const diffConfig = difficulty ? DIFFICULTY_CONFIG[difficulty as keyof typeof DIFFICULTY_CONFIG] : null;
   const firstTag = location.tags?.[0];
 
@@ -27,14 +29,14 @@ export const LocationCard = memo(function LocationCard({ location, index = 0 }: 
 
   // 使用 useMemo 缓存复杂计算
   const routeInfo = useMemo(() => {
-    const route = location.routes?.[0];
-    if (!route) return null;
+    const hiking = normalizeLocationHiking(location);
+    if (!hiking) return null;
     return {
-      duration: route.duration,
-      distance: route.distance,
-      elevation: route.elevation,
+      duration: formatRouteMetric(hiking.duration, t),
+      distance: hiking.distance?.value,
+      elevation: hiking.elevation?.value,
     };
-  }, [location.routes]);
+  }, [location, t]);
 
   return (
     <a href={`/locations/${location.id}`} className="block group">

--- a/frontend/src/components/features/location-detail/route-info-card.tsx
+++ b/frontend/src/components/features/location-detail/route-info-card.tsx
@@ -13,7 +13,7 @@ import { cn } from "@/lib/utils";
 import type { Location } from "@/lib/types";
 import { DIFFICULTY_CONFIG } from "./constants";
 import {
-  normalizeLocationRoutes,
+  normalizeLocationHiking,
   type NormalizedLocationRoute,
   type RouteMetric,
 } from "./route-utils";
@@ -22,24 +22,24 @@ interface RouteInfoCardProps {
   location: Location;
 }
 
+/**
+ * 「徒步攻略」区块（task #152：原 RouteInfoCard 改读 location 字段，多路线选择器删除）。
+ * 布局（Steven 定稿）：标题 + 4 参数 tiles + overview 引导段 + tips/装备/注意事项 notes。
+ * 数据：4 参数 = location 扁平化字段（0010 回填）；notes = location.extra.hiking（0011 回填）。
+ * 空态：4 参数全空且无 hiking 内容 → 整区块不渲染。
+ */
 export function RouteInfoCard({ location }: RouteInfoCardProps) {
   const { t } = useI18n(["enums", "locations", "common", "locationDetail"]);
-  const routes = React.useMemo(() => normalizeLocationRoutes(location), [location]);
-  const [selectedRouteId, setSelectedRouteId] = React.useState<string | null>(null);
+  const hiking = React.useMemo(() => normalizeLocationHiking(location), [location]);
 
-  React.useEffect(() => {
-    setSelectedRouteId(routes[0]?.id ?? null);
-  }, [routes]);
+  if (!hiking) return null;
 
-  if (routes.length === 0) return null;
-
-  const selectedRoute = routes.find((route) => route.id === selectedRouteId) ?? routes[0];
-  const metrics = getMetricItems(selectedRoute, t);
+  const metrics = getMetricItems(hiking, t);
+  const tips = hiking.routeGuide?.tips ?? [];
   const hasRouteNotes =
-    selectedRoute.equipmentNeeded.length > 0 ||
-    selectedRoute.warnings.length > 0 ||
-    Boolean(selectedRoute.routeGuide?.overview) ||
-    (selectedRoute.routeGuide?.tips.length ?? 0) > 0;
+    hiking.equipmentNeeded.length > 0 ||
+    hiking.warnings.length > 0 ||
+    tips.length > 0;
 
   return (
     <section className="bg-card rounded-xl border border-stone-100 dark:border-stone-800 p-4 sm:p-5 shadow-[0_1px_8px_rgba(0,0,0,0.04)]">
@@ -53,41 +53,7 @@ export function RouteInfoCard({ location }: RouteInfoCardProps) {
             {t("locationDetail.routeSummarySubtitle")}
           </p>
         </div>
-        {routes.length > 1 && (
-          <span className="inline-flex w-fit items-center rounded-full border border-emerald-100 dark:border-emerald-900/50 bg-emerald-50 dark:bg-emerald-950/30 px-2.5 py-1 text-xs font-semibold text-emerald-700 dark:text-emerald-400">
-            {t("locationDetail.routeOptions", { count: routes.length })}
-          </span>
-        )}
       </div>
-
-      {routes.length > 1 && (
-        <div className="mb-4 flex gap-2 overflow-x-auto pb-1 scrollbar-none" role="listbox" aria-label={t("locations.routeInfo")}>
-          {routes.map((route, index) => {
-            const selected = route.id === selectedRoute.id;
-            return (
-              <button
-                key={route.id}
-                type="button"
-                role="option"
-                aria-selected={selected}
-                aria-label={t("locationDetail.routeCardAria", { name: route.name })}
-                onClick={() => setSelectedRouteId(route.id)}
-                className={cn(
-                  "min-w-[132px] rounded-xl border px-3 py-2.5 text-left transition-all duration-150",
-                  selected
-                    ? "border-emerald-300 bg-emerald-50 text-emerald-950 shadow-sm dark:border-emerald-800 dark:bg-emerald-950/30 dark:text-emerald-100"
-                    : "border-stone-100 bg-stone-50/70 text-stone-700 hover:border-stone-200 hover:bg-stone-100 dark:border-stone-800 dark:bg-stone-900/60 dark:text-stone-300 dark:hover:bg-stone-800"
-                )}
-              >
-                <span className="block text-sm font-bold leading-snug line-clamp-1">{route.name}</span>
-                <span className="mt-1 block text-[11px] font-medium text-stone-600 dark:text-stone-400">
-                  {index === 0 ? t("locationDetail.recommendedRoute") : getRouteDifficulty(route, t)}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-      )}
 
       <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-4">
         {metrics.map((item) => (
@@ -95,35 +61,35 @@ export function RouteInfoCard({ location }: RouteInfoCardProps) {
         ))}
       </div>
 
-      {(selectedRoute.description || selectedRoute.routeGuide?.overview) && (
+      {hiking.routeGuide?.overview && (
         <p className="mt-4 rounded-xl border border-stone-100 dark:border-stone-800 bg-stone-50/70 dark:bg-stone-900/50 px-3.5 py-3 text-sm leading-relaxed text-stone-600 dark:text-stone-400">
-          {selectedRoute.routeGuide?.overview || selectedRoute.description}
+          {hiking.routeGuide.overview}
         </p>
       )}
 
       {hasRouteNotes && (
         <div className="mt-4 grid gap-3 sm:grid-cols-2">
-          {selectedRoute.equipmentNeeded.length > 0 && (
+          {hiking.equipmentNeeded.length > 0 && (
             <RouteNoteBlock
               icon={<Backpack className="h-3.5 w-3.5" />}
               title={t("common.recommendedGear")}
-              items={selectedRoute.equipmentNeeded}
+              items={hiking.equipmentNeeded}
               tone="stone"
             />
           )}
-          {(selectedRoute.routeGuide?.tips.length ?? 0) > 0 && (
+          {tips.length > 0 && (
             <RouteNoteBlock
               icon={<Lightbulb className="h-3.5 w-3.5" />}
               title={t("locationDetail.routeTips")}
-              items={selectedRoute.routeGuide?.tips ?? []}
+              items={tips}
               tone="stone"
             />
           )}
-          {selectedRoute.warnings.length > 0 && (
+          {hiking.warnings.length > 0 && (
             <RouteNoteBlock
               icon={<AlertTriangle className="h-3.5 w-3.5" />}
               title={t("common.precautions")}
-              items={selectedRoute.warnings}
+              items={hiking.warnings}
               tone="warning"
             />
           )}
@@ -131,13 +97,6 @@ export function RouteInfoCard({ location }: RouteInfoCardProps) {
       )}
     </section>
   );
-}
-
-function getRouteDifficulty(
-  route: NormalizedLocationRoute,
-  t: (key: string, vars?: Record<string, string | number>) => string
-) {
-  return route.difficulty ? t(`enums.difficulty.${route.difficulty}`) : t("common.unknown");
 }
 
 function getMetricItems(

--- a/frontend/src/components/features/location-detail/route-utils.ts
+++ b/frontend/src/components/features/location-detail/route-utils.ts
@@ -1,4 +1,4 @@
-import type { Location, Route } from "@/lib/types";
+import type { Location } from "@/lib/types";
 
 export type RouteMetricUnit = "hour" | "minute" | "kilometer" | "meter";
 
@@ -23,11 +23,20 @@ export interface NormalizedLocationRoute {
   };
 }
 
-type RouteRecord = Partial<Route> & {
+type RouteRecord = {
+  id?: string;
+  locationId?: string;
+  name?: string;
+  description?: string;
+  difficulty?: Location["difficulty"];
+  duration?: string;
   durationMin?: number | null;
   durationMax?: number | null;
   distance?: string | number | null;
   elevation?: string | number | null;
+  equipmentNeeded?: string[] | null;
+  warnings?: string[] | null;
+  routeGuide?: unknown;
   extra?: unknown;
 };
 
@@ -120,8 +129,7 @@ function normalizeRoute(route: RouteRecord): NormalizedLocationRoute {
   };
 }
 
-export function normalizeLocationRoutes(location: Location): NormalizedLocationRoute[] {
-  const routes = location.routes?.map((route) => normalizeRoute(route as RouteRecord)) ?? [];
+export function normalizeLocationRoutes(location: Location): NormalizedLocationRoute[] {  const routes = location.routes?.map((route) => normalizeRoute(route as RouteRecord)) ?? [];
   if (routes.length > 0) return routes;
 
   const fallback: RouteRecord = {
@@ -140,4 +148,40 @@ export function normalizeLocationRoutes(location: Location): NormalizedLocationR
   const hasAnyMetric = normalized.difficulty || normalized.duration || normalized.distance || normalized.elevation
     || normalized.equipmentNeeded.length > 0 || normalized.warnings.length > 0;
   return hasAnyMetric ? [normalized] : [];
+}
+
+/**
+ * task #152：从 location 自身字段构造「徒步攻略」区块数据（数据源已从 routes 切到 location）。
+ * 4 参数读 location 扁平化字段（0010 回填）；overview/tips/装备/注意事项读 extra.hiking（0011 回填）。
+ * 无任何内容时返回 null（区块整体不渲染）。
+ */
+export function normalizeLocationHiking(location: Location): NormalizedLocationRoute | null {
+  const hiking = location.extra?.hiking ?? undefined;
+  const normalized = normalizeRoute({
+    id: `${location.id}-hiking`,
+    locationId: location.id,
+    name: location.name,
+    difficulty: location.difficulty,
+    durationMin: location.durationMin,
+    durationMax: location.durationMax,
+    distance: location.distance,
+    elevation: location.elevation,
+    routeGuide: hiking ? { overview: hiking.overview ?? undefined, tips: hiking.tips ?? [] } : undefined,
+    equipmentNeeded: hiking?.equipmentNeeded ?? undefined,
+    warnings: hiking?.warnings ?? undefined,
+  });
+  const hasAnyMetric = normalized.difficulty || normalized.duration || normalized.distance || normalized.elevation;
+  const hasAnyNote = Boolean(normalized.routeGuide?.overview) || (normalized.routeGuide?.tips.length ?? 0) > 0
+    || normalized.equipmentNeeded.length > 0 || normalized.warnings.length > 0;
+  return hasAnyMetric || hasAnyNote ? normalized : null;
+}
+
+/** 把 RouteMetric 渲染为带单位的文本（单位走 locationDetail.metricUnits.* i18n） */
+export function formatRouteMetric(
+  metric: RouteMetric | undefined,
+  t: (key: string, vars?: Record<string, string | number>) => string
+): string | undefined {
+  if (!metric) return undefined;
+  const unit = metric.unit ? t(`locationDetail.metricUnits.${metric.unit}`) : "";
+  return unit ? `${metric.value} ${unit}` : metric.value;
 }

--- a/frontend/src/components/features/locations/locations-grid.tsx
+++ b/frontend/src/components/features/locations/locations-grid.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import type { Location, Tag } from "@/lib/types";
 import { tagColorClasses } from "./constants";
 import { LocationCoverImage } from "@/components/ui/lazy-image";
+import { formatRouteMetric, normalizeLocationHiking } from "@/components/features/location-detail/route-utils";
 
 function ShimmerCard() {
   return (
@@ -26,8 +27,11 @@ function ShimmerCard() {
 }
 
 function LocationCard({ location, index }: { location: Location; index: number }) {
-  const { t } = useI18n(["locations", "common"]);
-  const route = location.routes?.[0];
+  const { t } = useI18n(["locations", "common", "locationDetail"]);
+  // task #152 切源：徒步参数读 location 自身字段（0010 回填），不再读 routes[0]
+  const hiking = normalizeLocationHiking(location);
+  const durationText = formatRouteMetric(hiking?.duration, t);
+  const distanceText = hiking?.distance?.value;
   const delayMs = Math.min(index, 5) * 60;
 
   return (
@@ -63,18 +67,18 @@ function LocationCard({ location, index }: { location: Location; index: number }
             <h3 className="font-bold text-white text-lg leading-tight drop-shadow-sm">
               {location.name}
             </h3>
-            {route && (
+            {(durationText || distanceText) && (
               <div className="flex items-center gap-3 mt-1.5 text-white/75 text-xs">
-                {route.duration && (
+                {durationText && (
                   <span className="flex items-center gap-1">
                     <Clock className="w-3 h-3" />
-                    {route.duration}
+                    {durationText}
                   </span>
                 )}
-                {route.distance && (
+                {distanceText && (
                   <span className="flex items-center gap-1">
                     <TrendingUp className="w-3 h-3" />
-                    {route.distance}
+                    {distanceText}
                   </span>
                 )}
               </div>

--- a/frontend/src/components/features/team-detail/team-detail-content.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-content.tsx
@@ -4,6 +4,7 @@ import { useTeamDetail } from "./use-team-detail";
 import { getStatusInfo } from "./team-detail-utils";
 import { MemberAvatarGrid } from "./team-detail-members";
 import { TeamActivityPosts } from "@/components/features/activity-posts";
+import { formatRouteMetric, normalizeLocationHiking } from "@/components/features/location-detail/route-utils";
 import type { Location, Team } from "@/lib/types";
 
 export function TeamMainContent({ ctx }: { ctx: ReturnType<typeof useTeamDetail>; }) {
@@ -92,20 +93,24 @@ function LocationCover({ location, statusInfo }: { location: Location; statusInf
 }
 
 function LocationRouteInfo({ location }: { location: Location; }) {
-  const route = location.routes?.[0];
-  if (!route) return null;
+  const { t } = useI18n(["locationDetail"]);
+  // task #152 切源：徒步参数读 location 自身字段（0010 回填），不再读 routes[0]
+  const hiking = normalizeLocationHiking(location);
+  const durationText = formatRouteMetric(hiking?.duration, t);
+  const distanceText = hiking?.distance?.value;
+  if (!durationText && !distanceText) return null;
   return (
     <div className="flex items-center gap-4 text-white/70 text-sm mb-3">
-      {route.duration && (
+      {durationText && (
         <span className="flex items-center gap-1">
           <Clock className="w-4 h-4" />
-          {route.duration}
+          {durationText}
         </span>
       )}
-      {route.distance && (
+      {distanceText && (
         <span className="flex items-center gap-1">
           <TrendingUp className="w-4 h-4" />
-          {route.distance}
+          {distanceText}
         </span>
       )}
     </div>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -34,8 +34,11 @@ export interface Location {
   cityName: string;
   difficulty?: "easy" | "moderate" | "hard" | "expert";
   duration?: string;
-  distance?: string;
-  elevation?: string;
+  /** task #152：徒步参数扁平化到 location（API 下发 number，单位：分钟/公里/米） */
+  durationMin?: number | null;
+  durationMax?: number | null;
+  distance?: string | number | null;
+  elevation?: string | number | null;
   equipmentNeeded?: string[];
   bestSeason: string[];
   coverImage: string;
@@ -48,6 +51,13 @@ export interface Location {
     facilities?: string[];  // ["parking", "restroom", "water", "food"]
     tips?: string | string[];
     warnings?: string[];
+    /** task #152：主路线攻略回填（0011 迁移），缺省字段为显式 null，按 falsy 隐藏 */
+    hiking?: {
+      overview?: string | null;
+      tips?: string[] | null;
+      equipmentNeeded?: string[] | null;
+      warnings?: string[] | null;
+    } | null;
   };
 
   // 关联的路线数组


### PR DESCRIPTION
## 改动范围

task #152（gomate 简化系列 Phase 2，依赖 #151/#159/0011 均已合并）。

**API（4 处切源，routes join 全部移除）**
- `api/src/routes/locations/queries.ts`：卡片视图改读 location 的 difficulty/durationMin/durationMax/distance/elevation；保留 `routes[0]` 兼容镜像（同 5 键、源自 location 列），现有消费方不破。全量列表同步切源。
- `api/src/routes/teams/queries.ts`：`?difficulty=` 过滤改查 `locations.difficulty`；count/rows 查询去掉 routes join；team 详情 location 对象补 5 字段；teams 列表 location 输出补 difficulty。

**前端**
- `route-info-card.tsx`：重写为「徒步攻略」区块（方案 A 定稿）——标题 + 4 参数 tiles（location 字段）+ overview 段 + tips/装备/注意事项 notes（extra.hiking，0011 已回填）；4 参数全 NULL 且无 hiking 时整区块不渲染。
- `route-utils.ts`：新增 `normalizeLocationHiking` / `formatRouteMetric`。
- home 卡片、locations 网格卡片、team 详情 LocationRouteInfo 同步切源。
- 建队推荐时长改由 location 参数推导（durationMin/Max 均值 → durationMin → difficulty 映射）。
- i18n：`locations.routeInfo` 三语言改「徒步攻略 / Hiking Guide / ハイキング攻略」。

## 预期内的可见变化（不是回归）

1. **卡片时长行恢复显示**：此前 `route.duration` 从未被任何 API 响应填充，时长行只渲染图标或空白；切源后显示真实时长。
2. **TeamCard 难度 badge 首次生效**：此前 formatTeams 从未 select difficulty，badge 是死代码；本次 teams 列表 location 输出补 difficulty 后恢复渲染。

## 验证

- API：`pnpm vitest run` 220/220 PASS（新增「task #152 切源」用例：卡片 5 字段 + routes[0] 镜像、全量列表 difficulty 经干扰路线证伪、teams ?difficulty= 按 location 过滤、team 详情 5 字段）
- 前端：`tsc --noEmit` 干净、`vitest` 108/108 PASS、eslint 干净
- i18n 门禁 `validate-i18n-keys.mjs`：0 errors / 0 warnings
- 无 DB 变更（0010/0011 迁移已先行合并）

## Wen 需验证场景（线上回归）

1. 地点详情页「徒步攻略」区块：有参数/攻略的地点正常渲染 4 tiles + overview + notes；无数据地点整区块不出现。
2. 首页 / locations 列表卡片：时长、距离行显示真实数据（与详情页一致）。
3. 队伍列表卡片：难度 badge 显示（此前没有，是新增）。
4. 队伍详情页顶部：时长/距离行正常。
5. 建队流程：选地点后推荐时长自动填入，可手动覆盖。
6. /teams?difficulty= 过滤结果与地点详情页难度一致。
7. 三语言切换下「徒步攻略」标题正确。

## 风险与回滚

- 风险：低。纯读路径切源 + 前端展示改造；`routes[0]` 镜像保底卡片消费方。
- 回滚：revert 本 PR 即可，无数据迁移依赖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)