### PR TITLE
fix: 编辑页草稿 shape 校验 + error.code 映射 i18n + 建队 nit 两项 (task #157)

### DIFF
--- a/frontend/public/locales/en/content.json
+++ b/frontend/public/locales/en/content.json
@@ -373,7 +373,8 @@
       "coverTypeError": "Only JPG or PNG images are supported",
       "errorBoundaryTitle": "Something went wrong",
       "errorBoundaryDesc": "Your changes may have been auto-saved as a local draft. Reload the page to restore them.",
-      "errorBoundaryReload": "Reload"
+      "errorBoundaryReload": "Reload",
+      "draftInvalid": "The local draft was corrupted and has been discarded. Please re-edit based on the current content."
     }
   },
   "title": "GoMate - Discover Places, Team Up Together",

--- a/frontend/public/locales/en/errors.json
+++ b/frontend/public/locales/en/errors.json
@@ -69,5 +69,6 @@
   "getTeamDetailFailed": "Failed to get team details",
   "networkRetry": "Network error, please try again later",
   "getStatusFailed": "Failed to get status",
-  "fetchApplicationsFailed": "Failed to get application list"
+  "fetchApplicationsFailed": "Failed to get application list",
+  "validationFailed": "Validation failed. Please check your input."
 }

--- a/frontend/public/locales/en/teams.json
+++ b/frontend/public/locales/en/teams.json
@@ -441,5 +441,6 @@
   "posterMemberCount": "{current}/{max} people",
   "posterLeaderLabel": "Leader",
   "posterQrHint": "Scan to join team",
-  "posterGeneratingDesc": "Generating beautiful poster..."
+  "posterGeneratingDesc": "Generating beautiful poster...",
+  "durationRecommendedMarked": "(Recommended)"
 }

--- a/frontend/public/locales/ja/content.json
+++ b/frontend/public/locales/ja/content.json
@@ -373,7 +373,8 @@
       "coverTypeError": "JPGまたはPNG形式のみ対応しています",
       "errorBoundaryTitle": "ページでエラーが発生しました",
       "errorBoundaryDesc": "変更はローカル下書きとして自動保存されている可能性があります。再読み込み後に復元できます",
-      "errorBoundaryReload": "再読み込み"
+      "errorBoundaryReload": "再読み込み",
+      "draftInvalid": "ローカルの下書きが破損していたため破棄しました。現在の内容をもとに編集し直してください"
     }
   },
   "title": "GoMate - スポットを発見し、チームで同行",

--- a/frontend/public/locales/ja/errors.json
+++ b/frontend/public/locales/ja/errors.json
@@ -69,5 +69,6 @@
   "getTeamDetailFailed": "チーム詳細の取得に失敗しました",
   "networkRetry": "ネットワークエラー。後でもう一度お試しください",
   "getStatusFailed": "ステータスの取得に失敗しました",
-  "fetchApplicationsFailed": "申請リストの取得に失敗しました"
+  "fetchApplicationsFailed": "申請リストの取得に失敗しました",
+  "validationFailed": "入力検証に失敗しました。内容をご確認ください"
 }

--- a/frontend/public/locales/ja/teams.json
+++ b/frontend/public/locales/ja/teams.json
@@ -441,5 +441,6 @@
   "posterMemberCount": "{current}/{max}名",
   "posterLeaderLabel": "リーダー",
   "posterQrHint": "スキャンしてチームに参加",
-  "posterGeneratingDesc": "素敵なシェア画像を生成中..."
+  "posterGeneratingDesc": "素敵なシェア画像を生成中...",
+  "durationRecommendedMarked": "（推薦）"
 }

--- a/frontend/public/locales/zh-CN/content.json
+++ b/frontend/public/locales/zh-CN/content.json
@@ -373,7 +373,8 @@
       "coverTypeError": "仅支持 JPG 或 PNG 格式",
       "errorBoundaryTitle": "页面出现异常",
       "errorBoundaryDesc": "你的修改可能已自动保存为本地草稿，重新加载后可恢复",
