### PR TITLE
feat: i18n 门禁覆盖 ja + 难度标签统一 enums.json + ns 静态检查 (task #158)

### DIFF
--- a/frontend/public/locales/ja/common.json
+++ b/frontend/public/locales/ja/common.json
@@ -150,5 +150,10 @@
   "footer": {
     "expand": "展開",
     "collapse": "折りたたむ"
-  }
+  },
+  "share": "シェア",
+  "optional": "（任意）",
+  "languageChangedTo": "言語を{lang}に切り替えました",
+  "selectLanguage": "言語を選択",
+  "close": "閉じる"
 }

--- a/frontend/public/locales/ja/content.json
+++ b/frontend/public/locales/ja/content.json
@@ -340,7 +340,40 @@
       "removeTag": "{tag} タグを削除",
       "submit": "ストーリーを投稿",
       "submitting": "投稿中...",
-      "submitFailed": "ストーリーの投稿に失敗しました"
+      "submitFailed": "ストーリーの投稿に失敗しました",
+      "coverPlaceholder": "クリックしてカバー画像をアップロード",
+      "coverEmptyTitle": "カバーをアップロード（任意）",
+      "coverEmptyHint": "アップロードしない場合はデフォルトスタイルで表示されます"
+    },
+    "edit": {
+      "titlePlaceholder": "ストーリータイトル",
+      "summaryPlaceholder": "短い説明...",
+      "contentPlaceholder": "Markdownでストーリーを書いてください...",
+      "statusLabel": "ステータス",
+      "statusPublished": "公開済み",
+      "statusDraft": "下書き",
+      "coverFormatHint": "JPG/PNG、≤2MB",
+      "locationSearchPlaceholder": "場所を検索...",
+      "removeLocation": "関連場所を削除",
+      "tagsCountHint": "{count}/10 まで",
+      "draftBanner": "未保存の下書きが検出されました",
+      "restoreDraft": "下書きを復元",
+      "discardDraft": "破棄",
+      "cancelTitle": "編集を破棄しますか？",
+      "cancelDesc": "現在の変更は保存されません",
+      "continueEditing": "編集を続ける",
+      "discardConfirm": "破棄",
+      "expandMore": "さらに表示（ステータス/カバー/場所/タグ）",
+      "collapseMore": "折りたたむ",
+      "saveSuccess": "保存しました",
+      "saveFailed": "保存に失敗しました",
+      "saveNetworkError": "保存に失敗しました：ネットワークエラー",
+      "saveRetry": "再試行",
+      "coverTooLarge": "画像は2MB以下にしてください",
+      "coverTypeError": "JPGまたはPNG形式のみ対応しています",
+      "errorBoundaryTitle": "ページでエラーが発生しました",
+      "errorBoundaryDesc": "変更はローカル下書きとして自動保存されている可能性があります。再読み込み後に復元できます",
+      "errorBoundaryReload": "再読み込み"
     }
   },
   "title": "GoMate - スポットを発見し、チームで同行",
@@ -369,6 +402,9 @@
     "help": "ヘルプセンター",
     "privacy": "プライバシーポリシー",
     "terms": "利用規約",
-    "adminLocations": "スポットを管理"
-  }
+    "adminLocations": "スポットを管理",
+    "storyCreate": "ストーリーを公開 - GoMate",
+    "storyEdit": "ストーリーを編集 - GoMate"
+  },
+  "writeStories": "Markdownでストーリーを書いてください..."
 }

