### PR TITLE
fix: add --no-stash to lint-staged to prevent detached HEAD in worktrees

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm exec lint-staged
+pnpm exec lint-staged --no-stash


### PR DESCRIPTION
## 变更

 中  加上  参数。

## 原因

lint-staged 的自动 stash/restore 流程在 worktree 环境下偶发将 HEAD 留在 detached 状态，commit 后需手动  指回分支。

## 修复

禁用自动 stash。未暂存的改动不会被包含在 commit 中，但 lint 后也不会有 detached HEAD 风险。

🤖 Generated with [Claude Code](https://claude.com/claude-code)