### PR TITLE
docs: 沉淀本地全栈测试环境配方（Wen 验收路径）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,15 @@ lsof -ti:5432
 - API：`http://localhost:8799`
 - 前端：`http://localhost:5432`
 
+### 本地全栈测试环境（数据对齐 prod，Wen 验收配方）
+
+需要本地数据与 prod 对齐做验收时（而非空库/纯 seed）：
+
+1. API 用 `wrangler dev` 起本地 D1（需要 `api/.dev.vars`，gitignored，找团队索取，勿入库）
+2. 同步 prod 地点数据：`cd api && tsx db/sync-locations.ts`（从远程 API 拉 cities/locations/tags 写本地 D1）
+3. 本地注册 QA 用户；需要微信号字段的用例用 `PATCH /api/users/me` 补 wechat
+4. 前端必须跑 `5432`——API 的 CORS 白名单只放行该端口，其他端口（如 5436）会被拒
+
 ## 架构入口
 
 API：


### PR DESCRIPTION
## 改动范围

AGENTS.md 新增「本地全栈测试环境（数据对齐 prod，Wen 验收配方）」一节——PR #386 验收中 Wen 跑通的路径，随会话易丢失，按 Martin 建议沉淀：

1. API 用 `wrangler dev` 起本地 D1（需 `api/.dev.vars`，gitignored）
2. `tsx db/sync-locations.ts` 从远程 API 同步 prod cities/locations/tags 到本地 D1
3. 本地注册 QA 用户 + `PATCH /api/users/me` 补 wechat 字段
4. 前端必须跑 5432（API CORS 白名单只放行该端口）

纯文档，无代码变更。