--- a/frontend/src/components/features/home/home-location-card.tsx
+++ b/frontend/src/components/features/home/home-location-card.tsx
@@ -18,7 +18,7 @@ interface LocationCardProps {
  * 仅当 location.id 变化时重新渲染
  */
 export const LocationCard = memo(function LocationCard({ location, index = 0 }: LocationCardProps) {
-  const { t } = useI18n(["locations", "locationDetail"]);
+  const { t } = useI18n(["locations", "locationDetail", "enums"]);
   // task #152 切源：徒步参数读 location 自身字段（0010 回填），不再读 routes[0]
   const difficulty = location.difficulty;
   const diffConfig = difficulty ? DIFFICULTY_CONFIG[difficulty as keyof typeof DIFFICULTY_CONFIG] : null;
@@ -77,7 +77,7 @@ export const LocationCard = memo(function LocationCard({ location, index = 0 }: 
 
           <div className="absolute top-3 right-3 flex flex-col gap-1.5 items-end">
             {diffConfig && (
-              <span className="px-2.5 py-1 rounded-full text-xs font-semibold" style={{ background: diffConfig.bg, color: diffConfig.color, backdropFilter: "blur(4px)" }}>{diffConfig.label}</span>
+              <span className="px-2.5 py-1 rounded-full text-xs font-semibold" style={{ background: diffConfig.bg, color: diffConfig.color, backdropFilter: "blur(4px)" }}>{t(diffConfig.labelKey)}</span>
             )}
             {firstTag && (
               <span className="px-2.5 py-1 rounded-full text-xs font-medium" style={{ background: "rgba(255,255,255,0.90)", color: "#92400E", backdropFilter: "blur(4px)" }}>{firstTag.name}</span>

--- a/frontend/src/components/features/location-detail/constants.tsx
+++ b/frontend/src/components/features/location-detail/constants.tsx
@@ -1,9 +1,9 @@
 
-// ─── 难度配置 ─────────────────────────────────────────────────────────────────
+// ─── 难度配置（labelKey 为 i18n key，样式字段供 route-info-card 使用）─────────────────────────────────────────────────────────────────
 export const DIFFICULTY_CONFIG: Record<
   string,
   {
-    label: string;
+    labelKey: string;
     barColor: string;
     textColor: string;
     bgColor: string;
@@ -12,7 +12,7 @@ export const DIFFICULTY_CONFIG: Record<
   }
 > = {
   easy: {
-    label: "enums.difficulty.easy",
+    labelKey: "enums.difficulty.easy",
     barColor: "bg-emerald-400",
     textColor: "text-emerald-700 dark:text-emerald-400",
     bgColor: "bg-emerald-50 dark:bg-emerald-950/30",
@@ -20,7 +20,7 @@ export const DIFFICULTY_CONFIG: Record<
     ringColor: "ring-emerald-200 dark:ring-emerald-800",
   },
   moderate: {
-    label: "enums.difficulty.moderate",
+    labelKey: "enums.difficulty.moderate",
     barColor: "bg-amber-400",
     textColor: "text-amber-700 dark:text-amber-400",
     bgColor: "bg-amber-50 dark:bg-amber-950/30",
@@ -28,7 +28,7 @@ export const DIFFICULTY_CONFIG: Record<
     ringColor: "ring-amber-200 dark:ring-amber-800",
   },
   hard: {
-    label: "enums.difficulty.hard",
+    labelKey: "enums.difficulty.hard",
     barColor: "bg-orange-500",
     textColor: "text-orange-700 dark:text-orange-400",
     bgColor: "bg-orange-50 dark:bg-orange-950/30",
@@ -36,7 +36,7 @@ export const DIFFICULTY_CONFIG: Record<
     ringColor: "ring-orange-200 dark:ring-orange-800",
   },
   expert: {
-    label: "enums.difficulty.expert",
+    labelKey: "enums.difficulty.expert",
     barColor: "bg-red-500",
     textColor: "text-red-700 dark:text-red-400",
     bgColor: "bg-red-50 dark:bg-red-950/30",

--- a/frontend/src/components/features/teams/teams-ui.tsx
+++ b/frontend/src/components/features/teams/teams-ui.tsx
@@ -82,7 +82,7 @@ export function StatusBadge({ status }: { status: string }) {
 
 // ─── TeamCard ───────────────────────────────────────────────────────
 export const TeamCard = React.memo(function TeamCard({ team }: { team: Team }) {
-  const { t } = useI18n(["teams", "filter", "common"]);
+  const { t } = useI18n(["teams", "filter", "common", "enums"]);
   const location = team.location;
   const diff = location?.difficulty ? DIFFICULTY_CONFIG[location.difficulty as keyof typeof DIFFICULTY_CONFIG] : null;
   const gradient = getCardGradient(team.id);
@@ -116,7 +116,7 @@ export const TeamCard = React.memo(function TeamCard({ team }: { team: Team }) {
               <MapPin className="h-3.5 w-3.5 flex-shrink-0 text-amber-500" />
               <span className="text-sm font-semibold text-foreground">
                 {location.name}
-                {diff && <span className="text-muted-foreground font-normal"><span className="mx-1">·</span>{diff.emoji} {diff.label}</span>}
+                {diff && <span className="text-muted-foreground font-normal"><span className="mx-1">·</span>{t(diff.labelKey)}</span>}
               </span>
             </div>
           )}
@@ -228,7 +228,7 @@ export function FilterPanel({
   startDate, endDate, selectedDifficulty, availableTags, selectedTags, activeFiltersCount, activeDateQuickType,
   onDateQuickSelect, onDifficultyToggle, onTagToggle, onClearAll,
 }: FilterPanelProps) {
-  const { t } = useI18n(["teams", "filter", "common"]);
+  const { t } = useI18n(["teams", "filter", "common", "enums"]);
   return (
     <div className="mt-4 pt-4 pb-1 border-t border-border space-y-4 animate-in slide-in-from-top-2 duration-200">
       <div>
@@ -271,7 +271,7 @@ export function FilterPanel({
                 className={cn("px-3 py-1.5 text-xs rounded-full border transition-all duration-200 active:scale-95",
                   isSelected ? opt.activeColor : "bg-card text-stone-600 dark:text-stone-400 border-border hover:border-stone-300 dark:hover:border-stone-600"
                 )}>
-                {opt.emoji} {opt.label}
+                {t(opt.labelKey)}
               </button>
             );
           })}

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -10,10 +10,12 @@ export type TeamStatus = "recruiting" | "full" | "formed" | "cancelled" | "compl
 export type Difficulty = "easy" | "moderate" | "hard" | "expert";
 
 // 难度配置（全局统一）
+// task #158：标签统一以 enums.json 为唯一出处（Steven 定稿），此处只留 labelKey + 样式，
+// 渲染处用 t(config.labelKey) 取多语言文案（enums 值自带 emoji，无需再拼 config.emoji）
 export const DIFFICULTY_CONFIG: Record<
   Difficulty,
   {
-    label: string;
+    labelKey: string;
     emoji: string;
     badgeColor: string;
     bg: string;
@@ -22,7 +24,7 @@ export const DIFFICULTY_CONFIG: Record<
   }
 > = {
   easy: {
-    label: "轻松",
+    labelKey: "enums.difficulty.easy",
     emoji: "🌿",
     badgeColor: "bg-amber-500/80 text-white",
     bg: "rgba(217,119,6,0.85)",
@@ -30,7 +32,7 @@ export const DIFFICULTY_CONFIG: Record<
     activeColor: "bg-amber-600 border-amber-600 text-white",
   },
   moderate: {
-    label: "适中",
+    labelKey: "enums.difficulty.moderate",
     emoji: "⛰",
     badgeColor: "bg-amber-500/80 text-white",
     bg: "rgba(217,119,6,0.88)",
@@ -38,7 +40,7 @@ export const DIFFICULTY_CONFIG: Record<
     activeColor: "bg-amber-500 border-amber-500 text-white",
   },
   hard: {
-    label: "困难",
+    labelKey: "enums.difficulty.hard",
     emoji: "🧗",
     badgeColor: "bg-orange-500/80 text-white",
     bg: "rgba(255,122,101,0.90)",
@@ -46,7 +48,7 @@ export const DIFFICULTY_CONFIG: Record<
     activeColor: "bg-orange-500 border-orange-500 text-white",
   },
   expert: {
-    label: "专家",
+    labelKey: "enums.difficulty.expert",
     emoji: "🏔",
     badgeColor: "bg-red-500/80 text-white",
     bg: "rgba(109,40,217,0.85)",
@@ -55,11 +57,11 @@ export const DIFFICULTY_CONFIG: Record<
   },
 };
 
-// 难度选项（用于筛选面板）
+// 难度选项（用于筛选面板，label 渲染处 t(labelKey)）
 export const DIFFICULTY_OPTIONS = Object.entries(DIFFICULTY_CONFIG).map(([id, config]) => ({
   id,
   emoji: config.emoji,
-  label: config.label,
+  labelKey: config.labelKey,
   activeColor: config.activeColor,
 }));
 

--- a/frontend/src/pages/discover/[id].astro
+++ b/frontend/src/pages/discover/[id].astro
@@ -7,7 +7,7 @@ import { StoryDetail } from "../../components/features/discover-client";
 import { declareI18nNs } from "../../middleware";
 import { API_BASE } from "../../lib/api";
 
-declareI18nNs(Astro.locals, ["content", "common"]);
+declareI18nNs(Astro.locals, ["content", "common", "teams", "share"]);
 
 const { id } = Astro.params;
 

--- a/frontend/src/pages/locations/[id].astro
+++ b/frontend/src/pages/locations/[id].astro
@@ -9,7 +9,7 @@ import { ErrorBoundary } from "../../components/ui/error-boundary";
 import { declareI18nNs } from "../../middleware";
 import { API_BASE } from "../../lib/api";
 
-declareI18nNs(Astro.locals, ["locationDetail", "locations", "errors", "admin", "enums", "content"]);
+declareI18nNs(Astro.locals, ["locationDetail", "locations", "errors", "admin", "enums", "teams", "content"]);
 
 const { id } = Astro.params;
 

--- a/frontend/src/pages/profile/index.astro
+++ b/frontend/src/pages/profile/index.astro
@@ -6,7 +6,7 @@ import Layout from "../../layouts/Layout.astro";
 import { ProfileClient } from "../../components/features/profile-client";
 import { declareI18nNs } from "../../middleware";
 
-declareI18nNs(Astro.locals, ["profile", "content"]);
+declareI18nNs(Astro.locals, ["profile", "enums", "content"]);
 ---
 
 <Layout title="个人资料 - GoMate" showNavbar={false} showFooter={false}>

--- a/frontend/src/pages/teams/[id].astro
+++ b/frontend/src/pages/teams/[id].astro
@@ -8,7 +8,7 @@ import { TeamDetailPartiful } from "../../components/features/team-detail-partif
 import { declareI18nNs } from "../../middleware";
 import { API_BASE } from "../../lib/api";
 
-declareI18nNs(Astro.locals, ["teams", "locationDetail", "enums", "profile", "content"]);
+declareI18nNs(Astro.locals, ["teams", "locationDetail", "enums", "profile", "errors", "content"]);
 
 const { id } = Astro.params;
 

--- a/frontend/src/pages/teams/[id]/edit.astro
+++ b/frontend/src/pages/teams/[id]/edit.astro
@@ -6,7 +6,7 @@ import Layout from "../../../layouts/Layout.astro";
 import { EditTeamClient } from "../../../components/features/edit-team-client";
 import { declareI18nNs } from "../../../middleware";
 
-declareI18nNs(Astro.locals, ["teams", "content"]);
+declareI18nNs(Astro.locals, ["teams", "errors", "content"]);
 
 const { id } = Astro.params;
 ---

--- a/frontend/src/pages/teams/create.astro
+++ b/frontend/src/pages/teams/create.astro
@@ -6,7 +6,7 @@ import Layout from "../../layouts/Layout.astro";
 import { CreateTeamClient } from "../../components/features/create-team-client";
 import { declareI18nNs } from "../../middleware";
 
-declareI18nNs(Astro.locals, ["teams", "content"]);
+declareI18nNs(Astro.locals, ["teams", "errors", "content"]);
 ---
 
 <Layout title="创建队伍 - GoMate" showNavbar={false} showFooter={false}>

--- a/frontend/src/pages/teams/index.astro
+++ b/frontend/src/pages/teams/index.astro
@@ -10,7 +10,7 @@ import { getDateRangeByQuickType } from "../../lib/date-beijing";
 import type { TeamsInitialData } from "../../components/features/teams/use-teams";
 import type { Team } from "../../lib/types";
 
-declareI18nNs(Astro.locals, ["teams", "filter", "content"]);
+declareI18nNs(Astro.locals, ["teams", "filter", "enums", "content"]); // task #158：TeamCard/FilterPanel 难度标签走 enums
 
 async function fetchJson<T>(path: string): Promise<T | null> {
   try {

--- a/scripts/validate-i18n-keys.mjs
+++ b/scripts/validate-i18n-keys.mjs
@@ -90,6 +90,132 @@ function loadJSON(filePath) {
   }
 }
 
+// ─── Check 5 helpers: island ns coverage ────────────────────────────────────
+
+const SRC_DIR = path.join(PROJECT_ROOT, "frontend", "src");
+const PAGES_DIR = path.join(SRC_DIR, "pages");
+// Layout.astro 对每页固定加载的基座 ns（见 Layout.astro nsList 拼接）
+const BASE_NS = ["nav", "common", "content"];
+const RESOLVE_EXTS = ["", ".tsx", ".ts", ".jsx", ".js", "/index.tsx", "/index.ts"];
+
+function walkAstroPages(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkAstroPages(full));
+    else if (entry.name.endsWith(".astro")) out.push(full);
+  }
+  return out;
+}
+
+/** 解析 import 来源到文件路径（@/ → src/，相对路径基于 fromFile） */
+function resolveImport(spec, fromFile) {
+  let base;
+  if (spec.startsWith("@/")) base = path.join(SRC_DIR, spec.slice(2));
+  else if (spec.startsWith(".")) base = path.resolve(path.dirname(fromFile), spec);
+  else return null; // 包导入不跟踪
+  for (const ext of RESOLVE_EXTS) {
+    const candidate = base + ext;
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate;
+  }
+  return null;
+}
+
+/** 提取文件中的静态 import / export-from 来源（regex 级，够用于组件树追踪） */
+function extractImportSpecs(code) {
+  const specs = [];
+  const re = /(?:import|export)[^'"]*?from\s*["']([^"']+)["']/g;
+  let m;
+  while ((m = re.exec(code))) specs.push(m[1]);
+  return specs;
+}
+
+/** 提取 useI18n([...]) 字面量数组里的 ns 列表（先剥注释，防 JSDoc 示例误匹配） */
+function extractUseI18nNs(code) {
+  const stripped = code.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+  const ns = new Set();
+  const re = /useI18n\(\s*\[([^\]]*)\]/g;
+  let m;
+  while ((m = re.exec(stripped))) {
+    for (const item of m[1].split(",")) {
+      const v = item.trim().replace(/^["']|["']$/g, "");
+      if (v) ns.add(v);
+    }
+  }
+  return ns;
+}
+
+/**
+ * 对每个页面：island 入口（带 client:* 指令的组件）传递闭包内所有
+ * useI18n ns 必须 ⊆ declareI18nNs ∪ BASE_NS。
+ */
+function checkIslandNsCoverage() {
+  let errCount = 0;
+  const pages = walkAstroPages(PAGES_DIR);
+
+  for (const page of pages) {
+    const code = fs.readFileSync(page, "utf-8");
+    const relPage = path.relative(PROJECT_ROOT, page);
+
+    // 页面声明（可多次调用，合并）
+    const declared = new Set(BASE_NS);
+    const declRe = /declareI18nNs\(\s*Astro\.locals\s*,\s*\[([^\]]*)\]/g;
+    let dm;
+    while ((dm = declRe.exec(code))) {
+      for (const item of dm[1].split(",")) {
+        const v = item.trim().replace(/^["']|["']$/g, "");
+        if (v) declared.add(v);
+      }
+    }
+
+    // island 入口组件：带 client: 指令的大写标签
+    const islandNames = new Set();
+    const islandRe = /<([A-Z][A-Za-z0-9]*)[^>]*?client:(?:load|visible|idle|only|media)/g;
+    let im;
+    while ((im = islandRe.exec(code))) islandNames.add(im[1]);
+
+    // 组件名 → import 来源
+    const entryFiles = [];
+    const importRe = /import\s+(?:([A-Z][A-Za-z0-9]*)\s*,?|\{([^}]*)\})\s*(?:[A-Z][A-Za-z0-9]*\s*,?\s*)?from\s*["']([^"']+)["']/g;
+    let nm;
+    while ((nm = importRe.exec(code))) {
+      const names = [];
+      if (nm[1]) names.push(nm[1]);
+      if (nm[2]) names.push(...nm[2].split(",").map((s) => s.trim().split(/\s+as\s+/).pop()).filter(Boolean));
+      if (names.some((n) => islandNames.has(n))) {
+        const resolved = resolveImport(nm[3], page);
+        if (resolved) entryFiles.push(resolved);
+      }
+    }
+
+    // BFS 传递闭包，收集 useI18n ns
+    const visited = new Set();
+    const queue = [...entryFiles];
+    const usedNs = new Map(); // ns -> first file using it
+    while (queue.length) {
+      const file = queue.shift();
+      if (visited.has(file) || !file.endsWith(".tsx") && !file.endsWith(".ts")) continue;
+      visited.add(file);
+      const fcode = fs.readFileSync(file, "utf-8");
+      for (const ns of extractUseI18nNs(fcode)) {
+        if (!usedNs.has(ns)) usedNs.set(ns, path.relative(PROJECT_ROOT, file));
+      }
+      for (const spec of extractImportSpecs(fcode)) {
+        const resolved = resolveImport(spec, file);
+        if (resolved && !visited.has(resolved)) queue.push(resolved);
+      }
+    }
+
+    for (const [ns, usedIn] of usedNs) {
+      if (!declared.has(ns)) {
+        log("error", `${relPage}: island 使用 ns "${ns}"（${usedIn}）但页面未 declareI18nNs`);
+        errCount++;
+      }
+    }
+  }
+  return errCount;
+}
+
 function main() {
   console.log("=== i18n Key Validation ===\n");
 
@@ -198,6 +324,15 @@ function main() {
   }
   if (emptyCount === 0) {
     console.log("  ✓ No empty or null values");
+  }
+
+  // ── Check 5: Island Namespace Coverage ──
+  // task #158：island 组件树里 useI18n 声明的 ns 必须 ⊆ 页面 declareI18nNs ∪ 基座三件套，
+  // 否则 SSR 数据缺口导致 hydration mismatch（task #162 事故的静态防线）。
+  console.log("\n── Island Namespace Coverage ──");
+  const nsErrors = checkIslandNsCoverage();
+  if (nsErrors === 0) {
+    console.log("  ✓ All island namespaces covered by page declarations");
   }
 
   // ── Summary ──

--- a/scripts/validate-i18n-keys.mjs
+++ b/scripts/validate-i18n-keys.mjs
@@ -18,7 +18,8 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = path.resolve(__dirname, "..");
 const LOCALES_DIR = path.join(PROJECT_ROOT, "frontend", "public", "locales");
-const LOCALES = ["zh-CN", "en"];
+// task #158：ja 纳入 key 一致性校验（此前仅 zh-CN/en，漏 ja 的 key  CI 不拦截）
+const LOCALES = ["zh-CN", "en", "ja"];
 const BASE_LOCALE = "zh-CN";
 
 let errors = 0;


### PR DESCRIPTION
## 改动范围

三个 i18n 加固项（Martin 合并排期），三个独立 commit：

### ① i18n 门禁覆盖 ja（`5bd3b51`）
- `validate-i18n-keys.mjs` LOCALES `[zh-CN, en]` → `[zh-CN, en, ja]`——此前三 locale 产品里 ja 完全不受 key 一致性校验（PR #376 漏 ja draftBadge 即因此 CI 未拦截）
- 补齐 ja 历史缺失 39 key：common 5 + content 34（discover.edit 草稿/状态/错误提示系列为主），按 zh/en 语义翻译

### ② 难度标签统一 enums.json 唯一出处（`51a6ded`，Steven 定稿）
- 问题：teams 页 `DIFFICULTY_CONFIG` 硬编码中文（hard=「困难」）vs enums.json（hard=「挑战」）vs 详情页 enums key——同一难度三个出处两个名字，且英文界面仍显示中文
- Steven 口径：enums.json 为唯一出处（取「挑战」，改动面最小，prod 附录文本和详情页本就用这套）
- `DIFFICULTY_CONFIG/OPTIONS`：label → labelKey，只留样式；三处消费点（首页位置卡 badge / TeamCard badge / 筛选按钮）改 `t(labelKey)`；enums 值自带 emoji，去掉渲染处 emoji 前缀拼接
- `useI18n` + `declareI18nNs` 补 enums（teams 页）
- **注意（需 Steven 知情）**：首页位置卡难度 badge 文案从「适中」变为「⛰ 适中」（enums 值自带 emoji），与详情页/teams 页展示一致

### ③ ns 静态检查（`29d9f92`，Martin 建议）
- `validate-i18n-keys.mjs` 新增 Check 5「Island Namespace Coverage」：island 入口组件传递闭包内所有 `useI18n` ns 必须 ⊆ 页面 `declareI18nNs` ∪ 基座三件套（nav/common/content），失配即 fail——task #162 hydration 事故类的静态防线
- 挂在既有 `i18n:validate` 命令里，**无 CI 配置变更**
- 首次运行抓出 7 处真实声明缺口并修复：discover/[id] +teams +share、locations/[id] +teams、profile/index +enums、teams/[id] +errors、teams/[id]/edit +errors、teams/create +errors

## 验证

- `node scripts/validate-i18n-keys.mjs`：五项检查全过（Errors 0）
- `pnpm type-check`（astro check）：0 errors
- `pnpm vitest run`：109/109 PASS
- `pnpm build`：成功
- 本地 dev SSR 实测：/teams 筛选按钮 zh「🌿 轻松/⛰ 适中/🧗 挑战/🏔 专家」、en「Easy/Moderate/Challenging/Expert」正确渲染（此前 en 界面显示中文）

## Wen 需验证场景

1. **teams 页筛选按钮**：zh 四档「轻松/适中/挑战/专家」（hard 从「困难」变「挑战」）；en 界面按钮显示英文（此前是中文，属 bug 修复）
2. **TeamCard 难度 badge**：「地点·⛰ 适中」格式不变，标签与筛选按钮同源
3. **首页位置卡难度 badge**：文案带 emoji（「⛰ 适中」），与详情页一致——这是有意的视觉统一
4. **三页 console 无 hydration error**（teams / 首页 / locations 详情）——ns 声明补齐后的回归确认
5. 桌面+移动断点抽查即可，无布局改动

## 风险与回滚

- 低风险：纯前端 i18n/文案层，无 API/schema/数据变更
- 回滚：revert 三个 commit 即可，无状态依赖