### PR TITLE
feat: task #163（P0-A T1+T5）Team「行动本」checklist schema + API + 通知钩子

### DIFF
--- a/api/db/migrations/0014_teams_checklist.sql
+++ b/api/db/migrations/0014_teams_checklist.sql
@@ -1,0 +1,9 @@
+-- Migration: task #163（P0-A T1）—— teams 加 checklist 字段（Team「行动本」）
+-- spec：notes/gomate-p0a-team-actionbook-spec.md v1.1 §2
+-- 规则：
+--   1. checklist 是 TEXT nullable，存 JSON（drizzle $type<TeamChecklist>）
+--   2. nullable 语义 = 队长未填；非空 = 完整 JSON 结构
+--   3. 单字段 <2KB，不建索引（无 SQL 层查询需求，业务层 parse JSON）
+-- 原子性：ALTER TABLE ADD COLUMN 单语句天然原子
+-- 幂等：wrangler d1 migrations apply 已跟踪 idx，重跑安全
+ALTER TABLE `teams` ADD `checklist` text;

--- a/api/db/migrations/meta/0014_snapshot.json
+++ b/api/db/migrations/meta/0014_snapshot.json
@@ -1,0 +1,2056 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "4e022ff3-311d-4264-a01f-707a44f55c50",
+  "prevId": "39ddefb0-79cc-47f0-bc76-e9cf57d7b942",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "accounts_user_idx": {
+          "name": "accounts_user_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "accounts_provider_idx": {
+          "name": "accounts_provider_idx",
+          "columns": ["provider_id", "account_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "activity_posts": {
+      "name": "activity_posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "images": {
+          "name": "images",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'visible'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "activity_posts_team_idx": {
+          "name": "activity_posts_team_idx",
+          "columns": ["team_id"],
+          "isUnique": false
+        },
+        "activity_posts_location_idx": {
+          "name": "activity_posts_location_idx",
+          "columns": ["location_id"],
+          "isUnique": false
+        },
+        "activity_posts_author_idx": {
+          "name": "activity_posts_author_idx",
+          "columns": ["author_id"],
+          "isUnique": false
+        },
+        "activity_posts_status_idx": {
+          "name": "activity_posts_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "activity_posts_created_at_idx": {
+          "name": "activity_posts_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "activity_posts_team_id_teams_id_fk": {
+          "name": "activity_posts_team_id_teams_id_fk",
+          "tableFrom": "activity_posts",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_posts_location_id_locations_id_fk": {
+          "name": "activity_posts_location_id_locations_id_fk",
+          "tableFrom": "activity_posts",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "activity_posts_author_id_users_id_fk": {
+          "name": "activity_posts_author_id_users_id_fk",
+          "tableFrom": "activity_posts",
+          "tableTo": "users",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cities": {
+      "name": "cities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "adcode": {
+          "name": "adcode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pinyin": {
+          "name": "pinyin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "province": {
+          "name": "province",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_hot": {
+          "name": "is_hot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cities_adcode_unique": {
+          "name": "cities_adcode_unique",
+          "columns": ["adcode"],
+          "isUnique": true
+        },
+        "cities_adcode_idx": {
+          "name": "cities_adcode_idx",
+          "columns": ["adcode"],
+          "isUnique": true
+        },
+        "cities_is_hot_idx": {
+          "name": "cities_is_hot_idx",
+          "columns": ["is_hot"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "leader_id": {
+          "name": "leader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initiator_id": {
+          "name": "initiator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_message_content": {
+          "name": "last_message_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "conversations_team_idx": {
+          "name": "conversations_team_idx",
+          "columns": ["team_id"],
+          "isUnique": false
+        },
+        "conversations_user_idx": {
+          "name": "conversations_user_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "conversations_leader_idx": {
+          "name": "conversations_leader_idx",
+          "columns": ["leader_id"],
+          "isUnique": false
+        },
+        "conversations_participant_idx": {
+          "name": "conversations_participant_idx",
+          "columns": ["team_id", "user_id"],
+          "isUnique": true
+        },
+        "conversations_last_msg_idx": {
+          "name": "conversations_last_msg_idx",
+          "columns": ["last_message_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "conversations_team_id_teams_id_fk": {
+          "name": "conversations_team_id_teams_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversations_user_id_users_id_fk": {
+          "name": "conversations_user_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversations_leader_id_users_id_fk": {
+          "name": "conversations_leader_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": ["leader_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversations_initiator_id_users_id_fk": {
+          "name": "conversations_initiator_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": ["initiator_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "entity_to_tags": {
+      "name": "entity_to_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "entity_to_tags_entity_idx": {
+          "name": "entity_to_tags_entity_idx",
+          "columns": ["entity_id", "entity_type"],
+          "isUnique": false
+        },
+        "entity_to_tags_tag_idx": {
+          "name": "entity_to_tags_tag_idx",
+          "columns": ["tag_id"],
+          "isUnique": false
+        },
+        "entity_to_tags_type_tag_entity_idx": {
+          "name": "entity_to_tags_type_tag_entity_idx",
+          "columns": ["entity_type", "tag_id", "entity_id"],
+          "isUnique": false
+        },
+        "entity_to_tags_unique_idx": {
+          "name": "entity_to_tags_unique_idx",
+          "columns": ["entity_id", "entity_type", "tag_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "entity_to_tags_tag_id_tags_id_fk": {
+          "name": "entity_to_tags_tag_id_tags_id_fk",
+          "tableFrom": "entity_to_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "image_caches": {
+      "name": "image_caches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base64_data": {
+          "name": "base64_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'image/jpeg'"
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "image_caches_url_idx": {
+          "name": "image_caches_url_idx",
+          "columns": ["image_url"],
+          "isUnique": true
+        },
+        "image_caches_expires_idx": {
+          "name": "image_caches_expires_idx",
+          "columns": ["expires_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city_name": {
+          "name": "city_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_max": {
+          "name": "duration_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "distance": {
+          "name": "distance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "elevation": {
+          "name": "elevation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "best_season": {
+          "name": "best_season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cover_image": {
+          "name": "cover_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "images": {
+          "name": "images",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "coordinates": {
+          "name": "coordinates",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "locations_slug_unique": {
+          "name": "locations_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        },
+        "locations_slug_idx": {
+          "name": "locations_slug_idx",
+          "columns": ["slug"],
+          "isUnique": true
+        },
+        "locations_name_idx": {
+          "name": "locations_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "locations_city_idx": {
+          "name": "locations_city_idx",
+          "columns": ["city_id"],
+          "isUnique": false
+        },
+        "locations_type_idx": {
+          "name": "locations_type_idx",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "locations_created_at_idx": {
+          "name": "locations_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "locations_city_id_cities_id_fk": {
+          "name": "locations_city_id_cities_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "cities",
+          "columnsFrom": ["city_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "messages_conversation_idx": {
+          "name": "messages_conversation_idx",
+          "columns": ["conversation_id"],
+          "isUnique": false
+        },
+        "messages_sender_idx": {
+          "name": "messages_sender_idx",
+          "columns": ["sender_id"],
+          "isUnique": false
+        },
+        "messages_created_idx": {
+          "name": "messages_created_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "messages_conversation_created_at_idx": {
+          "name": "messages_conversation_created_at_idx",
+          "columns": ["conversation_id", "created_at"],
+          "isUnique": false
+        },
+        "messages_conversation_unread_sender_idx": {
+          "name": "messages_conversation_unread_sender_idx",
+          "columns": ["conversation_id", "is_read", "sender_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sender_id_users_id_fk": {
+          "name": "messages_sender_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": ["sender_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_resets": {
+      "name": "password_resets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "password_resets_token_unique": {
+          "name": "password_resets_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        },
+        "password_resets_token_idx": {
+          "name": "password_resets_token_idx",
+          "columns": ["token"],
+          "isUnique": false
+        },
+        "password_resets_user_idx": {
+          "name": "password_resets_user_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "password_resets_email_idx": {
+          "name": "password_resets_email_idx",
+          "columns": ["email"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "password_resets_user_id_users_id_fk": {
+          "name": "password_resets_user_id_users_id_fk",
+          "tableFrom": "password_resets",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        },
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "sessions_token_idx": {
+          "name": "sessions_token_idx",
+          "columns": ["token"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_events": {
+      "name": "share_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "share_channel": {
+          "name": "share_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "share_events_entity_idx": {
+          "name": "share_events_entity_idx",
+          "columns": ["entity_type", "entity_id"],
+          "isUnique": false
+        },
+        "share_events_channel_idx": {
+          "name": "share_events_channel_idx",
+          "columns": ["share_channel"],
+          "isUnique": false
+        },
+        "share_events_created_at_idx": {
+          "name": "share_events_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stories": {
+      "name": "stories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cover_image": {
+          "name": "cover_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'published'"
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "stories_author_idx": {
+          "name": "stories_author_idx",
+          "columns": ["author_id"],
+          "isUnique": false
+        },
+        "stories_location_idx": {
+          "name": "stories_location_idx",
+          "columns": ["location_id"],
+          "isUnique": false
+        },
+        "stories_status_idx": {
+          "name": "stories_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "stories_created_at_idx": {
+          "name": "stories_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "stories_status_created_at_idx": {
+          "name": "stories_status_created_at_idx",
+          "columns": ["status", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stories_author_id_users_id_fk": {
+          "name": "stories_author_id_users_id_fk",
+          "tableFrom": "stories",
+          "tableTo": "users",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stories_location_id_locations_id_fk": {
+          "name": "stories_location_id_locations_id_fk",
+          "tableFrom": "stories",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "tags_type_idx": {
+          "name": "tags_type_idx",
+          "columns": ["type"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_members": {
+      "name": "team_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_members_team_idx": {
+          "name": "team_members_team_idx",
+          "columns": ["team_id"],
+          "isUnique": false
+        },
+        "team_members_user_idx": {
+          "name": "team_members_user_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "team_members_team_status_idx": {
+          "name": "team_members_team_status_idx",
+          "columns": ["team_id", "status"],
+          "isUnique": false
+        },
+        "team_members_team_user_idx": {
+          "name": "team_members_team_user_idx",
+          "columns": ["team_id", "user_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teams": {
+      "name": "teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "leader_id": {
+          "name": "leader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 240
+        },
+        "max_members": {
+          "name": "max_members",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'⛰️'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'recruiting'"
+        },
+        "checklist": {
+          "name": "checklist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "teams_location_idx": {
+          "name": "teams_location_idx",
+          "columns": ["location_id"],
+          "isUnique": false
+        },
+        "teams_leader_idx": {
+          "name": "teams_leader_idx",
+          "columns": ["leader_id"],
+          "isUnique": false
+        },
+        "teams_status_idx": {
+          "name": "teams_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "teams_start_time_idx": {
+          "name": "teams_start_time_idx",
+          "columns": ["start_time"],
+          "isUnique": false
+        },
+        "teams_title_idx": {
+          "name": "teams_title_idx",
+          "columns": ["title"],
+          "isUnique": false
+        },
+        "teams_status_created_at_idx": {
+          "name": "teams_status_created_at_idx",
+          "columns": ["status", "created_at"],
+          "isUnique": false
+        },
+        "teams_status_start_time_idx": {
+          "name": "teams_status_start_time_idx",
+          "columns": ["status", "start_time"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "teams_location_id_locations_id_fk": {
+          "name": "teams_location_id_locations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "teams_leader_id_users_id_fk": {
+          "name": "teams_leader_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": ["leader_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_favorites": {
+      "name": "user_favorites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_favorites_user_idx": {
+          "name": "user_favorites_user_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "user_favorites_entity_idx": {
+          "name": "user_favorites_entity_idx",
+          "columns": ["entity_type", "entity_id"],
+          "isUnique": false
+        },
+        "user_favorites_unique_idx": {
+          "name": "user_favorites_unique_idx",
+          "columns": ["user_id", "entity_type", "entity_id"],
+          "isUnique": true
+        },
+        "user_favorites_user_created_idx": {
+          "name": "user_favorites_user_created_idx",
+          "columns": ["user_id", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_story_likes": {
+      "name": "user_story_likes",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "user_story_likes_user_idx": {
+          "name": "user_story_likes_user_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "user_story_likes_story_idx": {
+          "name": "user_story_likes_story_idx",
+          "columns": ["story_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_story_likes_user_id_users_id_fk": {
+          "name": "user_story_likes_user_id_users_id_fk",
+          "tableFrom": "user_story_likes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_story_likes_story_id_stories_id_fk": {
+          "name": "user_story_likes_story_id_stories_id_fk",
+          "tableFrom": "user_story_likes",
+          "tableTo": "stories",
+          "columnsFrom": ["story_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_story_likes_user_id_story_id_pk": {
+          "columns": ["user_id", "story_id"],
+          "name": "user_story_likes_user_id_story_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "birthday": {
+          "name": "birthday",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'beginner'"
+        },
+        "completed_hikes": {
+          "name": "completed_hikes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "wechat": {
+          "name": "wechat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "extra": {
+          "name": "extra",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": ["email"],
+          "isUnique": false
+        },
+        "users_name_idx": {
+          "name": "users_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "users_nickname_idx": {
+          "name": "users_nickname_idx",
+          "columns": ["nickname"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verifications": {
+      "name": "verifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": ["identifier"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/api/db/migrations/meta/_journal.json
+++ b/api/db/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1784384938665,
       "tag": "0013_drop_routes",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1784462555557,
+      "tag": "0014_teams_checklist",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/__tests__/helpers/db.ts
+++ b/api/src/__tests__/helpers/db.ts
@@ -136,6 +136,8 @@ export function createTestDb() {
       requirements TEXT,
       icon TEXT NOT NULL DEFAULT '⛰️',
       status TEXT NOT NULL DEFAULT 'recruiting',
+      -- task #163：Team「行动本」checklist（TEXT JSON，nullable）
+      checklist TEXT,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     );

--- a/api/src/__tests__/integration/teams-checklist.test.ts
+++ b/api/src/__tests__/integration/teams-checklist.test.ts
@@ -230,6 +230,76 @@ describe("Teams checklist API 集成测试", () => {
       });
       expect(res.status).toBe(400);
     });
+
+    // B1（Martin CR）：spec §2.3 明确「PUT 是队长覆盖式更新整个 checklist」，
+    // 未传字段 → 清空。第一版用条件展开会保留旧值，破坏覆盖式语义。此处回归。
+    it("PUT 覆盖式：不传字段应清空旧值（B1 回归）", async () => {
+      setSession({ id: leader.id, email: "l@x.com", name: "l" });
+
+      // 第一次：写入完整 checklist（有 meetingPoint / transport / gear / assignments / notes）
+      const first = await req(app, `/teams/${team.id}/checklist`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          meetingPoint: { name: "地铁北门", time: "07:30" },
+          transport: { mode: "self_drive" as const, detail: "拼车" },
+          gear: { essential: ["水"], optional: [] },
+          assignments: [{ task: "买水", assigneeIds: [] }],
+          notes: "旧口令",
+        }),
+      });
+      expect(first.status).toBe(200);
+      const firstJson = (await first.json()) as { checklist: TeamChecklist };
+      expect(firstJson.checklist.meetingPoint?.name).toBe("地铁北门");
+      expect(firstJson.checklist.assignments).toHaveLength(1);
+
+      // 第二次：只传 notes，其他字段全部缺省 → 应清空
+      const second = await req(app, `/teams/${team.id}/checklist`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ notes: "新口令" }),
+      });
+      expect(second.status).toBe(200);
+      const secondJson = (await second.json()) as { checklist: TeamChecklist };
+      expect(secondJson.checklist.notes).toBe("新口令");
+      expect(secondJson.checklist.meetingPoint).toBeUndefined();
+      expect(secondJson.checklist.transport).toBeUndefined();
+      expect(secondJson.checklist.gear).toBeUndefined();
+      // assignments：既然全没传，normalize 后是 []（server 视为「清空」）
+      expect(secondJson.checklist.assignments).toEqual([]);
+
+      // DB 落盘一致
+      const saved = await readChecklist(team.id);
+      expect(saved?.notes).toBe("新口令");
+      expect(saved?.meetingPoint).toBeUndefined();
+      expect(saved?.transport).toBeUndefined();
+      expect(saved?.gear).toBeUndefined();
+      expect(saved?.assignments).toEqual([]);
+    });
+
+    it("PUT 覆盖式：显式传空 assignments 也应清空", async () => {
+      setSession({ id: leader.id, email: "l@x.com", name: "l" });
+
+      await req(app, `/teams/${team.id}/checklist`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          assignments: [
+            { task: "买水", assigneeIds: [member.id] },
+            { task: "买餐", assigneeIds: [] },
+          ],
+        }),
+      });
+
+      const res = await req(app, `/teams/${team.id}/checklist`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ assignments: [] }),
+      });
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { checklist: TeamChecklist };
+      expect(json.checklist.assignments).toEqual([]);
+    });
   });
 
   // ===== POST /teams/:id/checklist/assignments/:assignmentId/claim =====

--- a/api/src/__tests__/integration/teams-checklist.test.ts
+++ b/api/src/__tests__/integration/teams-checklist.test.ts
@@ -1,0 +1,423 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Hono } from "hono";
+import { createTestDb } from "../helpers/db";
+import { seedUser, seedCity, seedLocation, seedTeam, seedTeamMember } from "../helpers/seed";
+import { eq } from "drizzle-orm";
+import * as schema from "../../db/schema";
+import type { TeamChecklist } from "@gomate/types";
+
+/**
+ * task #163（P0-A T1+T5）：Team「行动本」checklist 集成测试
+ *
+ * 覆盖：
+ * - PUT /teams/:id/checklist：队长权限、非队长 403、匿名 401、404
+ * - assignment id 保留策略：入参已存在 id → 复用；缺 id → server 补新 uuid
+ * - POST claim：joined-only、幂等、assignmentId（非 index）定位
+ * - DELETE claim：幂等 204、不在时也 204
+ * - assigneeIds server 去重
+ */
+
+let currentSession: { user: { id: string; email: string; name: string } } | null = null;
+let testDb: ReturnType<typeof createTestDb>["db"];
+
+vi.mock("../../lib/auth", () => ({
+  createAuth: (_env: unknown) => ({
+    api: { getSession: async (_opts: unknown) => currentSession },
+  }),
+}));
+
+vi.mock("../../db", () => ({
+  createDb: (_d1: unknown) => testDb,
+}));
+
+const { teamsRoute } = await import("../../routes/teams");
+
+function createApp() {
+  const app = new Hono<{ Bindings: { DB: unknown } }>();
+  app.route("/teams", teamsRoute);
+  return app;
+}
+
+async function req(
+  app: ReturnType<typeof createApp>,
+  path: string,
+  options: RequestInit = {},
+): Promise<Response> {
+  const request = new Request(`http://localhost${path}`, options);
+  return app.fetch(request, { DB: {} });
+}
+
+function setSession(user: { id: string; email: string; name: string } | null) {
+  currentSession = user ? { user } : null;
+}
+
+/** 从 DB 读回 checklist（driver 差异：可能是 JSON 字符串或对象） */
+async function readChecklist(teamId: string): Promise<TeamChecklist | null> {
+  const [row] = await testDb.select().from(schema.teams).where(eq(schema.teams.id, teamId));
+  const raw = row?.checklist as unknown;
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw === "string") {
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw) as TeamChecklist;
+    } catch {
+      return null;
+    }
+  }
+  return raw as TeamChecklist;
+}
+
+describe("Teams checklist API 集成测试", () => {
+  let app: ReturnType<typeof createApp>;
+  let leader: schema.User;
+  let member: schema.User;
+  let stranger: schema.User;
+  let city: schema.City;
+  let location: schema.Location;
+  let team: schema.Team;
+
+  beforeEach(async () => {
+    const fresh = createTestDb();
+    testDb = fresh.db;
+    app = createApp();
+    currentSession = null;
+
+    leader = await seedUser(testDb, { name: "队长" });
+    member = await seedUser(testDb, { name: "成员" });
+    stranger = await seedUser(testDb, { name: "路人" });
+    city = await seedCity(testDb);
+    location = await seedLocation(testDb, city.id);
+    team = await seedTeam(testDb, leader.id, location.id, { title: "周末徒步" });
+    await seedTeamMember(testDb, team.id, member.id, "approved");
+  });
+
+  // ===== PUT /teams/:id/checklist =====
+
+  describe("PUT /teams/:id/checklist - 队长覆盖式更新", () => {
+    it("匿名用户 → 401", async () => {
+      const res = await req(app, `/teams/${team.id}/checklist`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ notes: "test" }),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("非队长成员 → 403", async () => {
+      setSession({ id: member.id, email: "m@x.com", name: "m" });
+      const res = await req(app, `/teams/${team.id}/checklist`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ notes: "test" }),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("队伍不存在 → 404", async () => {
+      setSession({ id: leader.id, email: "l@x.com", name: "l" });
+      const res = await req(app, "/teams/not-exist/checklist", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ notes: "test" }),
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("队长完整提交 → 200，DB 落盘一致", async () => {
+      setSession({ id: leader.id, email: "l@x.com", name: "l" });
+      const body = {
+        meetingPoint: { name: "地铁北门", time: "07:30", note: "迟到 15 分钟不等" },
+        transport: { mode: "self_drive" as const, detail: "3 辆车拼车" },
+        gear: { essential: ["登山鞋", "水"], optional: ["登山杖"], note: "自带午餐" },
+        assignments: [
+          { task: "买水", assigneeIds: [] },
+          { task: "买路餐", assigneeIds: [member.id] },
+        ],
+        notes: "队伍口令：出发",
+      };
+      const res = await req(app, `/teams/${team.id}/checklist`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { success: boolean; checklist: TeamChecklist };
+      expect(json.success).toBe(true);
+      expect(json.checklist.meetingPoint?.name).toBe("地铁北门");
+      expect(json.checklist.transport?.mode).toBe("self_drive");
+      expect(json.checklist.gear?.essential).toEqual(["登山鞋", "水"]);
+      expect(json.checklist.assignments).toHaveLength(2);
+      // server 补 uuid：入参无 id，返回值应带 id
+      expect(json.checklist.assignments![0].id).toBeTruthy();
+      expect(json.checklist.assignments![1].id).toBeTruthy();
+      expect(json.checklist.assignments![0].id).not.toBe(json.checklist.assignments![1].id);
+
+      const saved = await readChecklist(team.id);
+      expect(saved?.notes).toBe("队伍口令：出发");
+    });
+
+    it("入参 assignment.id 命中已有 → 复用；缺 id → 生成新 uuid", async () => {
+      setSession({ id: leader.id, email: "l@x.com", name: "l" });
+
+      // 第一次 PUT：种下两条 assignment，让 server 生成 id
+      const first = await req(app, `/teams/${team.id}/checklist`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          assignments: [
+            { task: "带水", assigneeIds: [] },
+            { task: "带餐", assigneeIds: [] },
+          ],
+        }),
+      });
+      const firstJson = (await first.json()) as { checklist: TeamChecklist };
+      const existingId = firstJson.checklist.assignments![0].id;
+
+      // 第二次 PUT：一条带已有 id（应复用）、一条不带 id（应新生成）
+      const second = await req(app, `/teams/${team.id}/checklist`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          assignments: [
+            { id: existingId, task: "带水（改）", assigneeIds: [member.id] },
+            { task: "带气罐", assigneeIds: [] },
+          ],
+        }),
+      });
+      const secondJson = (await second.json()) as { checklist: TeamChecklist };
+      expect(secondJson.checklist.assignments).toHaveLength(2);
+      expect(secondJson.checklist.assignments![0].id).toBe(existingId); // 复用
+      expect(secondJson.checklist.assignments![0].task).toBe("带水（改）");
+      expect(secondJson.checklist.assignments![0].assigneeIds).toEqual([member.id]);
+      expect(secondJson.checklist.assignments![1].id).toBeTruthy();
+      expect(secondJson.checklist.assignments![1].id).not.toBe(existingId); // 新 id
+    });
+
+    it("入参 assigneeIds 重复 → server 去重", async () => {
+      setSession({ id: leader.id, email: "l@x.com", name: "l" });
+      const res = await req(app, `/teams/${team.id}/checklist`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          assignments: [{ task: "买水", assigneeIds: [member.id, member.id, member.id] }],
+        }),
+      });
+      const json = (await res.json()) as { checklist: TeamChecklist };
+      expect(json.checklist.assignments![0].assigneeIds).toEqual([member.id]);
+    });
+
+    it("入参非法 (task 空字符串) → 400", async () => {
+      setSession({ id: leader.id, email: "l@x.com", name: "l" });
+      const res = await req(app, `/teams/${team.id}/checklist`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ assignments: [{ task: "" }] }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("入参序列化后 > 2KB → 400（软上限，防滥用）", async () => {
+      setSession({ id: leader.id, email: "l@x.com", name: "l" });
+      // 精心构造：多个字段加起来触发 >2KB 上限
+      // 单字段 notes 上限 2000，加 gear/notes/note 组合足以超 2048
+      const res = await req(app, `/teams/${team.id}/checklist`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          notes: "x".repeat(2000),
+          gear: { essential: ["a", "b"], optional: ["c"], note: "y".repeat(500) },
+        }),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ===== POST /teams/:id/checklist/assignments/:assignmentId/claim =====
+
+  describe("POST claim - 队员认领", () => {
+    async function seedOneAssignment(): Promise<string> {
+      setSession({ id: leader.id, email: "l@x.com", name: "l" });
+      const res = await req(app, `/teams/${team.id}/checklist`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ assignments: [{ task: "买水", assigneeIds: [] }] }),
+      });
+      const json = (await res.json()) as { checklist: TeamChecklist };
+      return json.checklist.assignments![0].id;
+    }
+
+    it("匿名 → 401", async () => {
+      const aid = await seedOneAssignment();
+      setSession(null);
+      const res = await req(app, `/teams/${team.id}/checklist/assignments/${aid}/claim`, {
+        method: "POST",
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("非成员（路人） → 403", async () => {
+      const aid = await seedOneAssignment();
+      setSession({ id: stranger.id, email: "s@x.com", name: "s" });
+      const res = await req(app, `/teams/${team.id}/checklist/assignments/${aid}/claim`, {
+        method: "POST",
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("assignmentId 不存在 → 404（防漂移）", async () => {
+      await seedOneAssignment();
+      setSession({ id: member.id, email: "m@x.com", name: "m" });
+      const res = await req(app, `/teams/${team.id}/checklist/assignments/no-such-id/claim`, {
+        method: "POST",
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("成员认领 → 200，assigneeIds 含 userId；重复调用幂等", async () => {
+      const aid = await seedOneAssignment();
+      setSession({ id: member.id, email: "m@x.com", name: "m" });
+
+      const first = await req(app, `/teams/${team.id}/checklist/assignments/${aid}/claim`, {
+        method: "POST",
+      });
+      expect(first.status).toBe(200);
+      const firstJson = (await first.json()) as { assignment: { assigneeIds: string[] } };
+      expect(firstJson.assignment.assigneeIds).toEqual([member.id]);
+
+      const second = await req(app, `/teams/${team.id}/checklist/assignments/${aid}/claim`, {
+        method: "POST",
+      });
+      expect(second.status).toBe(200);
+      const secondJson = (await second.json()) as { assignment: { assigneeIds: string[] } };
+      expect(secondJson.assignment.assigneeIds).toEqual([member.id]); // 幂等：仍是一个
+
+      const saved = await readChecklist(team.id);
+      expect(saved?.assignments![0].assigneeIds).toEqual([member.id]);
+    });
+
+    it("队长本人（也是队长）→ 200，可认领", async () => {
+      const aid = await seedOneAssignment();
+      setSession({ id: leader.id, email: "l@x.com", name: "l" });
+      const res = await req(app, `/teams/${team.id}/checklist/assignments/${aid}/claim`, {
+        method: "POST",
+      });
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { assignment: { assigneeIds: string[] } };
+      expect(json.assignment.assigneeIds).toEqual([leader.id]);
+    });
+  });
+
+  // ===== DELETE /teams/:id/checklist/assignments/:assignmentId/claim =====
+
+  describe("DELETE claim - 队员取消认领", () => {
+    async function seedAssignmentClaimedByMember(): Promise<string> {
+      setSession({ id: leader.id, email: "l@x.com", name: "l" });
+      const res = await req(app, `/teams/${team.id}/checklist`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ assignments: [{ task: "买水", assigneeIds: [member.id] }] }),
+      });
+      const json = (await res.json()) as { checklist: TeamChecklist };
+      return json.checklist.assignments![0].id;
+    }
+
+    it("匿名 → 401", async () => {
+      const aid = await seedAssignmentClaimedByMember();
+      setSession(null);
+      const res = await req(app, `/teams/${team.id}/checklist/assignments/${aid}/claim`, {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("路人 → 403", async () => {
+      const aid = await seedAssignmentClaimedByMember();
+      setSession({ id: stranger.id, email: "s@x.com", name: "s" });
+      const res = await req(app, `/teams/${team.id}/checklist/assignments/${aid}/claim`, {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("assignmentId 不存在 → 404", async () => {
+      await seedAssignmentClaimedByMember();
+      setSession({ id: member.id, email: "m@x.com", name: "m" });
+      const res = await req(app, `/teams/${team.id}/checklist/assignments/no-such-id/claim`, {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("成员取消认领 → 204，DB 中 userId 已移除；重复调用仍 204（幂等）", async () => {
+      const aid = await seedAssignmentClaimedByMember();
+      setSession({ id: member.id, email: "m@x.com", name: "m" });
+
+      const first = await req(app, `/teams/${team.id}/checklist/assignments/${aid}/claim`, {
+        method: "DELETE",
+      });
+      expect(first.status).toBe(204);
+
+      const saved = await readChecklist(team.id);
+      expect(saved?.assignments![0].assigneeIds).toEqual([]);
+
+      const second = await req(app, `/teams/${team.id}/checklist/assignments/${aid}/claim`, {
+        method: "DELETE",
+      });
+      expect(second.status).toBe(204); // 幂等：本来就不在，仍 204
+    });
+  });
+
+  // ===== 并发防漂移：assignmentId 稳定 =====
+
+  describe("并发防漂移：assignmentId 而非 index", () => {
+    it("队长删掉前一个 assignment 后，用旧 index 认领不会误伤（走 404）", async () => {
+      setSession({ id: leader.id, email: "l@x.com", name: "l" });
+      const firstPut = await req(app, `/teams/${team.id}/checklist`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          assignments: [
+            { task: "买水", assigneeIds: [] },
+            { task: "买餐", assigneeIds: [] },
+          ],
+        }),
+      });
+      const first = (await firstPut.json()) as { checklist: TeamChecklist };
+      const idA = first.checklist.assignments![0].id;
+      const idB = first.checklist.assignments![1].id;
+
+      // 队长删掉第一个（"买水"）
+      await req(app, `/teams/${team.id}/checklist`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          assignments: [{ id: idB, task: "买餐", assigneeIds: [] }],
+        }),
+      });
+
+      // 用旧的 idA 认领：应 404，而不是错认到 idB
+      setSession({ id: member.id, email: "m@x.com", name: "m" });
+      const claim = await req(app, `/teams/${team.id}/checklist/assignments/${idA}/claim`, {
+        method: "POST",
+      });
+      expect(claim.status).toBe(404);
+
+      // idB 依然可认领
+      const claimB = await req(app, `/teams/${team.id}/checklist/assignments/${idB}/claim`, {
+        method: "POST",
+      });
+      expect(claimB.status).toBe(200);
+    });
+
+    /**
+     * CAS 并发保护的说明（不在集成测试中真正验证）：
+     *
+     * 认领/取消认领路由用 `UPDATE ... WHERE id = ? AND updatedAt = ?` 做
+     * compare-and-swap，命中 0 行时重读一次再重试；两次都失败返回 409。
+     *
+     * 集成测试的 better-sqlite3 是同步 driver + Promise.all 无法真并发，
+     * 只能在生产（D1）验证真并发丢失场景。若需白盒测试，可在下一版通过
+     * 打桩 db.update 强制第一次返回 [] 来断言重试路径。
+     */
+  });
+});

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -8,6 +8,7 @@ import {
   primaryKey,
 } from "drizzle-orm/sqlite-core";
 import { relations, sql } from "drizzle-orm";
+import type { TeamChecklist } from "@gomate/types";
 
 // ==================== Tables ====================
 
@@ -208,6 +209,9 @@ export const teams = sqliteTable(
     requirements: text("requirements"),
     icon: text("icon").default("⛰️").notNull(),
     status: text("status").notNull().default("recruiting"),
+    // task #163：Team「行动本」checklist（JSON，nullable = 队长未填）
+    // 结构见 packages/types TeamChecklist；单字段 <2KB，D1 batch 写入简单
+    checklist: text("checklist", { mode: "json" }).$type<TeamChecklist>(),
     createdAt: integer("created_at", { mode: "timestamp_ms" }).$defaultFn(() => new Date()).notNull(),
     updatedAt: integer("updated_at", { mode: "timestamp_ms" }).$defaultFn(() => new Date()).notNull(),
   },

--- a/api/src/lib/team-checklist-utils.ts
+++ b/api/src/lib/team-checklist-utils.ts
@@ -1,0 +1,27 @@
+/**
+ * task #163：Team「行动本」checklist 工具函数（api 内共享）
+ *
+ * spec：notes/gomate-p0a-team-actionbook-spec.md v1.1 §2
+ *
+ * 目前只放 parseChecklist：checklist.ts / queries.ts 都要读 DB checklist，
+ * driver 层 JSON 兜底逻辑只需一处，未来若 D1 driver 行为变化只改这里。
+ */
+
+import type { TeamChecklist } from "@gomate/types";
+
+/**
+ * DB 里 checklist 可能是 JSON 字符串（driver 不同表现不同）；统一 parse 成对象。
+ * null / undefined / 空串 / 无效 JSON → 一律返回 null（视为「未填」）。
+ */
+export function parseChecklist(raw: unknown): TeamChecklist | null {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw === "string") {
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw) as TeamChecklist;
+    } catch {
+      return null;
+    }
+  }
+  return raw as TeamChecklist;
+}

--- a/api/src/lib/team-events.ts
+++ b/api/src/lib/team-events.ts
@@ -1,0 +1,24 @@
+/**
+ * task #163 T5：Team「行动本」通知钩子（合并进 T1）
+ *
+ * spec：notes/gomate-p0a-team-actionbook-spec.md v1.1 §7
+ * - 本 spec 只留 emit 点 + payload 类型定义
+ * - 不接入真实推送渠道（Web Push / 小程序订阅消息 P1 单独立项）
+ * - 实现层用 logger.info 落审计线索，方便 P1 立项时回读
+ * - Cloudflare Workers 冷启动敏感，emit 保持同步纯函数（无 IO）
+ */
+
+import { logger } from "./logger";
+import type { TeamActionbookEvent } from "@gomate/types";
+
+/**
+ * emit 一个 Team「行动本」相关事件。
+ *
+ * MVP：仅日志落审计，不异步分发。
+ * P1：可在此点扩展接入 Web Push / KV 队列 / Durable Object 推送渠道。
+ * 调用方保持同步语义（不 await），避免影响主请求延迟。
+ */
+export function emitTeamActionbookEvent(event: TeamActionbookEvent): void {
+  // structured log：字段稳定，方便 P1 立项时按事件类型回填推送逻辑
+  logger.info("[actionbook-event]", event);
+}

--- a/api/src/routes/teams/checklist.ts
+++ b/api/src/routes/teams/checklist.ts
@@ -9,6 +9,7 @@ import * as schema from "../../db/schema";
 import type { Env } from "../../lib/auth";
 import { generateId } from "../../lib/id";
 import { emitTeamActionbookEvent } from "../../lib/team-events";
+import { parseChecklist } from "../../lib/team-checklist-utils";
 import type { TeamChecklist, ActionbookAssignment } from "@gomate/types";
 
 /**
@@ -59,35 +60,18 @@ const assignmentInputSchema = z.object({
   assigneeIds: z.array(z.string().min(1).max(100)).max(50).optional(),
 });
 
-const checklistPutSchema = z
-  .object({
-    meetingPoint: meetingPointSchema,
-    transport: transportSchema,
-    gear: gearSchema,
-    assignments: z.array(assignmentInputSchema).max(50).optional(),
-    notes: z.string().max(2000).optional(),
-  })
-  .refine(
-    // task #163 v1.1 spec §2.1：checklist 序列化后单字段 <2KB（软上限，防滥用）
-    (v) => JSON.stringify(v).length <= 2048,
-    { message: "checklist 内容过大（超过 2KB 上限）" },
-  );
+const checklistPutSchema = z.object({
+  meetingPoint: meetingPointSchema,
+  transport: transportSchema,
+  gear: gearSchema,
+  assignments: z.array(assignmentInputSchema).max(50).optional(),
+  notes: z.string().max(2000).optional(),
+});
+
+/** spec §2.1：checklist 序列化后单字段 <2KB（软上限，防滥用） */
+const CHECKLIST_MAX_BYTES = 2048;
 
 // ==================== 工具 ====================
-
-/** DB 里 checklist 可能是 JSON 字符串（driver 不同表现不同）；统一 parse 成对象 */
-function parseChecklist(raw: unknown): TeamChecklist | null {
-  if (raw === null || raw === undefined) return null;
-  if (typeof raw === "string") {
-    if (!raw) return null;
-    try {
-      return JSON.parse(raw) as TeamChecklist;
-    } catch {
-      return null;
-    }
-  }
-  return raw as TeamChecklist;
-}
 
 /**
  * 合并入参 assignments 与已有 assignments 的 id：
@@ -167,13 +151,31 @@ checklist.put("/:id/checklist", async (c) => {
       existing?.assignments,
     );
 
+    // B1（Martin CR）：spec 是「队长覆盖式更新整个 checklist」，未传字段视为清空。
+    // 之前用条件展开会保留旧值 → 与 spec 矛盾。这里改为无条件字段赋值。
     const next: TeamChecklist = {
-      ...(parsed.data.meetingPoint ? { meetingPoint: parsed.data.meetingPoint } : {}),
-      ...(parsed.data.transport ? { transport: parsed.data.transport } : {}),
-      ...(parsed.data.gear ? { gear: parsed.data.gear } : {}),
-      ...(normalizedAssignments.length ? { assignments: normalizedAssignments } : {}),
-      ...(parsed.data.notes ? { notes: parsed.data.notes } : {}),
+      meetingPoint: parsed.data.meetingPoint,
+      transport: parsed.data.transport,
+      gear: parsed.data.gear,
+      assignments: normalizedAssignments,
+      notes: parsed.data.notes,
     };
+
+    // S1（Martin CR）：<2KB 软上限从 zod refine 挪到落盘前显式校验，
+    // 返回 validationError 带明确 message，前端能落到 error.code 映射链路。
+    const serialized = JSON.stringify(next);
+    if (serialized.length > CHECKLIST_MAX_BYTES) {
+      return c.json(
+        APIErrors.validationError("checklist 内容过大（超过 2KB 上限）", [
+          {
+            code: "custom",
+            path: [],
+            message: `序列化后 ${serialized.length} 字节，上限 ${CHECKLIST_MAX_BYTES}`,
+          },
+        ]),
+        400,
+      );
+    }
 
     await db
       .update(schema.teams)

--- a/api/src/routes/teams/checklist.ts
+++ b/api/src/routes/teams/checklist.ts
@@ -1,0 +1,350 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { eq, and } from "drizzle-orm";
+import { APIErrors } from "../../lib/api-errors";
+import { logger } from "../../lib/logger";
+import { createAuth } from "../../lib/auth";
+import { createDb } from "../../db";
+import * as schema from "../../db/schema";
+import type { Env } from "../../lib/auth";
+import { generateId } from "../../lib/id";
+import { emitTeamActionbookEvent } from "../../lib/team-events";
+import type { TeamChecklist, ActionbookAssignment } from "@gomate/types";
+
+/**
+ * task #163（P0-A T1+T5）：Team「行动本」checklist 路由
+ *
+ * spec：notes/gomate-p0a-team-actionbook-spec.md v1.1 §2.3
+ *
+ * 两条路径：
+ *   PUT    /:id/checklist                                     队长覆盖式更新
+ *   POST   /:id/checklist/assignments/:assignmentId/claim     队员认领（幂等）
+ *   DELETE /:id/checklist/assignments/:assignmentId/claim     队员取消认领（幂等）
+ *
+ * 并发防漂移：assignment 用稳定 id 定位，不用 index。
+ * server 端总是负责 assigneeIds 去重、只允许操作自己。
+ */
+
+const checklist = new Hono<{ Bindings: Env }>();
+
+// ==================== Zod schemas ====================
+
+const meetingPointSchema = z
+  .object({
+    name: z.string().min(1).max(200),
+    time: z.string().max(50).optional(),
+    note: z.string().max(500).optional(),
+  })
+  .optional();
+
+const transportSchema = z
+  .object({
+    mode: z.enum(["self_drive", "public", "charter", "other"]),
+    detail: z.string().max(500).optional(),
+  })
+  .optional();
+
+const gearSchema = z
+  .object({
+    essential: z.array(z.string().min(1).max(50)).max(50),
+    optional: z.array(z.string().min(1).max(50)).max(50),
+    note: z.string().max(500).optional(),
+  })
+  .optional();
+
+/** 入参 assignment：id 可缺（新增项，server 补 uuid v4）；assigneeIds 可缺（默认 []） */
+const assignmentInputSchema = z.object({
+  id: z.string().min(1).max(100).optional(),
+  task: z.string().min(1).max(200),
+  assigneeIds: z.array(z.string().min(1).max(100)).max(50).optional(),
+});
+
+const checklistPutSchema = z
+  .object({
+    meetingPoint: meetingPointSchema,
+    transport: transportSchema,
+    gear: gearSchema,
+    assignments: z.array(assignmentInputSchema).max(50).optional(),
+    notes: z.string().max(2000).optional(),
+  })
+  .refine(
+    // task #163 v1.1 spec §2.1：checklist 序列化后单字段 <2KB（软上限，防滥用）
+    (v) => JSON.stringify(v).length <= 2048,
+    { message: "checklist 内容过大（超过 2KB 上限）" },
+  );
+
+// ==================== 工具 ====================
+
+/** DB 里 checklist 可能是 JSON 字符串（driver 不同表现不同）；统一 parse 成对象 */
+function parseChecklist(raw: unknown): TeamChecklist | null {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw === "string") {
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw) as TeamChecklist;
+    } catch {
+      return null;
+    }
+  }
+  return raw as TeamChecklist;
+}
+
+/**
+ * 合并入参 assignments 与已有 assignments 的 id：
+ * - 已有 id：保留 + 更新 task；assigneeIds 由队长入参覆盖（保留旧 id 意味着已认领关系不丢）
+ * - 缺 id 的新增项：server 补 uuid v4（generateId 沿用现有 nanoid）
+ * - 已有 assignmentId 若不在入参里：视为队长删除，直接不落库（关联的 claim 关系一并消失）
+ * - assigneeIds 强制去重
+ *
+ * 注意：入参 assignments 已经是队长的最终视图，此函数只做补 id + 去重。
+ */
+function normalizeAssignments(
+  input: z.infer<typeof assignmentInputSchema>[] | undefined,
+  existing: ActionbookAssignment[] | undefined,
+): ActionbookAssignment[] {
+  if (!input) return [];
+  const existingIds = new Set((existing ?? []).map((a) => a.id));
+  return input.map((item) => {
+    const id = item.id && existingIds.has(item.id) ? item.id : generateId();
+    const assigneeIds = Array.from(new Set(item.assigneeIds ?? []));
+    return { id, task: item.task, assigneeIds };
+  });
+}
+
+async function getTeamOr404(db: ReturnType<typeof createDb>, teamId: string) {
+  const team = await db.query.teams.findFirst({ where: eq(schema.teams.id, teamId) });
+  return team ?? null;
+}
+
+/** 队员必须是该队伍 approved 成员或队长本人才能认领 */
+async function assertJoined(
+  db: ReturnType<typeof createDb>,
+  teamId: string,
+  userId: string,
+  leaderId: string,
+): Promise<boolean> {
+  if (userId === leaderId) return true;
+  const member = await db.query.teamMembers.findFirst({
+    where: and(
+      eq(schema.teamMembers.teamId, teamId),
+      eq(schema.teamMembers.userId, userId),
+      eq(schema.teamMembers.status, "approved"),
+    ),
+  });
+  return !!member;
+}
+
+// ==================== PUT /:id/checklist ====================
+
+/**
+ * PUT /teams/:id/checklist
+ * 队长覆盖式更新整个 checklist。
+ * assignment id 保留策略：入参 id 若已存在则复用，否则 server 补新 uuid。
+ */
+checklist.put("/:id/checklist", async (c) => {
+  try {
+    const authInstance = createAuth(c.env);
+    const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
+
+    const teamId = c.req.param("id");
+    const db = createDb(c.env.DB);
+
+    const team = await getTeamOr404(db, teamId);
+    if (!team) return c.json(APIErrors.notFound("队伍不存在"), 404);
+    if (team.leaderId !== session.user.id)
+      return c.json(APIErrors.forbidden("只有队长可以编辑行动本"), 403);
+
+    const body = await c.req.json().catch(() => null);
+    const parsed = checklistPutSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json(APIErrors.validationError("输入无效", parsed.error.errors), 400);
+    }
+
+    const existing = parseChecklist(team.checklist);
+    const normalizedAssignments = normalizeAssignments(
+      parsed.data.assignments,
+      existing?.assignments,
+    );
+
+    const next: TeamChecklist = {
+      ...(parsed.data.meetingPoint ? { meetingPoint: parsed.data.meetingPoint } : {}),
+      ...(parsed.data.transport ? { transport: parsed.data.transport } : {}),
+      ...(parsed.data.gear ? { gear: parsed.data.gear } : {}),
+      ...(normalizedAssignments.length ? { assignments: normalizedAssignments } : {}),
+      ...(parsed.data.notes ? { notes: parsed.data.notes } : {}),
+    };
+
+    await db
+      .update(schema.teams)
+      .set({ checklist: next, updatedAt: new Date() })
+      .where(eq(schema.teams.id, teamId));
+
+    emitTeamActionbookEvent({
+      type: "checklist.updated",
+      teamId,
+      actorUserId: session.user.id,
+      timestamp: Date.now(),
+    });
+
+    return c.json({ success: true, checklist: next });
+  } catch (error) {
+    logger.error("Update checklist error:", error);
+    return c.json(APIErrors.internalError("更新行动本失败"), 500);
+  }
+});
+
+// ==================== POST /:id/checklist/assignments/:assignmentId/claim ====================
+
+/**
+ * POST /teams/:id/checklist/assignments/:assignmentId/claim
+ * 队员自助认领指定 assignment（幂等：重复调用不重复加）。
+ * 只能操作自己的 userId；assignment 不存在返回 404（防漂移）。
+ * 并发防丢失：用 updatedAt CAS 更新，冲突时重试一次。
+ */
+checklist.post("/:id/checklist/assignments/:assignmentId/claim", async (c) => {
+  try {
+    const authInstance = createAuth(c.env);
+    const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
+
+    const teamId = c.req.param("id");
+    const assignmentId = c.req.param("assignmentId");
+    const userId = session.user.id;
+    const db = createDb(c.env.DB);
+
+    const team = await getTeamOr404(db, teamId);
+    if (!team) return c.json(APIErrors.notFound("队伍不存在"), 404);
+
+    const joined = await assertJoined(db, teamId, userId, team.leaderId);
+    if (!joined) return c.json(APIErrors.forbidden("仅已加入的成员可认领分工"), 403);
+
+    // CAS 重试：并发时另一方先写 → 我们的 UPDATE where updatedAt=old 命中 0 行 → 重新读一次
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const current = attempt === 0
+        ? team
+        : await getTeamOr404(db, teamId);
+      if (!current) return c.json(APIErrors.notFound("队伍不存在"), 404);
+
+      const existing = parseChecklist(current.checklist);
+      const assignments = existing?.assignments ?? [];
+      const idx = assignments.findIndex((a) => a.id === assignmentId);
+      if (idx < 0) return c.json(APIErrors.notFound("分工不存在或已被删除"), 404);
+
+      const target = assignments[idx];
+      if (target.assigneeIds.includes(userId)) {
+        // 幂等：已认领，直接返回当前状态
+        return c.json({ success: true, assignment: target });
+      }
+
+      const next: ActionbookAssignment = {
+        ...target,
+        assigneeIds: [...target.assigneeIds, userId],
+      };
+      const nextAssignments = assignments.slice();
+      nextAssignments[idx] = next;
+      const nextChecklist: TeamChecklist = { ...existing, assignments: nextAssignments };
+
+      // compare-and-swap：where updatedAt = 当前值
+      const result = await db
+        .update(schema.teams)
+        .set({ checklist: nextChecklist, updatedAt: new Date() })
+        .where(and(eq(schema.teams.id, teamId), eq(schema.teams.updatedAt, current.updatedAt)))
+        .returning({ id: schema.teams.id });
+
+      if (result.length > 0) {
+        emitTeamActionbookEvent({
+          type: "assignment.claim_changed",
+          action: "claim",
+          teamId,
+          assignmentId,
+          actorUserId: userId,
+          timestamp: Date.now(),
+        });
+        return c.json({ success: true, assignment: next });
+      }
+      // CAS 失败：另一方先写，进入下一轮重读
+    }
+    // 两次都失败，返回 409 让客户端重试
+    return c.json(APIErrors.conflict("并发写入冲突，请重试"), 409);
+  } catch (error) {
+    logger.error("Claim assignment error:", error);
+    return c.json(APIErrors.internalError("认领分工失败"), 500);
+  }
+});
+
+// ==================== DELETE /:id/checklist/assignments/:assignmentId/claim ====================
+
+/**
+ * DELETE /teams/:id/checklist/assignments/:assignmentId/claim
+ * 队员取消认领（幂等：不在时返回 204 语义 —— 走 204 no content）。
+ * 并发防丢失：用 updatedAt CAS 更新，冲突时重试一次。
+ */
+checklist.delete("/:id/checklist/assignments/:assignmentId/claim", async (c) => {
+  try {
+    const authInstance = createAuth(c.env);
+    const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
+
+    const teamId = c.req.param("id");
+    const assignmentId = c.req.param("assignmentId");
+    const userId = session.user.id;
+    const db = createDb(c.env.DB);
+
+    const team = await getTeamOr404(db, teamId);
+    if (!team) return c.json(APIErrors.notFound("队伍不存在"), 404);
+
+    const joined = await assertJoined(db, teamId, userId, team.leaderId);
+    if (!joined) return c.json(APIErrors.forbidden("仅已加入的成员可取消认领"), 403);
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const current = attempt === 0
+        ? team
+        : await getTeamOr404(db, teamId);
+      if (!current) return c.json(APIErrors.notFound("队伍不存在"), 404);
+
+      const existing = parseChecklist(current.checklist);
+      const assignments = existing?.assignments ?? [];
+      const idx = assignments.findIndex((a) => a.id === assignmentId);
+      if (idx < 0) return c.json(APIErrors.notFound("分工不存在或已被删除"), 404);
+
+      const target = assignments[idx];
+      if (!target.assigneeIds.includes(userId)) {
+        // 幂等：本来就没认领，直接返回当前状态
+        return c.body(null, 204);
+      }
+
+      const next: ActionbookAssignment = {
+        ...target,
+        assigneeIds: target.assigneeIds.filter((uid) => uid !== userId),
+      };
+      const nextAssignments = assignments.slice();
+      nextAssignments[idx] = next;
+      const nextChecklist: TeamChecklist = { ...existing, assignments: nextAssignments };
+
+      const result = await db
+        .update(schema.teams)
+        .set({ checklist: nextChecklist, updatedAt: new Date() })
+        .where(and(eq(schema.teams.id, teamId), eq(schema.teams.updatedAt, current.updatedAt)))
+        .returning({ id: schema.teams.id });
+
+      if (result.length > 0) {
+        emitTeamActionbookEvent({
+          type: "assignment.claim_changed",
+          action: "unclaim",
+          teamId,
+          assignmentId,
+          actorUserId: userId,
+          timestamp: Date.now(),
+        });
+        return c.body(null, 204);
+      }
+    }
+    return c.json(APIErrors.conflict("并发写入冲突，请重试"), 409);
+  } catch (error) {
+    logger.error("Unclaim assignment error:", error);
+    return c.json(APIErrors.internalError("取消认领失败"), 500);
+  }
+});
+
+export default checklist;

--- a/api/src/routes/teams/index.ts
+++ b/api/src/routes/teams/index.ts
@@ -5,6 +5,7 @@ import queries from "./queries";
 import mutations from "./mutations";
 import membership from "./membership";
 import status from "./status";
+import checklist from "./checklist";
 
 const teams = new Hono<{ Bindings: Env }>();
 
@@ -37,6 +38,12 @@ teams.route("/:id", membership);
 // POST /teams/:id/members/:userId/approve-leave
 // POST /teams/:id/members/:userId/reject-leave
 teams.route("/:id", status);
+
+// Mount checklist routes (task #163 Team「行动本」)
+// PUT    /teams/:id/checklist
+// POST   /teams/:id/checklist/assignments/:assignmentId/claim
+// DELETE /teams/:id/checklist/assignments/:assignmentId/claim
+teams.route("/", checklist);
 
 export default teams;
 export { teams as teamsRoute };

--- a/api/src/routes/teams/queries.ts
+++ b/api/src/routes/teams/queries.ts
@@ -461,6 +461,17 @@ queries.get("/:id", async (c) => {
           extra: leader.extra || null,
         } : { id: "unknown", name: "未知用户", avatar: "", level: "beginner", completedHikes: 0, bio: "" },
         members: relevantMembers,
+        // task #163：Team「行动本」checklist（未填 = undefined）
+        // DB 里可能是 JSON 字符串（driver 差异），此处不 parse——由 API 消费者/前端做，或后续统一到 checklist 路由
+        checklist: (() => {
+          const raw = teamWithRelations.checklist as unknown;
+          if (raw === null || raw === undefined) return undefined;
+          if (typeof raw === "string") {
+            if (!raw) return undefined;
+            try { return JSON.parse(raw); } catch { return undefined; }
+          }
+          return raw;
+        })(),
       },
     });
   } catch (error) {

--- a/api/src/routes/teams/queries.ts
+++ b/api/src/routes/teams/queries.ts
@@ -10,6 +10,7 @@ import { formatBeijingDateTime } from "../../lib/date-utils";
 import { getCachedOrFetch, buildListCacheKey, setPublicCacheHeaders } from "../../lib/cache";
 import { updateExpiredTeams } from "../../lib/team-status";
 import { APIErrors } from "../../lib/api-errors";
+import { parseChecklist } from "../../lib/team-checklist-utils";
 
 const queries = new Hono<{ Bindings: Env }>();
 
@@ -462,16 +463,8 @@ queries.get("/:id", async (c) => {
         } : { id: "unknown", name: "未知用户", avatar: "", level: "beginner", completedHikes: 0, bio: "" },
         members: relevantMembers,
         // task #163：Team「行动本」checklist（未填 = undefined）
-        // DB 里可能是 JSON 字符串（driver 差异），此处不 parse——由 API 消费者/前端做，或后续统一到 checklist 路由
-        checklist: (() => {
-          const raw = teamWithRelations.checklist as unknown;
-          if (raw === null || raw === undefined) return undefined;
-          if (typeof raw === "string") {
-            if (!raw) return undefined;
-            try { return JSON.parse(raw); } catch { return undefined; }
-          }
-          return raw;
-        })(),
+        // driver 差异 parse 兜底统一到 parseChecklist（api/src/lib/team-checklist-utils.ts）
+        checklist: parseChecklist(teamWithRelations.checklist) ?? undefined,
       },
     });
   } catch (error) {

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -10,11 +10,7 @@
     "outDir": "dist",
     "rootDir": "src",
     "jsx": "react-jsx",
-    "jsxImportSource": "react",
-    "paths": {
-      "@gomate/types": ["../packages/types/src/index.ts"],
-      "@gomate/types/*": ["../packages/types/src/*.ts"]
-    }
+    "jsxImportSource": "react"
   },
   "include": ["src/**/*"]
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -4,6 +4,9 @@
  */
 
 export * from "./enums";
+export * from "./team-checklist";
+// 显式 import 以便本文件 Team 接口的 checklist 字段可引用（export * 不引入 local scope）
+import type { TeamChecklist } from "./team-checklist";
 
 /** ISO 格式时间戳 */
 export type Timestamp = string;
@@ -113,6 +116,8 @@ export interface Team {
   createdAt: Timestamp;
   members?: TeamMember[];
   location?: Location;
+  /** task #163：行动本 checklist（未填 = undefined） */
+  checklist?: TeamChecklist;
 }
 
 /** 用户公开资料 */

--- a/packages/types/src/team-checklist.ts
+++ b/packages/types/src/team-checklist.ts
@@ -1,0 +1,104 @@
+/**
+ * task #163（P0-A T1+T5）：Team「行动本」checklist 类型 + 通知钩子事件 payload
+ *
+ * spec：notes/gomate-p0a-team-actionbook-spec.md（v1.1）
+ * - checklist 单 JSON 字段而非子表（<2KB，D1 batch 简单）
+ * - assignment 用稳定 id（uuid）而非 index，防并发漂移
+ * - assigneeIds[] 支持多人认领同一任务；server 端去重
+ * - 队长 PUT 覆盖式，队员 POST/DELETE claim 独立路径
+ */
+
+/** 集合信息 */
+export interface ActionbookMeetingPoint {
+  name: string;
+  /** 集合时间（可选，与 team.startTime 不同才填） */
+  time?: string;
+  /** 备注：例如「不见不散，迟到 15 分钟不等」 */
+  note?: string;
+}
+
+/** 交通方案 */
+export type ActionbookTransportMode = "self_drive" | "public" | "charter" | "other";
+
+export interface ActionbookTransport {
+  mode: ActionbookTransportMode;
+  /** 自由文本：车辆数/拼车联系人/公交路线等 */
+  detail?: string;
+}
+
+/** 装备清单（分级） */
+export interface ActionbookGear {
+  essential: string[];
+  optional: string[];
+  note?: string;
+}
+
+/**
+ * 分工任务。
+ * - id 稳定，认领接口按 id 定位（不用 index，防并发漂移）
+ * - assigneeIds 支持多人认领；server 负责去重、只允许操作自己
+ */
+export interface ActionbookAssignment {
+  id: string;
+  task: string;
+  assigneeIds: string[];
+}
+
+/** Team「行动本」checklist 完整结构 */
+export interface TeamChecklist {
+  meetingPoint?: ActionbookMeetingPoint;
+  transport?: ActionbookTransport;
+  gear?: ActionbookGear;
+  assignments?: ActionbookAssignment[];
+  /** 其他约定（自由文本，支持基础 markdown） */
+  notes?: string;
+}
+
+// ============================================================================
+// 通知钩子事件（T5 合并进 T1，本 spec 只留 payload 类型 + emit 点，不接推送渠道）
+// ============================================================================
+
+/** 队长更新 checklist */
+export interface ChecklistUpdatedEvent {
+  type: "checklist.updated";
+  teamId: string;
+  actorUserId: string;
+  timestamp: number;
+}
+
+/** 队员认领/取消认领（合并成一个事件，用 action 区分——减一半推送分支） */
+export interface AssignmentClaimChangedEvent {
+  type: "assignment.claim_changed";
+  action: "claim" | "unclaim";
+  teamId: string;
+  assignmentId: string;
+  actorUserId: string;
+  timestamp: number;
+}
+
+/**
+ * 队伍开始前 24h 触发点（P1 定时任务）。
+ * 当前 MVP 不接 cron；此类型仅定义 payload，emit 触发点未接入调度器。
+ */
+export interface TeamStartingSoonEvent {
+  type: "team.starting_soon";
+  teamId: string;
+  startTime: number;
+  timestamp: number;
+}
+
+/**
+ * 队伍结束后 6h 触发点（P1 定时任务，短复盘引导）。
+ * 当前 MVP 不接 cron；此类型仅定义 payload，emit 触发点未接入调度器。
+ */
+export interface TeamCompletedEvent {
+  type: "team.completed";
+  teamId: string;
+  timestamp: number;
+}
+
+export type TeamActionbookEvent =
+  | ChecklistUpdatedEvent
+  | AssignmentClaimChangedEvent
+  | TeamStartingSoonEvent
+  | TeamCompletedEvent;


### PR DESCRIPTION
## 关联

- task #163（P0-A T1+T5）
- spec：notes/gomate-p0a-team-actionbook-spec.md v1.1 §2 / §7
- Martin CR pass 记录：#proj-gomate:88ff8e5a（三点反馈全部落地 + CAS 方案确认）

## 改动概览

### 数据层（T1）

- **`api/db/migrations/0014_teams_checklist.sql`**（新增）
  - `ALTER TABLE teams ADD checklist TEXT` — nullable JSON 单字段
  - 选型对齐 spec §2.1：JSON <2KB、无 SQL 层查询需求 → 单字段而非子表
- **`api/db/migrations/meta/0014_snapshot.json`**（新增）+ `_journal.json` idx=14
- **`api/src/db/schema.ts`**：`teams.checklist: text($type<TeamChecklist>)`（15 列）
- **`api/src/__tests__/helpers/db.ts`**：测试 sqlite teams 表补 `checklist` 列

### 类型（共享）

- **`packages/types/src/team-checklist.ts`**（新增）
  - `TeamChecklist` / `ActionbookAssignment` 等类型
  - **事件 payload 4 类**：`ChecklistUpdatedEvent` / `AssignmentClaimChangedEvent`（合并 claimed/unclaimed，用 `action` 区分——Martin CR 复核后精简）/ `TeamStartingSoonEvent` / `TeamCompletedEvent`（后两者只保留类型，本 PR 不接 cron）
- **`packages/types/src/index.ts`**：re-export + `Team.checklist?`

### 路由（T1）

**`api/src/routes/teams/checklist.ts`**（新增）三条路径：

| 路径 | 权限 | 语义 |
|---|---|---|
| `PUT /teams/:id/checklist` | 队长 | 覆盖式更新；assignment.id 已有则复用（认领关系不丢），缺 id 补 nanoid |
| `POST /teams/:id/checklist/assignments/:aid/claim` | approved 成员或队长本人 | 认领；幂等 |
| `DELETE /teams/:id/checklist/assignments/:aid/claim` | approved 成员或队长本人 | 取消认领；幂等 204 |

设计要点：
1. `assignmentId` 稳定 id 定位（非 index，防并发漂移，spec §2.3）
2. `assigneeIds` server 端强制去重、只允许操作自己 userId
3. **并发防丢失**：claim/unclaim 走 CAS（`UPDATE ... WHERE id = ? AND updatedAt = ?` + `.returning()` 判命中），冲突重读重试一次；两次都失败返 409 让 client 重试
4. **软上限**：PUT body 序列化后 `<=2048` 字节（zod refine），超限 400
5. `GET /teams/:id` 顺手把 checklist 带回给前端

### 通知钩子（T5）

**`api/src/lib/team-events.ts`**（新增）
- `emitTeamActionbookEvent(event)`：同步纯函数，`logger.info` 落审计线索
- Cloudflare 冷启动敏感 → 无 IO、不 await、不阻塞主请求
- `team.starting_soon` / `team.completed` payload 类型保留但**本 PR 不接调度器**（P1 立项时按事件类型回填推送逻辑，前后端零改动接入）

### 工程决策：api tsconfig 首次跨引 packages/types

- **原状**：`api/tsconfig.json` `paths: ["@gomate/types" → "../packages/types/src/index.ts"]` 直接指向包外源码 → 触发 rootDir 越界报错（此前 api 从未跨引 packages/types）
- **本 PR 选择**：删掉 `paths`，走 pnpm workspace symlink → `node_modules/@gomate/types/package.json` main（`./src/index.ts`）
- **验证**：type-check ✅ / build ✅（dist 干净，无跨包污染）
- 若后续 CR 认为该切换到 project references（standard 方案），可单独立项——会动 base tsconfig

## 本地验证

```bash
pnpm --filter @gomate/api type-check     # ✅
pnpm --filter @gomate/api lint            # ✅
pnpm --filter @gomate/api build           # ✅（dist 干净）
pnpm --filter @gomate/api test            # ✅ 205/205（+18 checklist 用例）
pnpm --filter @gomate/types type-check    # ✅
pnpm --filter @gomate/frontend type-check # ✅
pnpm --filter @gomate/api db:generate     # ✅ "No schema changes"（三闸对齐）
```

新增 18 个集成用例覆盖：
- PUT：匿名 401 / 非队长 403 / 队伍不存在 404 / 完整字段落盘 / assignment id 复用 vs 新生成 / assigneeIds 去重 / task 空 400 / 序列化 >2KB 400
- POST claim：匿名 401 / 路人 403 / assignmentId 不存在 404 / 幂等 200 / 队长本人可认领
- DELETE claim：匿名 401 / 路人 403 / 不存在 404 / 幂等 204
- 防漂移：队长删掉 assignment 后旧 id 认领返 404、不误伤同 index 的其他 assignment

## 已知风险与回滚

- **迁移**：0014 ADD COLUMN 单语句天然原子；`wrangler d1 migrations apply` 已跟踪 idx，重跑安全；生产回滚只需 `ALTER TABLE teams DROP checklist`（D1 支持 3.35+ 语法），前端在此期间读到 undefined 视为「未填」，无 breaking
- **生产资源变更**：仅 D1 schema，无 R2 / KV / secrets
- **回滚路径**：revert 本 PR + drop 列即可，无中间态兼容问题
- **并发正确性**：CAS 保护了 read-modify-write，但集成测试用 better-sqlite3 同步 driver 无法真并发验证——生产（D1）验收时观察 409 出现频率

## 下一步（不在本 PR）

- T2 详情页渲染 / T3 编辑页表单：等本 PR 合并后 Phase 2 并行接手
- P1 立项接 cron 时接入 `team.starting_soon` / `team.completed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)