-      "errorBoundaryReload": "重新加载"
+      "errorBoundaryReload": "重新加载",
+      "draftInvalid": "本地草稿已损坏，已自动丢弃，请基于当前内容重新编辑"
     }
   },
   "title": "GoMate - 发现趣处，组队同行",

--- a/frontend/public/locales/zh-CN/errors.json
+++ b/frontend/public/locales/zh-CN/errors.json
@@ -69,5 +69,6 @@
   "getTeamDetailFailed": "获取队伍详情失败",
   "networkRetry": "网络错误，请稍后重试",
   "getStatusFailed": "获取状态失败",
-  "fetchApplicationsFailed": "获取申请列表失败"
+  "fetchApplicationsFailed": "获取申请列表失败",
+  "validationFailed": "输入验证失败，请检查填写内容"
 }

--- a/frontend/public/locales/zh-CN/teams.json
+++ b/frontend/public/locales/zh-CN/teams.json
@@ -441,5 +441,6 @@
   "posterMemberCount": "{current}/{max} 人",
   "posterLeaderLabel": "领队",
   "posterQrHint": "扫码加入队伍",
-  "posterGeneratingDesc": "正在生成精美海报..."
+  "posterGeneratingDesc": "正在生成精美海报...",
+  "durationRecommendedMarked": "（推荐）"
 }

--- a/frontend/src/components/features/create-team-client.tsx
+++ b/frontend/src/components/features/create-team-client.tsx
@@ -13,7 +13,7 @@ import {
 } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import { fetchAPI, fetchCurrentUser } from "@/lib/api";
-import { DURATION_OPTION_VALUES, snapToDurationOption } from "@/lib/duration-options";
+import { DURATION_OPTION_DEFS, snapToDurationOption } from "@/lib/duration-options";
 import type { Location } from "@/lib/types";
 import { Navbar } from "@/components/layout/navbar";
 import { FieldGroup } from "@/components/ui/field-group";
@@ -354,7 +354,7 @@ export function CreateTeamClient() {
                   >
                     {getDurationOptions(t).map((opt) => (
                       <option key={opt.value} value={opt.value}>
-                        {opt.label} {recommendedDuration === opt.value ? `（${t("teams.durationRecommended")}）` : ""}
+                        {opt.label} {recommendedDuration === opt.value ? t("teams.durationRecommendedMarked") : ""}
                       </option>
                     ))}
                   </select>
@@ -483,13 +483,7 @@ export function CreateTeamClient() {
  * Build duration option labels with translation
  */
 function getDurationOptions(t: (key: string, vars?: Record<string, string | number>) => string) {
-  const labelKeys = [
-    "teams.duration1h", "teams.duration1_5h", "teams.duration2h", "teams.duration3h",
-    "teams.duration4h", "teams.duration5h", "teams.duration6h", "teams.duration7h",
-    "teams.duration8h", "teams.duration9h", "teams.duration10h", "teams.duration12h",
-    "teams.duration15h", "teams.duration20h",
-  ];
-  return DURATION_OPTION_VALUES.map((value, i) => ({ value, label: t(labelKeys[i]) }));
+  return DURATION_OPTION_DEFS.map(([value, key]) => ({ value, label: t(key) }));
 }
 
 

--- a/frontend/src/components/features/discover/use-story-form.test.ts
+++ b/frontend/src/components/features/discover/use-story-form.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { isValidDraftShape } from "./use-story-form";
+
+// task #157：损坏草稿恢复前 shape 校验（Steven 裁决：非法草稿丢弃并提示重新编辑）
+describe("isValidDraftShape（草稿 shape 校验）", () => {
+  it("合法草稿通过", () => {
+    expect(isValidDraftShape({ title: "标题", tags: ["徒步", "露营"] })).toBe(true);
+    expect(isValidDraftShape({})).toBe(true); // 空草稿对象合法（spread 无效果）
+    expect(
+      isValidDraftShape({
+        title: "t", summary: "s", content: "c", coverImage: "", locationId: "loc_1",
+        locationName: "梧桐山", tags: [], status: "draft", authorId: "u_1",
+      }),
+    ).toBe(true);
+  });
+
+  it("tags 非字符串数组 → 非法（Wen 实测的滑稽计数来源）", () => {
+    expect(isValidDraftShape({ tags: "徒步" })).toBe(false);
+    expect(isValidDraftShape({ tags: { 0: "徒步" } })).toBe(false);
+    expect(isValidDraftShape({ tags: [1, 2] })).toBe(false);
+    expect(isValidDraftShape({ tags: null })).toBe(false);
+  });
+
+  it("字符串字段类型错 → 非法", () => {
+    expect(isValidDraftShape({ title: 123 })).toBe(false);
+    expect(isValidDraftShape({ content: {} })).toBe(false);
+    expect(isValidDraftShape({ status: ["draft"] })).toBe(false);
+  });
+
+  it("混入未知字段 → 非法（spread 会污染 form state）", () => {
+    expect(isValidDraftShape({ title: "t", hacker: "x" })).toBe(false);
+  });
+
+  it("非对象 → 非法", () => {
+    expect(isValidDraftShape(null)).toBe(false);
+    expect(isValidDraftShape("draft")).toBe(false);
+    expect(isValidDraftShape([1, 2])).toBe(false);
+    expect(isValidDraftShape(42)).toBe(false);
+  });
+});

--- a/frontend/src/components/features/discover/use-story-form.ts
+++ b/frontend/src/components/features/discover/use-story-form.ts
@@ -75,6 +75,28 @@ export interface UseStoryFormReturn {
 
 const DRAFT_KEY_PREFIX = "story-edit-draft-";
 
+/**
+ * task #157：草稿 shape 校验。损坏草稿（tags 为对象/字符串、字段类型错、
+ * 混入未知字段）duck-type 渲染会出滑稽计数或触发错误边界——恢复前校验，
+ * 非法草稿丢弃并提示重新编辑（Steven 裁决）。
+ */
+const DRAFT_STRING_FIELDS = ["title", "summary", "content", "coverImage", "locationId", "locationName", "status", "authorId"] as const;
+
+export function isValidDraftShape(draft: unknown): draft is Partial<FormFields> {
+  if (typeof draft !== "object" || draft === null || Array.isArray(draft)) return false;
+  const d = draft as Record<string, unknown>;
+  for (const key of Object.keys(d)) {
+    if ((DRAFT_STRING_FIELDS as readonly string[]).includes(key)) {
+      if (typeof d[key] !== "string") return false;
+    } else if (key === "tags") {
+      if (!Array.isArray(d.tags) || d.tags.some((x) => typeof x !== "string")) return false;
+    } else {
+      return false; // 未知字段：spread 进 form 会污染 state
+    }
+  }
+  return true;
+}
+
 function loadDraft(storyId: string): Partial<FormFields> | null {
   try {
     const raw = localStorage.getItem(`${DRAFT_KEY_PREFIX}${storyId}`);
@@ -97,7 +119,7 @@ function clearDraft(storyId: string): void {
 }
 
 export function useStoryForm(storyId: string): UseStoryFormReturn {
-  const { t } = useI18n(["content"]);
+  const { t } = useI18n(["content", "errors"]);
   const [currentUser, setCurrentUser] = React.useState<SessionUser | null>(null);
   const [isLoading, setIsLoading] = React.useState(true);
   const [isSaving, setIsSaving] = React.useState(false);
@@ -176,10 +198,15 @@ export function useStoryForm(storyId: string): UseStoryFormReturn {
           return;
         }
 
-        // 检查草稿
+        // 检查草稿（shape 非法 → 丢弃并提示重新编辑，走 toast 通道）
         const draft = loadDraft(storyId);
         if (draft) {
-          setDraftAvailable(true);
+          if (isValidDraftShape(draft)) {
+            setDraftAvailable(true);
+          } else {
+            clearDraft(storyId);
+            setUploadMessage(t("content.discover.edit.draftInvalid"));
+          }
         }
 
         setForm(f);
@@ -285,13 +312,27 @@ export function useStoryForm(storyId: string): UseStoryFormReturn {
         initialForm.current = { ...form };
       } else {
         // API 错误契约 {success:false, error:{code,message}}；容错 string 形 error
+        // task #157：error.code 优先映射 i18n 文案（en 界面不再显示中文 server message），
+        // 映射不到才 fallback server message（有信息 > 无信息）
+        const apiCode =
+          typeof data.error === "object" && data.error !== null
+            ? (data.error as { code?: string }).code
+            : undefined;
         const apiMessage =
           typeof data.error === "string"
             ? data.error
             : data.error?.message;
+        const ERROR_CODE_I18N: Record<string, string> = {
+          UNAUTHORIZED: "errors.loginRequired",
+          FORBIDDEN: "errors.noPermission",
+          NOT_FOUND: "content.discover.storyNotFound",
+          VALIDATION_ERROR: "errors.validationFailed",
+          INTERNAL_ERROR: "content.discover.edit.saveFailed",
+        };
+        const mapped = apiCode ? ERROR_CODE_I18N[apiCode] : undefined;
         setSaveResult({
           type: "error",
-          message: apiMessage || t("content.discover.edit.saveFailed"),
+          message: (mapped && t(mapped)) || apiMessage || t("content.discover.edit.saveFailed"),
         });
       }
     } catch {
@@ -309,11 +350,18 @@ export function useStoryForm(storyId: string): UseStoryFormReturn {
   const handleRestoreDraft = React.useCallback(() => {
     const draft = loadDraft(storyId);
     if (draft) {
+      if (!isValidDraftShape(draft)) {
+        // 与 load 时校验同源：load 后草稿被写坏（其他 tab/手动改 storage）的兜底
+        clearDraft(storyId);
+        setDraftAvailable(false);
+        setUploadMessage(t("content.discover.edit.draftInvalid"));
+        return;
+      }
       setForm((prev) => ({ ...prev, ...draft }));
       clearDraft(storyId);
       setDraftAvailable(false);
     }
-  }, [storyId]);
+  }, [storyId, t]);
 
   return {
     form, initialForm, currentUser, isLoading, isSaving, saveResult, uploadMessage, error, canEdit,

--- a/frontend/src/lib/duration-options.ts
+++ b/frontend/src/lib/duration-options.ts
@@ -6,8 +6,29 @@
  * 用户看到 1 小时、实际提交推荐值，且「（推荐）」标记永不出现。
  */
 
-/** 下拉选项值（分钟）——推荐值 snap 的目标集 */
-export const DURATION_OPTION_VALUES = [60, 90, 120, 180, 240, 300, 360, 420, 480, 540, 600, 720, 900, 1200];
+/**
+ * [分钟, labelKey] 元组——选项渲染与 snap 目标集的唯一出处。
+ * 加档只改一行，不会出现 values/labelKeys 位置错位（task #157，Martin CR 建议）。
+ */
+export const DURATION_OPTION_DEFS: ReadonlyArray<readonly [number, string]> = [
+  [60, "teams.duration1h"],
+  [90, "teams.duration1_5h"],
+  [120, "teams.duration2h"],
+  [180, "teams.duration3h"],
+  [240, "teams.duration4h"],
+  [300, "teams.duration5h"],
+  [360, "teams.duration6h"],
+  [420, "teams.duration7h"],
+  [480, "teams.duration8h"],
+  [540, "teams.duration9h"],
+  [600, "teams.duration10h"],
+  [720, "teams.duration12h"],
+  [900, "teams.duration15h"],
+  [1200, "teams.duration20h"],
+];
+
+/** 下拉选项值（分钟）——推荐值 snap 的目标集，由 DURATION_OPTION_DEFS 派生 */
+export const DURATION_OPTION_VALUES = DURATION_OPTION_DEFS.map(([v]) => v);
 
 /** snap 到时间上最接近的选项，并列时取较长一档 */
 export function snapToDurationOption(minutes: number): number {

--- a/frontend/src/pages/discover/[id]/edit.astro
+++ b/frontend/src/pages/discover/[id]/edit.astro
@@ -6,7 +6,7 @@ import Layout from "../../../layouts/Layout.astro";
 import { StoryEditClient } from "../../../components/features/discover/story-edit-client";
 import { declareI18nNs } from "../../../middleware";
 
-declareI18nNs(Astro.locals, ["content", "common", "ui"]);
+declareI18nNs(Astro.locals, ["content", "common", "ui", "errors"]); // task #157：保存错误 error.code 映射走 errors ns
 
 const { id } = Astro.params;
 ---


### PR DESCRIPTION
## 改动范围

编辑页错误处理打磨批次（Martin 归并口径），两个独立 commit：

### ① 草稿 shape 校验 + error.code 映射（`243d5e9`）
- **草稿 restore 前 shape 校验**（Steven 裁决）：tags 为对象/字符串、字段类型错、混入未知字段的损坏草稿，此前 duck-type 渲染滑稽计数或触发错误边界。`isValidDraftShape` 在 load / restore 双入口校验，非法草稿**丢弃 + toast 提示重新编辑**（新 key `content.discover.edit.draftInvalid`，三 locale）
- **banner 错误文案 error.code 优先映射 i18n**：UNAUTHORIZED→loginRequired / FORBIDDEN→noPermission / NOT_FOUND→storyNotFound / VALIDATION_ERROR→validationFailed（新 key）/ INTERNAL_ERROR→saveFailed；映射不到才 fallback server message——修 en 界面显示中文 server message
- `useI18n` + 编辑页 `declareI18nNs` 补 errors ns（Check 5 门禁验证通过）
- 单测 5 组钉住校验规则

### ② 建队 nit 两项（`57d303c`）
- **en 推荐标记半角括号**：硬编码全角「（Recommended）」→ i18n key `teams.durationRecommendedMarked`（zh（推荐）/ en (Recommended) / ja（推薦））
- **时长选项元组防呆**（Martin CR 建议）：`DURATION_OPTION_DEFS [value, key]` 上收 lib/duration-options.ts，选项渲染与 snap 目标集唯一出处，`DURATION_OPTION_VALUES` 改为派生

## 验证

- vitest 119/119 PASS（新增 5 组 shape 校验）
- i18n 门禁 5 项全过（含 Check 5 ns 覆盖）
- type-check 0 errors / lint 干净 / build 成功

## Wen 需验证场景

1. **损坏草稿**：编辑页 localStorage 手动写入 `story-edit-draft-<id>` = `{"title":"x","tags":"徒步"}`（tags 字符串形）→ 刷新：不出现草稿恢复 banner，toast 提示草稿已丢弃，页面正常可编辑（此前会出滑稽计数/错误边界）
2. **合法草稿恢复**：正常编辑触发自动保存草稿 → 刷新 → banner 出现，恢复后内容完整（回归）
3. **error.code 映射**：en 界面触发保存失败（如断网后恢复但 session 失效 → 401）→ banner 显示英文「Please log in first」类文案，不再是中文 server message
4. **en 建队页推荐标记**：「3 hours (Recommended)」半角括号（此前全角）
5. zh 建队推荐标记「（推荐）」回归不变

## 风险与回滚

- 低风险：前端校验/文案层，无 API 契约变化；非法草稿丢弃是设计裁决行为
- 回滚：revert 两 commit