### PR TITLE
docs: 入库 P0-B/C/D 三份设计 spec v1.0

### DIFF
--- a/notes/gomate-p0b-location-decision-spec.md
+++ b/notes/gomate-p0b-location-decision-spec.md
@@ -1,0 +1,371 @@
+# gomate P0-B：地点详情页决策信息设计规范 v1.0
+
+> 需求：@Victor 2026-07-19/20（认同「体验的另一半」后，要求继续推进 P0 全套）
+> 依据：`notes/gomate-ux-experience-analysis.md` §三-P0-2
+> 设计者：@Steven
+> 范围：地点详情页 `/locations/[id]`（改造）
+> 交付给：Martin 拆任务
+
+> **v1.0 范围说明**：Victor 2026-07-20 拍板「天气先不加」，故本 spec 不包含「本周天气条件」卡片。**三块**：①怎么到（amap 已接入，需显式化为决策信息块）②季节适宜度（schema 已有 bestSeason 字段，需可视化呈现）③分级装备清单（schema 已有 tips 字段，需拆出 essential/optional）
+
+---
+
+## 0. 目标
+
+**让用户 3 秒内回答：「我周六早晨从福田出发能不能玩得舒服」。**
+
+把「地点是什么」补成「我能不能去、怎么去、什么季节去合适、要带什么」。
+
+---
+
+## 1. 顾客损失 → 设计对应
+
+| 顾客损失（用户勉强接受的现实） | 设计对应                                     | §   |
+| ------------------------------ | -------------------------------------------- | --- |
+| 「要查天气吗？」               | P1 推迟，本 spec 不含                        | —   |
+| 「怎么坐车到？」               | 详情页加**「怎么到」决策信息块**             | §3  |
+| 「现在这个季节合适吗？」       | 详情页加**「季节适宜度」标记**               | §4  |
+| 「要带什么装备？」             | 详情页加**「分级装备清单」**                 | §5  |
+| 「地铁出来要走多远？」         | 怎么到块内含**「最近地铁站 + 步行 N 分钟」** | §3  |
+| 「停车方便吗？」               | 怎么到块内含**停车信息**                     | §3  |
+
+---
+
+## 2. 不做什么（明确边界）
+
+- ❌ **不显示「本周天气」卡片**（Victor 拍板 2026-07-20 天气先不加）
+- ❌ **不显示「实时温度」/「降水概率」**——避免引入天气 API 选型问题，留 P1
+- ❌ **不显示「其他人也去过这里」**——P0-D 的事，本 spec 边界
+- ❌ **不重做 LocationIntroCard 整体布局**——只在现有「徒步参数」区块下加新区块
+- ❌ **不引入新的运动/活动场景**（攀岩/溯溪等）——只覆盖「徒步」一种
+
+---
+
+## 3. 「怎么到」决策信息块
+
+### 3.1 位置
+
+放在 LocationIntroCard **徒步参数区块下、装备清单上**，作为新的独立卡片区块。
+
+### 3.2 数据来源
+
+**全部复用现有数据**（无需新表、无需新字段）：
+
+- **坐标**：locations 表已有 lat/lng
+- **最近地铁站**：amap API（gomate 现有 `address-row.tsx:31` 已调用 amap navigation，可直接复用 + 扩展）
+- **停车**：locations 表需加字段 OR 用 description 文本中关键词（见 §3.4 决策点）
+- **自驾时长**：高德 amap 路径规划 API（已有 key 复用）
+
+### 3.3 信息结构
+
+```
+┌─ 怎么到 ────────────────────────────┐
+│                                       │
+│  🚇 最近地铁                          │
+│    地铁 4 号线 福田口岸站               │
+│    A 出口出站后步行 8 分钟               │
+│                                       │
+│  🚗 自驾 / 打车                       │
+│    距深圳市中心约 35 km                 │
+│    高峰时段约 50 分钟                   │
+│    [📍 在地图打开]                      │
+│                                       │
+│  🅿️ 停车                              │
+│    山下有停车场，5 元/小时，周末紧张     │
+│    或：公共交通建议（无停车信息时）       │
+│                                       │
+└───────────────────────────────────────┘
+```
+
+### 3.4 关键决策点（需要 Victor 拍板）
+
+**停车信息字段问题**：gomate 当前 locations 表**没有 `parkingInfo` 字段**。
+
+两条路：
+
+**A. 新加 `parkingInfo: text` 字段**（推荐）
+
+- 字段简短（<100 字），运营手动填
+- 与 description/tips 字段结构对齐
+- 数据真实，无「自动推断」风险
+- **需要 Victor 同意 schema 变更**（CLAUDE.md 红线）
+
+**B. 用 description 中关键词自动抽取**
+
+- 写规则匹配「停车」「parking」关键词
+- 缺点：location description 是用户自由文本，关键词命中率不稳定
+- 风险：抽取不到时区块显示空白
+
+**我推荐 A**——可治理的字段 + 真实数据 + 一致体验。但需要 Victor 点头。
+
+### 3.5 交互细节
+
+- **「📍 在地图打开」**：调 amap navigation API（已有 `uri.amap.com/navigation` 模板复用），在新标签打开
+- **地铁站步行时间**：调 amap 步行路径规划 API，超 800 米时显示「建议骑车/打车接驳」
+- **自驾时长**：调 amap 驾车路径规划 API，**默认算非高峰时段**（早 10 点出发），hover 显示「高峰时段约 X 分钟」
+- **未填字段不渲染**：停车未填时只显示公共交通建议，不显示空白
+
+### 3.6 i18n
+
+新增 `locations.transportation.*` keys：
+
+```
+transit.subway = "最近地铁" / "Nearest Subway" / "最寄り駅"
+transit.subway_walk = "{station} · 步行 {n} 分钟" / "{station} · {n}-min walk" / "{station} · 徒歩 {n} 分"
+transit.drive = "自驾 / 打车" / "Driving" / "車"
+transit.drive_distance = "距{landmark}约 {km} km" / "{km} km from {landmark}" / "{landmark} から約 {km} km"
+transit.drive_duration = "约 {n} 分钟" / "~{n} min" / "約 {n} 分"
+transit.parking = "停车" / "Parking" / "駐車場"
+transit.parking_tight = "周末紧张" / "Tight on weekends" / "週末は混み合う"
+transit.no_parking = "建议公共交通" / "Public transit recommended" / "公共交通機関推奨"
+transit.map_link = "在地图打开" / "Open in Maps" / "地図で開く"
+transit.transfer_hint = "建议骑车/打车接驳" / "Bike/taxi transfer recommended" / "自転車/タクシーで乗り継ぎ推奨"
+```
+
+---
+
+## 4. 「季节适宜度」标记
+
+### 4.1 位置
+
+放在「怎么到」块下、装备清单上。
+
+### 4.2 数据来源
+
+- **现有字段**：`locations.bestSeason`（comma-separated，例：「Spring,Autumn」）
+- **当前 i18n**：`seasons.spring/summer/autumn/winter` 已有 en/zh/ja 翻译
+- **en/ja 已有月份范围**：`seasons.spring.months = "Mar-May"`（参考现成）
+
+### 4.3 视觉结构
+
+```
+┌─ 适宜季节 ────────────────────────────┐
+│                                       │
+│  ✓ 推荐春季（3-5 月）                    │
+│  ✓ 推荐秋季（9-11 月）                  │
+│  ⚠️ 夏季闷热注意防晒（6-8 月）          │
+│  ❌ 冬季雨季路滑（12-2 月）              │
+│                                       │
+└───────────────────────────────────────┘
+```
+
+### 4.4 推荐 vs 警示 vs 不推荐的判定逻辑
+
+gomate 当前只有 `bestSeason` 一个字段，**没有「avoidSeason」或「seasonalWarnings」字段**。
+
+两条路：
+
+**A. 只用 bestSeason**（推荐 MVP）
+
+- 只显示「推荐春/夏/秋/冬」标记
+- 警示/不推荐留 P1 加字段
+- 与运营当前输入心智模型对齐（运营只需填「推荐季节」）
+
+**B. 加 seasonalWarnings 字段**
+
+- 运营额外填「夏季闷热」「冬季雨季」等警示
+- 信息更丰富但运营心智成本上升
+- **需要 Victor 同意 schema 变更**
+
+**我推荐 A**——MVP 阶段只显示推荐季节。警示/不推荐是后续 P1 的事。
+
+### 4.5 当前季节判定逻辑
+
+- 根据用户当前日期 + 地理位置（默认深圳 adcode）判断当前是哪个季节
+- 当前季节 = 推荐季节 → 整块用 `bg-emerald-50` 标记「**现在去正好**」
+- 当前季节非推荐 → 显示「**当前非最佳季节，建议春季/秋季前往**」副标题
+- 季节判断用本地时间，不调远程 API
+
+### 4.6 i18n
+
+新增 `locations.season.*` keys：
+
+```
+season.title = "适宜季节" / "Best Season" / "ベストシーズン"
+season.now_optimal = "现在去正好" / "Now is the best time" / "今がベストシーズン"
+season.not_now = "当前非最佳季节" / "Not the best season now" / "今はベストシーズンではありません"
+season.recommended = "推荐{season}" / "Recommended: {season}" / "{season} 推奨"
+season.warning = "建议{season}前往" / "{season} recommended" / "{season} 推奨"
+season.now = "现在" / "Now" / "現在"
+season.months = "{start}-{end} 月" / "{start}-{end}" / "{start}月-{end}月"
+```
+
+**复用现有 `seasons.spring/summer/autumn/winter.label`**（已在 locales-data.ts），不重复定义。
+
+---
+
+## 5. 分级装备清单
+
+### 5.1 位置
+
+放在季节适宜度块下、组队 tab 上。
+
+### 5.2 数据来源
+
+- **现有字段**：`locations.tips`（自由文本，例：「穿登山鞋、备 2L 水、防晒霜」）
+- **没有专门的 `gear` 字段**
+
+### 5.3 视觉结构
+
+```
+┌─ 装备清单 ────────────────────────────┐
+│                                       │
+│  ✓ 必带                                │
+│    登山鞋 · 2L 水 · 防晒霜 · 帽子         │
+│                                       │
+│  ◯ 选带                                │
+│    登山杖 · 护膝 · 头灯 · 备用电池        │
+│                                       │
+│  📝 注意事项                            │
+│    山顶风大，建议带薄外套                  │
+│    中途无补给站                        │
+│                                       │
+└───────────────────────────────────────┘
+```
+
+### 5.4 数据结构（关键决策）
+
+**当前 tips 是自由文本**——运营写「登山鞋、2L 水、防晒霜」。要做分级装备，必须有结构化字段。
+
+三条路：
+
+**A. 加结构化字段**（推荐）
+
+- 新字段：`gearEssential: text`（comma-separated，「登山鞋,2L 水,防晒霜,帽子」）
+- 新字段：`gearOptional: text`（comma-separated，「登山杖,护膝,头灯,备用电池」）
+- 保留 `tips` 字段做「注意事项」自由文本
+- 运营心智成本低（3 个字段对齐三块视觉）
+- **需要 Victor 同意 schema 变更**
+
+**B. 自动从 tips 抽取关键词**
+
+- 用关键词匹配（鞋/水/霜/帽）分类
+- 缺点：tips 写「建议穿运动鞋、备两瓶水」，关键词命中但语义不严
+- 风险：抽取不准确时用户对清单失去信任
+
+**C. 不分级，只显示自由文本 tips**
+
+- 视觉单薄，P0-B 价值打折
+- 不推荐
+
+**我推荐 A**——一次 schema 变更换 3 块结构化视觉，运营填表成本只增加 1 行。
+
+### 5.5 i18n
+
+新增 `locations.gear.*` keys：
+
+```
+gear.title = "装备清单" / "Gear List" / "装備リスト"
+gear.essential = "必带" / "Essential" / "必携"
+gear.optional = "选带" / "Optional" / "任意"
+gear.notes = "注意事项" / "Notes" / "注意事項"
+```
+
+---
+
+## 6. schema 变更请求汇总（需 Victor 一次性拍板）
+
+如果 Victor 接受 §3.4-A / §5.4-A，P0-B 需要 3 个新字段（一次性加）：
+
+| 表          | 字段             | 类型           | 说明                        |
+| ----------- | ---------------- | -------------- | --------------------------- |
+| `locations` | `parking_info`   | text, nullable | 停车信息，自由文本，<100 字 |
+| `locations` | `gear_essential` | text, nullable | 必带装备，comma-separated   |
+| `locations` | `gear_optional`  | text, nullable | 选带装备，comma-separated   |
+
+**保留**：`tips` 字段做「注意事项」自由文本，不替换。
+
+**风险评估**：
+
+- 3 个字段全部 nullable，旧数据自动兼容
+- Drizzle migration 新增字段无破坏性
+- 可与 P0-A 的 `teams.checklist` / `users.city` migration 一起做（独立表）
+- 不需要数据回填（旧 location 字段全 null，前端按未填处理）
+
+**CLAUDE.md 红线触发**：这是 schema 变更，需要 Victor 明确同意。已在 §3.4 / §5.4 标记，需在本 spec 评审时一次拍板。
+
+---
+
+## 7. 性能与实现约束
+
+- **「怎么到」块**的地铁站/驾车时长用 SSR 渲染 + ISR（revalidate 24h），不实时调用 amap
+- **amap API 调用**走现有封装（gomate 有 shared utils），统一 5xx 错误处理
+- **季节判断**纯前端逻辑（基于当前日期 + 地理位置），无远程调用
+- **装备清单**纯静态渲染，无交互
+- **数据未填时**整块不渲染（不占视觉空间）
+
+---
+
+## 8. 交付给 Martin 的任务拆分建议
+
+按依赖 + 可并行性，建议拆 3 个子任务：
+
+### T1：schema + API（后端基础）
+
+- **改动**：
+  - `api/src/db/schema.ts`：locations 表加 3 个字段（`parking_info` / `gear_essential` / `gear_optional`）
+  - drizzle migration（仅新增 nullable 字段）
+  - `api/src/routes/locations/queries.ts`：GET location 详情 include 新字段
+  - `api/src/utils/amap.ts`：扩展封装驾车路径规划 + 步行路径规划接口
+- **依赖**：amap API key 已在 .env，零外部依赖
+- **验收**：3 字段 nullable 默认、旧数据兼容、amap 调用 5xx 错误降级
+
+### T2：详情页三块视觉（前端主要工作量）
+
+- **依赖**：T1
+- **改动**：
+  - `frontend/src/components/features/location-detail/`：新增 `transport-block.tsx`（怎么到）、`season-block.tsx`（季节适宜度）、`gear-block.tsx`（装备清单）
+  - 三块插入到现有 `LocationIntroCard` / `RouteInfoCard` 之间
+  - 「现在去正好」用 emerald-50 背景高亮
+  - 装备 essential/optional 分级图标（✓ 和 ◯）
+- **验收**：未填字段不渲染、当前季节判断准确、三语言 i18n keys 完整
+
+### T3：i18n keys + 运营后台录入支持
+
+- **依赖**：T1
+- **改动**：
+  - `frontend/src/i18n/locales-data.ts`：新增 §3.6 / §4.6 / §5.5 所有 keys（zh/en/ja）
+  - `frontend/src/pages/admin/` 区域的管理表单（如有）：加 parking_info / gear_essential / gear_optional 输入框
+  - 验证脚本 `scripts/validate-i18n-keys.mjs` 跑过
+- **验收**：3 语言 key 数量一致、CI 拦截缺失
+
+**推荐执行顺序**：
+
+- Phase 1：T1（schema 变更需 Victor 一次性同意）
+- Phase 2（并行）：T2 + T3
+
+---
+
+## 9. 验收标准
+
+Wen 测试用例覆盖：
+
+1. location 详情页未填新字段时，三块都不渲染（不显示空态卡片）
+2. location 详情页填了新字段，三块按 §3.3 / §4.3 / §5.3 结构渲染
+3. 当前日期在 recommended season → 显示「现在去正好」高亮
+4. 当前日期不在 recommended season → 显示「当前非最佳季节」副标题
+5. amap 5xx 错误降级（地铁站/驾车时长字段不渲染，其他字段保留）
+6. 三语言 i18n 完整（zh/en/ja），无遗漏 key
+7. 移动端三块折叠/展开交互（与现有 RouteInfoCard 行为一致）
+
+---
+
+## 10. 与 P0-A / P0-C / P0-D 的关系
+
+| P0               | 关系                                                                                     |
+| ---------------- | ---------------------------------------------------------------------------------------- |
+| P0-A Team 行动本 | 无 schema 冲突；T1 都可与 #163/#164 migration 一起做                                     |
+| P0-C 首页推荐    | 详情页新增的「季节适宜度」可作为 P0-C「稳的」推荐位的输入信号（推荐季节 × 当前季节匹配） |
+| P0-D 本地圈子    | 无直接依赖                                                                               |
+
+**合并建议**：如果 Victor 同意本 spec 3 字段 schema 变更，可与 P0-A #163/#164 / P0-C 推荐位规则 / P0-D 本地圈子 B 方案**一起评估**，作为单次「P0 全套 schema 变更」提交给 Victor 拍板，避免多次打扰。
+
+---
+
+## 11. 一句话总结
+
+**P0-B 把地点详情页从「地点是什么」补成「我能不能去、怎么去、什么季节去合适、要带什么」——通过「怎么到」+「季节适宜度」+「分级装备清单」三块结构化信息，对应每个顾客损失点直接消除。需要 Victor 同意 3 个 nullable 字段的 schema 变更。**
+
+---
+
+_spec v1.0 完成，等 Victor 对 §3.4 / §5.4 schema 变更 + §7 「amap 5xx 降级」决策确认后提 Martin 拆任务。_

--- a/notes/gomate-p0b-location-decision-spec.md
+++ b/notes/gomate-p0b-location-decision-spec.md
@@ -1,4 +1,4 @@
-# gomate P0-B：地点详情页决策信息设计规范 v1.0
+# gomate P0-B：地点详情页决策信息设计规范 v1.1
 
 > 需求：@Victor 2026-07-19/20（认同「体验的另一半」后，要求继续推进 P0 全套）
 > 依据：`notes/gomate-ux-experience-analysis.md` §三-P0-2
@@ -6,7 +6,14 @@
 > 范围：地点详情页 `/locations/[id]`（改造）
 > 交付给：Martin 拆任务
 
-> **v1.0 范围说明**：Victor 2026-07-20 拍板「天气先不加」，故本 spec 不包含「本周天气条件」卡片。**三块**：①怎么到（amap 已接入，需显式化为决策信息块）②季节适宜度（schema 已有 bestSeason 字段，需可视化呈现）③分级装备清单（schema 已有 tips 字段，需拆出 essential/optional）
+> **v1.1 变更**（2026-07-20 Martin CR PR #393 + Victor DM 拍板）：
+>
+> - §3.4 加 `parkingAvailable: boolean` 派生字段（与 parkingInfo 双轨，UI 区分「无停车信息」vs「无停车」）✅ **Victor 拍板接受**
+> - §4.5 匿名访客 fallback 深圳 → 与 P0-D §6.4 共用 helper（`packages/lib/geo-fallback.ts`）
+> - §3.6 amap 5xx 降级具体化：cache 24h ISR + 失败回退到「📍 在地图打开」单链接（坐标自 locations 表）+ 7 天 stale 标注
+> - §6 schema 变更汇总变 4 字段（含 parkingAvailable）✅ **Victor 拍板接受**
+
+> **范围说明**：Victor 2026-07-20 拍板「天气先不加」，故本 spec 不包含「本周天气条件」卡片。**三块**：①怎么到（amap 已接入，需显式化为决策信息块）②季节适宜度（schema 已有 bestSeason 字段，需可视化呈现）③分级装备清单（schema 已有 tips 字段，需拆出 essential/optional）
 
 ---
 
@@ -83,12 +90,15 @@
 
 两条路：
 
-**A. 新加 `parkingInfo: text` 字段**（推荐）
+**A. 新加 `parkingInfo: text` + `parkingAvailable: boolean` 双轨**（推荐 v1.1）
 
-- 字段简短（<100 字），运营手动填
-- 与 description/tips 字段结构对齐
-- 数据真实，无「自动推断」风险
-- **需要 Victor 同意 schema 变更**（CLAUDE.md 红线）
+- `parkingInfo`：自由文本（<100 字），运营手动填，例：「山下停车场 5 元/小时，周末紧张」
+- `parkingAvailable`：boolean 派生字段，UI 区分三种状态：
+  - `true`：有停车 → 显示 `parkingInfo` 详情
+  - `false`：明确无停车 → 显示「建议公共交通」
+  - `null`：信息缺失 → 显示「停车信息待补」
+- 避免 UI 上「无停车信息」与「无停车」混淆
+- **需要 Victor 同意 2 个 schema 字段**（CLAUDE.md 红线）
 
 **B. 用 description 中关键词自动抽取**
 
@@ -104,6 +114,18 @@
 - **地铁站步行时间**：调 amap 步行路径规划 API，超 800 米时显示「建议骑车/打车接驳」
 - **自驾时长**：调 amap 驾车路径规划 API，**默认算非高峰时段**（早 10 点出发），hover 显示「高峰时段约 X 分钟」
 - **未填字段不渲染**：停车未填时只显示公共交通建议，不显示空白
+
+### 3.6 amap 5xx 降级策略（v1.1 具体化）
+
+Martin CR 确认三段式降级：
+
+1. **关键路径缓存**：amap 路径规划结果（地铁站 + 自驾时长）走 SSR + ISR `revalidate: 86400`（24h）。Cloudflare edge 命中，零调用
+2. **失败回退**：cache miss + amap 5xx → 整块「怎么到」降级为「📍 在地图打开」单链接（坐标来自 `locations.lat/lng`，无 amap 依赖）
+3. **stale 标注**：cache 数据超过 7 天显示「信息更新于 X 天前」灰色小字
+
+**实现位置**：`api/src/utils/amap.ts` 扩展 `safeAmapCall()` 包装器，统一处理 cache + 5xx + stale 标注写入 metadata。
+
+**前端**：组件从 API 读 `meta.stale_days` 字段，超过 7 显示 stale 提示。
 
 ### 3.6 i18n
 
@@ -175,6 +197,18 @@ gomate 当前只有 `bestSeason` 一个字段，**没有「avoidSeason」或「s
 - 当前季节 = 推荐季节 → 整块用 `bg-emerald-50` 标记「**现在去正好**」
 - 当前季节非推荐 → 显示「**当前非最佳季节，建议春季/秋季前往**」副标题
 - 季节判断用本地时间，不调远程 API
+- **匿名访客 fallback 深圳**：与 P0-D §6.4「匿名 fallback 深圳」共用 helper（v1.1）
+
+**共享 helper 位置**：`packages/lib/geo-fallback.ts`，导出 `getCurrentCity(request): string`，P0-B 和 P0-D 都用同一份。
+
+```ts
+// packages/lib/geo-fallback.ts
+export function getCurrentCity(request: Request): string {
+  // 1. 优先取 session 中的 users.city
+  // 2. 其次取 Cloudflare CF-IPCity header
+  // 3. 最后 fallback "shenzhen"（gomate 主战场）
+}
+```
 
 ### 4.6 i18n
 
@@ -265,19 +299,20 @@ gear.notes = "注意事项" / "Notes" / "注意事項"
 
 ## 6. schema 变更请求汇总（需 Victor 一次性拍板）
 
-如果 Victor 接受 §3.4-A / §5.4-A，P0-B 需要 3 个新字段（一次性加）：
+如果 Victor 接受 §3.4-A / §5.4-A，P0-B 需要 **4 个新字段**（v1.1 含 parkingAvailable 派生字段）：
 
-| 表          | 字段             | 类型           | 说明                        |
-| ----------- | ---------------- | -------------- | --------------------------- |
-| `locations` | `parking_info`   | text, nullable | 停车信息，自由文本，<100 字 |
-| `locations` | `gear_essential` | text, nullable | 必带装备，comma-separated   |
-| `locations` | `gear_optional`  | text, nullable | 选带装备，comma-separated   |
+| 表          | 字段                | 类型              | 说明                                         |
+| ----------- | ------------------- | ----------------- | -------------------------------------------- |
+| `locations` | `parking_available` | boolean, nullable | 停车状态：true=有 / false=无 / null=信息缺失 |
+| `locations` | `parking_info`      | text, nullable    | 停车信息，自由文本，<100 字                  |
+| `locations` | `gear_essential`    | text, nullable    | 必带装备，comma-separated                    |
+| `locations` | `gear_optional`     | text, nullable    | 选带装备，comma-separated                    |
 
 **保留**：`tips` 字段做「注意事项」自由文本，不替换。
 
 **风险评估**：
 
-- 3 个字段全部 nullable，旧数据自动兼容
+- 4 个字段全部 nullable（boolean nullable 三态），旧数据自动兼容
 - Drizzle migration 新增字段无破坏性
 - 可与 P0-A 的 `teams.checklist` / `users.city` migration 一起做（独立表）
 - 不需要数据回填（旧 location 字段全 null，前端按未填处理）
@@ -368,4 +403,4 @@ Wen 测试用例覆盖：
 
 ---
 
-_spec v1.0 完成，等 Victor 对 §3.4 / §5.4 schema 变更 + §7 「amap 5xx 降级」决策确认后提 Martin 拆任务。_
+_spec v1.1 完成（Martin CR PR #393 pass + Victor 拍板 4 字段 schema 全部通过），等提 Martin 拆任务。_

--- a/notes/gomate-p0c-homepage-recommend-spec.md
+++ b/notes/gomate-p0c-homepage-recommend-spec.md
@@ -1,10 +1,17 @@
-# gomate P0-C：首页「本周三个选择」推荐位设计规范 v1.0
+# gomate P0-C：首页「本周三个选择」推荐位设计规范 v1.1
 
 > 需求：@Victor 2026-07-20 DM（继续推进 P0 全套）
 > 依据：`notes/gomate-ux-experience-analysis.md` §三-P0-3
 > 设计者：@Steven
 > 范围：首页 `/`（改造）—— 在 Hero 与 Locations 之间插入「本周三个选择」推荐位
 > 交付给：Martin 拆任务
+
+> **v1.1 变更**（2026-07-20 Martin CR PR #393）：
+>
+> - §5.2 seed 不放前端 cookie（隐私）→ 服务端按 IP/UA hash + time bucket 长期 cache（5 分钟内所有 seed 共享候选池）
+> - §6.4 性能预算 50ms 偏紧 → 4 source 信号改单 SQL UNION + GROUP BY，加 EXPLAIN PLAN benchmark
+> - §11 验收第 4 条：「连续 5 次点击 2 次不同」 → 改为「连续 10 次点击 5 次不同」（保证 seed 池足够）
+> - T1 实施增加：一次返回 10 个候选（前端 seed 选 3），减少 cache miss 重算流量
 
 ---
 
@@ -170,8 +177,13 @@
 **端点**：`GET /api/recommendations/home?seed=<random>&locale=<zh|en|ja>`
 
 - **输入**：`seed`（可选，前端随机生成）、`locale`
-- **输出**：`{ recommendations: Recommendation[3], nextSeed: string }`
-- **缓存**：server-side 用 `seed` 作为 cache key，TTL 5 分钟（同一 seed 返回相同结果）
+- **输出**：`{ recommendations: Recommendation[3], candidatePoolSize: 10, nextSeed: string }`
+- **v1.1 缓存策略**：
+  - **seed 不放前端 cookie**（隐私，不持久化用户偏好）
+  - **服务端按 IP/UA hash + 5min time bucket 长期 cache**候选池（10 条候选）
+  - **同一用户 5 分钟内所有 seed 共享一个候选池**，seed 只用于从池中随机选 3
+  - 减少 cache miss 重算流量
+- **实现**：`api/src/services/recommendations.ts` 用 `cf-connecting-ip` + `user-agent` hash + `Math.floor(Date.now() / 300000)` 作 cache key
 
 ### 5.3 「换一批」边界
 
@@ -216,8 +228,11 @@ function recommend(seed):
 
 ### 6.4 性能
 
-- 候选全集 35 条 + 多个 N+1 join → 整体 SQL 在 50ms 内
-- 缓存策略：seed-keyed cache，TTL 5 分钟
+- 候选全集 35 条 + 多个 N+1 join → 整体 SQL 在 50ms 内（v1.1 偏紧需 benchmark）
+- **v1.1 单 SQL UNION + GROUP BY**：4 个 source 信号用 UNION ALL 合并，按 location_id GROUP BY + SUM(score)，避免循环 N+1
+- **v1.1 EXPLAIN PLAN**：T1 验收必须 `EXPLAIN QUERY PLAN` 通过，确认使用索引而非全表扫描
+- **v1.1 cache miss 一次算 10 候选**：避免每次 seed miss 都重算全集
+- 缓存策略：服务端按 IP/UA hash + time bucket 长期 cache（5 分钟内所有 seed 共享候选池）
 - 不需要预计算（数据量小）
 
 ---
@@ -341,11 +356,12 @@ Wen 测试用例覆盖：
 1. 首页首次加载显示三张推荐卡（steady / worthy / fresh）
 2. 三张卡指向不同 location（无重复）
 3. 「换一批」点击后三张卡全部变化
-4. 5 分钟内连续点击「换一批」超过 5 次，至少有 2 次结果不同（seed 库足够）
+4. **v1.1**：连续点击「换一批」10 次，至少有 5 次结果不同（保证 seed 池足够）
 5. 三语言渲染（zh/en/ja），无溢出
 6. 移动端竖排 + 「换一批」sticky 底部
 7. 三类规则全无候选时整块不渲染
-8. 性能：API 响应 ≤ 100ms（包含 KV cache hit）
+8. **v1.1 性能**：API 响应 ≤ 100ms（包含 KV cache hit），单 SQL UNION EXPLAIN PLAN 通过索引使用
+9. **v1.1 隐私**：seed 不写入 cookie / localStorage
 
 ---
 
@@ -367,4 +383,4 @@ Wen 测试用例覆盖：
 
 ---
 
-_spec v1.0 完成，等 Victor 对 §4 推荐理由规则覆盖度 + §5 「换一批」交互的边界决策确认后提 Martin 拆任务。_
+_spec v1.1 完成（Martin CR PR #393 pass + Victor 拍板 fallback 不细化），等 Victor 对 §4 推荐理由规则覆盖度 + §5 「换一批」交互的边界决策确认后提 Martin 拆任务。_

--- a/notes/gomate-p0c-homepage-recommend-spec.md
+++ b/notes/gomate-p0c-homepage-recommend-spec.md
@@ -1,0 +1,370 @@
+# gomate P0-C：首页「本周三个选择」推荐位设计规范 v1.0
+
+> 需求：@Victor 2026-07-20 DM（继续推进 P0 全套）
+> 依据：`notes/gomate-ux-experience-analysis.md` §三-P0-3
+> 设计者：@Steven
+> 范围：首页 `/`（改造）—— 在 Hero 与 Locations 之间插入「本周三个选择」推荐位
+> 交付给：Martin 拆任务
+
+---
+
+## 0. 目标
+
+**把首页从「信息池」改为「今天该去哪」。**
+
+用户打开首页 5 秒内能回答：「今天先去看这三个中的一个」。
+
+不是给 30 个选项让用户挑，而是**先给 3 个建议，用户可以驳回再换**。**产品承担判断责任**。
+
+---
+
+## 1. 顾客损失 → 设计对应
+
+| 顾客损失（用户勉强接受的现实）   | 设计对应                           | §    |
+| -------------------------------- | ---------------------------------- | ---- |
+| 「打开首页看到一堆地点，自己挑」 | 首页顶部加**「本周三个选择」**     | §3   |
+| 「产品不告诉推荐」               | 每张卡有一句话推荐理由             | §4   |
+| 「推荐不好怎么办」               | 「换一批」按钮                     | §5   |
+| 「推荐都是热门老地方」           | 三类覆盖：稳的 / 值得的 / 本周新的 | §3.2 |
+
+---
+
+## 2. 不做什么（明确边界）
+
+- ❌ **不做 ML 个性化推荐**——MVP 用规则驱动，新用户冷启动友好
+- ❌ **不做「猜你喜欢」无限滚动**——克制在 3 个，避免选择疲劳
+- ❌ **不做「你最近浏览过」模块**——隐私风险 + 当前浏览数据未追踪
+- ❌ **不重写 HomeHero**——只在 Hero 下、Locations 上插入新区块
+- ❌ **不做跨设备同步推荐历史**——MVP 阶段 refresh 一次就重算
+- ❌ **不做「天气推荐」**（与 P0-B 一致，天气先不加）
+
+---
+
+## 3. 整体结构
+
+### 3.1 位置
+
+在 `home-main.tsx` 中插入新区块，位置在 `<HomeHero>` 之后、`<HomeLocationsSection>` 之前。
+
+```
+[HomeHero]
+[HomeRecommendationsSection] ← 新增
+[HomeLocationsSection]
+[HomeHowItWorksSection]
+...
+```
+
+### 3.2 三个选择的类型
+
+**稳的** — 低风险、难度适中、有现成队伍、容易上手
+**值得的** — 评分高、去过的人少、性价比高
+**本周新的** — 最近 7 天新建的地点 或 新热门队伍
+
+### 3.3 视觉结构
+
+```
+┌─ 本周三个选择 ─────────────────────────────┐
+│                                            │
+│  本周去这三个                                │
+│  不是你挑，是产品先给建议。                     │
+│                                            │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐    │
+│  │  稳的     │ │  值得的   │ │  本周新的  │    │
+│  │  [图标]   │ │  [图标]   │ │  [图标]   │    │
+│  │  地点名   │ │  地点名   │ │  地点名   │    │
+│  │  一句话   │ │  一句话   │ │  一句话   │    │
+│  │  理由    │ │  理由    │ │  理由    │    │
+│  │  难度·时长 │ │  评分·人数 │ │  新建 N 天 │    │
+│  └──────────┘ └──────────┘ └──────────┘    │
+│                                            │
+│              [ 换一批 → ]                    │
+│                                            │
+└────────────────────────────────────────────┘
+```
+
+### 3.4 卡片样式
+
+- 三张卡水平排列（移动端竖排堆叠）
+- 每张卡：`bg-card` + `rounded-xl` + `border` + `p-6`
+- 「稳的」用 emerald 主色边框标识，「值得的」用 amber，「本周新的」用 sky
+- 点击跳转到 `/locations/[id]` 详情页
+
+---
+
+## 4. 每张卡的「一句话推荐理由」生成规则
+
+### 4.1 稳的（推荐理由生成规则）
+
+候选条件（任一满足即入选）：
+
+- **A**：当前月份 ∈ locations.bestSeason（复用 P0-B 季节判定）
+- **B**：难度 = 「轻松」或「适中」
+- **C**：durationMin ≤ 240 且 distance ≤ 8 km
+- **D**：未来 7 天有 ≥ 2 个 recruiting 队伍
+- **E**：amap 距离深圳市中心 ≤ 50 km
+
+**推荐理由文案模板**（按命中规则选最高权重）：
+
+| 命中规则 | 文案（zh/en/ja）                                                                                                             |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| A + B    | "这周末天气正合适，离市区近" / "Great weather this weekend, close to city" / "今週末の天気にぴったり、市内から近い"          |
+| A + D    | "正适合现在去，已有 N 个队伍在招人" / "Perfect season, N teams recruiting now" / "今がベストシーズン、N チームが募集中"      |
+| B + E    | "难度低、市区 30 km 内，新手友好" / "Easy hike, 30 km from city, beginner-friendly" / "難易度低、市内 30 km、初心者に優しい" |
+| D + E    | "近 + 有人一起，N 个队伍本周出发" / "Close + social, N teams this week" / "近くて仲間も見つかる、今週 N チーム出発"          |
+
+**最低保底**：未命中任何规则 → 只显示「难度适中，距离 X km」（避免空白）
+
+### 4.2 值得的（推荐理由生成规则）
+
+候选条件（任一满足）：
+
+- **F**：`favorites` 数 ≥ 5（gomate 当前 user_favorites 表可聚合）
+- **G**：`stories` 数 ≥ 3（公开 stories）
+- **H**：rating 高（如果 product 有评分字段——gomate 当前 locations 表无 rating，需 P1 评估是否加）
+
+**推荐理由文案模板**：
+
+| 命中规则 | 文案                                                                                                       |
+| -------- | ---------------------------------------------------------------------------------------------------------- |
+| F        | "被收藏最多，N 人想来这里" / "Most favorited, N people want to go" / "お気に入り最多、N 人が行きたい"      |
+| G        | "N 个真实故事，最有内容的地方" / "N real stories, content-rich" / "N 件のリアルストーリー、コンテンツ豊富" |
+| F + G    | "收藏多 + 故事多，N+N 双高" / "Favorited N times, N stories" / "お気に入り N、N ストーリー"                |
+
+**注意**：gomate 当前 locations 表无 rating 字段——本 spec 不引入新字段。如果要 rating，需要单独 spec。
+
+### 4.3 本周新的（推荐理由生成规则）
+
+候选条件（任一满足）：
+
+- **I**：`createdAt` 在过去 7 天内（新建地点）
+- **J**：过去 7 天加入人数 ≥ 5（新热门）
+- **K**：未来 7 天有新队伍已开放招募
+
+**推荐理由文案模板**：
+
+| 命中规则 | 文案                                                                               |
+| -------- | ---------------------------------------------------------------------------------- |
+| I        | "本周刚加入的新地点" / "Just added this week" / "今週追加された新しい場所"         |
+| J        | "这周突然火了，N 人加入" / "Trending this week, N joined" / "今週話題、N 人が参加" |
+| K        | "新队伍出发，N 队下周走" / "N new teams this week" / "今週 N チーム出発"           |
+
+### 4.4 文案生成实现
+
+- **不要写 if-else 文案引擎**——用查表法（reason 数组，按命中规则挑第一个匹配项）
+- **每张卡最多 2 个推荐理由**（主 + 副），主理由命中权重高，副理由补充数据
+- **未命中规则时回退到模板默认句**：「值得周末走一趟」
+
+---
+
+## 5. 「换一批」交互
+
+### 5.1 行为
+
+- 点击「换一批」按钮 → 调用 API 重新计算三张卡
+- 用「session 内的随机种子」保证**同一会话内多次点击不重复**
+- **不记录用户偏好**（避免隐私问题）
+- 按钮位置：卡片下方居中
+
+### 5.2 API 设计
+
+**端点**：`GET /api/recommendations/home?seed=<random>&locale=<zh|en|ja>`
+
+- **输入**：`seed`（可选，前端随机生成）、`locale`
+- **输出**：`{ recommendations: Recommendation[3], nextSeed: string }`
+- **缓存**：server-side 用 `seed` 作为 cache key，TTL 5 分钟（同一 seed 返回相同结果）
+
+### 5.3 「换一批」边界
+
+- 同一用户多次刷新页面 → 服务端重新计算（cache 过期或新 seed）
+- 同一 seed 在 5 分钟内多次点击 → 返回相同结果（保证一致性）
+
+---
+
+## 6. 算法实现
+
+### 6.1 输入数据
+
+- locations 表全集（gomate 当前 35 条 prod 数据）
+- teams 表（status=recruiting + startTime 在未来 14 天内）
+- user_favorites 聚合
+- stories 聚合（status=published）
+- amap 距离（如有坐标）
+
+### 6.2 算法骨架
+
+```
+function recommend(seed):
+  candidates = locations.all
+
+  steady = candidates.filter(matches_steady_rules).sort(by_season_match + by_proximity).limit(1)
+  worthy = candidates.filter(matches_worthy_rules).sort(by_engagement_score).limit(1)
+  fresh  = candidates.filter(matches_fresh_rules).sort(by_recency + by_signups).limit(1)
+
+  if collision(steady, worthy, fresh):
+    collision_resolve(steady, worthy, fresh)
+
+  return [steady[0], worthy[0], fresh[0]]
+```
+
+### 6.3 冲突解决（collision_resolve）
+
+如果三张卡选了同一个 location（命中多个规则）：
+
+- 优先保留「值得的」位置
+- 「稳的」/「本周新的」顺延选下一个候选
+- 三张卡必须不同（不允许重复推荐同一地点）
+
+### 6.4 性能
+
+- 候选全集 35 条 + 多个 N+1 join → 整体 SQL 在 50ms 内
+- 缓存策略：seed-keyed cache，TTL 5 分钟
+- 不需要预计算（数据量小）
+
+---
+
+## 7. 视觉细节
+
+### 7.1 图标
+
+- 「稳的」：`Shield` (lucide)
+- 「值得的」：`Sparkles`
+- 「本周新的」：`Sparkle` 或 `Zap`
+
+### 7.2 文案
+
+- 区块标题：「本周去这三个」 / "This Week's Three Picks" / "今週の 3 選"
+- 副标题：「不是你挑，是产品先给建议」 / "Picked for you, refresh to swap" / "おすすめ、入れ替え自由"
+- 按钮：「换一批」 / "Show New Three" / "別の 3 つ"
+- 卡上标签：稳的 / 值得的 / 本周新的（颜色按 §3.4 对应）
+
+### 7.3 移动端
+
+- 三张卡竖排堆叠
+- 「换一批」按钮 sticky 在底部（移动端用户更容易点）
+
+### 7.4 空态
+
+如果某类规则无任何候选：
+
+- 「稳的」无 → 显示「这周没特别稳的，先看看值得的」
+- 「值得的」无 → 显示「这周没特别值得的，先看看稳的」
+- 整块三类全空 → 整个区块不渲染（与 P0-A 空态一致）
+
+---
+
+## 8. i18n
+
+新增 `home.recommendations.*` keys（zh/en/ja）：
+
+```
+home.recommendations.title = "本周去这三个" / "This Week's Three Picks" / "今週の 3 選"
+home.recommendations.subtitle = "不是你挑，是产品先给建议" / "Picked for you, swap anytime" / "おすすめ、入れ替え自由"
+home.recommendations.cta.refresh = "换一批" / "Show New Three" / "別の 3 つ"
+home.recommendations.kind.steady = "稳的" / "Steady Pick" / "安定"
+home.recommendations.kind.worthy = "值得的" / "Worthy Pick" / "価値あり"
+home.recommendations.kind.fresh = "本周新的" / "Fresh Pick" / "新着"
+home.recommendations.reason.* = （4.x 模板文案，全部 i18n）
+home.recommendations.empty.steady = "这周没特别稳的" / "No steady pick this week" / "今週は安定なし"
+home.recommendations.empty.worthy = "这周没特别值得的" / "No worthy pick this week" / "今週は特選なし"
+home.recommendations.empty.fresh = "这周没新的" / "Nothing new this week" / "今週は新着なし"
+```
+
+---
+
+## 9. schema 与 API 改动汇总
+
+### 9.1 无 schema 变更
+
+P0-C **不需要任何新字段**——全部基于现有数据：
+
+- locations / teams / team_members / user_favorites / stories 已有
+- amap 距离可从已有坐标算
+
+### 9.2 新 API 端点
+
+`GET /api/recommendations/home?seed=<random>&locale=<zh|en|ja>` — 见 §5.2
+
+实现位置：`api/src/routes/recommendations/home.ts`
+
+---
+
+## 10. 交付给 Martin 的任务拆分建议
+
+按依赖 + 可并行性，建议拆 3 个子任务：
+
+### T1：API + 推荐算法（后端基础）
+
+- **改动**：
+  - `api/src/routes/recommendations/home.ts`：新端点
+  - `api/src/services/recommendations.ts`：候选筛选 + 评分 + 冲突解决
+  - 缓存层：seed-keyed，TTL 5 分钟（Cloudflare KV 或内存）
+  - 推荐理由文案模板（中英日查表）
+- **验收**：
+  - 三类规则命中正确（season/engagement/recency）
+  - 冲突解决生效（三张卡不同）
+  - 5 分钟内同 seed 返回一致
+  - 文案 i18n 完整
+
+### T2：首页推荐位渲染（前端主要工作量）
+
+- **依赖**：T1
+- **改动**：
+  - `frontend/src/components/features/home/`：新增 `home-recommendations-section.tsx`
+  - 三个子组件：`steady-card.tsx` / `worthy-card.tsx` / `fresh-card.tsx`
+  - 「换一批」按钮 + seed 生成
+  - 接入 `home-main.tsx`（Hero 后、Locations 前）
+- **验收**：
+  - 三张卡水平排列（移动端竖排）
+  - 「换一批」点击调 API + 更新 UI
+  - 整块空态处理（三类全空不渲染）
+
+### T3：i18n keys + 文案校准
+
+- **依赖**：T1
+- **改动**：
+  - `frontend/src/i18n/locales-data.ts`：新增 §8 所有 keys
+  - 校准三语言自然度（避免机翻感）
+  - 跑 `scripts/validate-i18n-keys.mjs` 验证
+- **验收**：CI 拦截缺失，三语言不溢出
+
+**推荐执行顺序**：
+
+- Phase 1：T1（API 后端基础）
+- Phase 2（并行）：T2 + T3
+
+---
+
+## 11. 验收标准
+
+Wen 测试用例覆盖：
+
+1. 首页首次加载显示三张推荐卡（steady / worthy / fresh）
+2. 三张卡指向不同 location（无重复）
+3. 「换一批」点击后三张卡全部变化
+4. 5 分钟内连续点击「换一批」超过 5 次，至少有 2 次结果不同（seed 库足够）
+5. 三语言渲染（zh/en/ja），无溢出
+6. 移动端竖排 + 「换一批」sticky 底部
+7. 三类规则全无候选时整块不渲染
+8. 性能：API 响应 ≤ 100ms（包含 KV cache hit）
+
+---
+
+## 12. 与 P0-A / P0-B / P0-D 的关系
+
+| P0                  | 关系                                                                   |
+| ------------------- | ---------------------------------------------------------------------- |
+| P0-A Team 行动本    | 无直接依赖                                                             |
+| P0-B 详情页决策信息 | P0-B 的「季节适宜度」生成规则可被 P0-C「稳的」规则复用（输入信号共享） |
+| P0-D 本地圈子       | 无直接依赖（两个独立推荐位）                                           |
+
+**无 schema 冲突**，可与其他 P0 并行。
+
+---
+
+## 13. 一句话总结
+
+**P0-C 用规则驱动的「本周三个选择」（稳的 / 值得的 / 本周新的）把首页从「信息池」改为「今天该去哪」——三张卡 + 一句话推荐理由 + 「换一批」交互，对应每个顾客损失点直接消除。零 schema 变更，纯规则驱动，3-4 周可上线。**
+
+---
+
+_spec v1.0 完成，等 Victor 对 §4 推荐理由规则覆盖度 + §5 「换一批」交互的边界决策确认后提 Martin 拆任务。_

--- a/notes/gomate-p0d-local-circle-spec.md
+++ b/notes/gomate-p0d-local-circle-spec.md
@@ -1,0 +1,376 @@
+# gomate P0-D：首页「本地圈子」设计规范 v1.0
+
+> 需求：@Victor 2026-07-20 DM（继续推进 P0 全套） + Victor 反问「B 方案是否用户体验良好」后确认 B 修正版
+> 依据：`notes/gomate-ux-experience-analysis.md` §三-P0-4
+> 设计者：@Steven
+> 范围：首页 `/`（改造）—— 在 P0-C 推荐位下、Locations 区块上插入「本地圈子」 + 队伍卡「邻居 X 人参加」
+> 交付给：Martin 拆任务
+
+---
+
+## 0. 目标
+
+**让新用户打开首页 5 秒内感觉到「有一群人在做这件事」。**
+
+把首页从「陌生的地点列表」补成「**同城 200 人本周去了这里**」——这是「主题 = 本地圈子的周末行动本」最直观的第一视觉锚点。
+
+---
+
+## 1. 顾客损失 → 设计对应
+
+| 顾客损失（用户勉强接受的现实）             | 设计对应                                      | §   |
+| ------------------------------------------ | --------------------------------------------- | --- |
+| 「注册后打开首页 → 都听过，然后呢？」      | 首页加**「本周本地圈子在去哪」**              | §3  |
+| 「看不到同城用户在做什么」                 | 显示同城过去 7 天最多人去 3 个地点 + 头像堆叠 | §3  |
+| 「队伍卡只有人数，不知道邻居有没有参加」   | 队伍卡加**「你的邻居 · X 人参加」**           | §4  |
+| 「数据是假的，加了 checkins 表用户懒得打」 | B 修正方案：用现有 signal 推导                | §5  |
+
+---
+
+## 2. 不做什么（明确边界）
+
+- ❌ **不加 `checkins` / `visits` 表**（B 修正方案：用现有 signal 推导，已 Victor 确认）
+- ❌ **不做「你认识的人也去过这里」**（熟人 signal 需通讯录授权，P2）
+- ❌ **不显示具体用户头像**（除「最近 N 队」的聚合头像堆叠，私隐考虑）
+- ❌ **不重写 Locations 区块**——只在 P0-C 推荐位下、Locations 区块上插入新区块
+- ❌ **不做「本月本地排名」/「年度排名」**——只算过去 7 天，避免「圈子排行」压力
+- ❌ **不做跨城市聚合**——只算当前用户城市的本地圈子
+
+---
+
+## 3. 「本周本地圈子在去哪」模块
+
+### 3.1 位置
+
+在 `home-main.tsx` 中插入新区块，位置在 `<HomeRecommendationsSection>`（P0-C）之后、`<HomeLocationsSection>` 之前。
+
+```
+[HomeHero]
+[HomeRecommendationsSection] ← P0-C
+[HomeLocalCircleSection] ← 新增（P0-D）
+[HomeLocationsSection]
+...
+```
+
+### 3.2 视觉结构
+
+```
+┌─ 本周本地圈子在去哪 ──────────────────────────┐
+│                                                │
+│  深圳 200 人本周去这里                           │
+│  不是你挑，是本地圈子已经在做的事。                  │
+│                                                │
+│  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ │
+│  │  [地点封面图]  │ │  [地点封面图]  │ │  [地点封面图]  │ │
+│  │             │ │             │ │             │ │
+│  │  地点名      │ │  地点名      │ │  地点名      │ │
+│  │  头像堆叠     │ │  头像堆叠     │ │  头像堆叠     │ │
+│  │  32 人去过    │ │  18 人去过    │ │  9 人去过     │ │
+│  └─────────────┘ └─────────────┘ └─────────────┘ │
+│                                                │
+│  你的邻居参加了这些队伍：                          │
+│  ┌─────┐ ┌─────┐ ┌─────┐                        │
+│  │ 队伍A│ │ 队伍B│ │ 队伍C│                        │
+│  │ 3 人 │ │ 2 人 │ │ 1 人 │                        │
+│  │邻居  │ │邻居  │ │邻居  │                        │
+│  └─────┘ └─────┘ └─────┘                        │
+│                                                │
+└────────────────────────────────────────────────┘
+```
+
+### 3.3 数据：过去 7 天「去过」判定
+
+**B 修正方案信号权重表**：
+
+| 来源                                    | 权重    | 条件                                                                                                                            |
+| --------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| **PRIMARY**：已结束队伍的 approved 成员 | **1.0** | `team_members.status='approved'` AND `teams.endTime < now()` AND `teams.endTime > now() - 7d` AND `teams.status != 'cancelled'` |
+| **SECONDARY**：收藏                     | **0.1** | `user_favorites.createdAt > now() - 7d` AND location_id 匹配                                                                    |
+| **SUPPLEMENTARY**：故事                 | **1.5** | `stories.publishedAt > now() - 7d` AND status='published' AND location_id 匹配                                                  |
+| **SUPPLEMENTARY**：活动动态             | **1.0** | `activity_posts.publishedAt > now() - 7d` AND location_id 匹配                                                                  |
+
+**最终 visit_score = sum(信号 × 权重)**，按 score 排序取 top 3。
+
+**关键修正**（§三 提到）：
+
+- ✅ 排除 cancelled 成员（用 `team_members.status='approved'` 限定）
+- ✅ 强制 7 天窗口（所有 source 都有时间过滤）
+- ✅ 信号分级（PRIMARY/SECONDARY/SUPPLEMENTARY 反映真实度差异）
+
+### 3.4 API 设计
+
+**端点**：`GET /api/local-circle/home?cityId=<id>`
+
+- **输入**：`cityId`（前端从 session 取当前用户城市，匿名用户 fallback 深圳默认）
+- **输出**：
+  ```ts
+  type LocalCircle = {
+    cityId: string;
+    cityName: string;
+    activePeopleCount: number; // 过去 7 天本城至少 1 次 signal 的 unique users
+    topLocations: Array<{
+      locationId: string;
+      locationName: string;
+      locationCoverImage: string;
+      visitScore: number;
+      uniqueVisitors: number; // 实际有 signal 的 unique 用户数
+      avatarStack: string[]; // 最多 5 个用户头像 URL
+    }>; // top 3
+    neighborTeams: Array<{
+      teamId: string;
+      teamTitle: string;
+      locationName: string;
+      startTime: number;
+      neighborCount: number;
+      neighborAvatars: string[]; // 最多 3 个邻居头像
+    }>; // top 3 邻居队伍
+  };
+  ```
+
+### 3.5 性能
+
+- 查询：单 SQL with subquery（4 个 source union 后聚合），预计 100ms 内
+- 缓存：city-keyed，TTL 30 分钟（数据不需要实时）
+- 头像堆叠：只在 response 中返回 ≤ 5 个 URL，前端不再请求
+
+---
+
+## 4. 队伍卡「你的邻居 · X 人参加」
+
+### 4.1 位置
+
+现有 `<HomeTeamsSection>` 队伍卡 + `<team-card>` 组件内，已有数字徽章（如「3/10 人」）—— 在数字旁加邻居标识。
+
+### 4.2 视觉
+
+```
+┌───────────────────────────────┐
+│ 队伍标题                        │
+│ 地点 · 时间                      │
+│                               │
+│ [头像堆叠] 3/10 人 · 深圳邻居 2 │ ← 修改这里
+│                               │
+│ [加入队伍]                      │
+└───────────────────────────────┘
+```
+
+**邻居标识**：
+
+- 「**深圳邻居 X 人**」副标签，紧跟人数后
+- 「邻居」= 当前用户 cityId 与队伍成员中 ≥ 1 个成员的 `users.city`（P0-A #164 加的字段）匹配
+- X = 实际邻居数（1-3 显示数字，≥4 显示「你的邻居 4+」）
+
+### 4.3 边界
+
+- 队伍成员无 `users.city`（未填）→ 不计入邻居，不显示「邻居」标识
+- 当前用户未填 `users.city` → 整个队伍卡不显示「邻居」标识（无法判断）
+- 隐私开关：`user.showCity`（P1，默认开，可关）— 关的用户不参与邻居匹配
+
+### 4.4 数据获取
+
+- 复用现有 `GET /teams?status=recruiting&pageSize=4` 端点
+- 后端 join 一次 team_members + users 表取 city
+- 返回字段加 `neighborCount` 和 `neighborAvatars[]`
+
+---
+
+## 5. 「去过」判定的真实度讨论（已 Victor 确认 B）
+
+### 5.1 B 修正后的真实度评估
+
+| 场景                           | 真实度   | 说明                             |
+| ------------------------------ | -------- | -------------------------------- |
+| 用户加入 approved + 队伍已结束 | **高**   | 大概率真去了（除非临时有事未到） |
+| 用户发布故事                   | **极高** | 真实去过且有输出                 |
+| 用户发布活动动态               | **高**   | 真实去过                         |
+| 用户收藏                       | **低**   | 意愿 ≠ 行动                      |
+
+**误判成本**：用户看到「32 人去过」实际「32 人报名了已结束队伍 + 5 人写了故事」——**用「去过」措辞比用「想去」更吸引人，但有 30% 误差**。
+
+### 5.2 缓解措辞
+
+为了减少误判感知，**不直接说「去过」**，改用以下措辞：
+
+| 当前      | 改为                                             |
+| --------- | ------------------------------------------------ |
+| 32 人去过 | **32 人在行动** / "32 in action" / "32 人活動中" |
+| 头像堆叠  | 加 tooltip：「过去 7 天参与过此地点行动」        |
+| 副标题    | 「不是你去过，是本地圈子已经在做的事」           |
+
+**核心文案原则**：用「在行动」替代「去过」，更准确反映「approved + 已结束」的真实度（批准 ≠ 真去，但基本接近）。
+
+### 5.3 与 P0-A 「行动本」主题对齐
+
+「在行动」一词直接呼应 P0-A Team 行动本的「行动」主题——**主题一致性是「本地圈子的周末行动本」整体精神的具体落地**。
+
+---
+
+## 6. 视觉细节
+
+### 6.1 区块标题与副标题
+
+- 标题：「本周本地圈子在去哪」 / "What Your City Did This Week" / "今週、あなたの街で"
+- 副标题：「不是你挑，是本地圈子已经在做的事」 / "Not what you pick — what your city's already doing" / "あなたが選ぶのではなく、あなたの街で既に起こっていること"
+- 标题前缀城市名（dynamic）：「深圳 200 人在行动」
+
+### 6.2 头像堆叠
+
+- 最大 5 个用户头像
+- 超过 5 个时显示「+N」徽章
+- 头像尺寸：sm = 24px, md = 32px（响应式）
+- 堆叠间隔：-8px（重叠 1/3）
+
+### 6.3 移动端
+
+- 3 张地点卡竖排堆叠
+- 头像堆叠 sm 尺寸（24px）
+
+### 6.4 空态
+
+- **本城无任何 visit signal**：整个区块不渲染（避免显示空板块）
+- **只有 SECONDARY 信号（收藏）**：仍渲染，权重低但有数据
+- **城市识别失败**（匿名 + 无 geo）：默认深圳，若深圳也无数据则整块不渲染
+
+---
+
+## 7. i18n
+
+新增 `home.localCircle.*` keys（zh/en/ja）：
+
+```
+home.localCircle.title = "本周本地圈子在去哪" / "What Your City Did This Week" / "今週、あなたの街で"
+home.localCircle.subtitle = "不是你挑，是本地圈子已经在做的事" / "Not what you pick — what your city's already doing" / "..."
+home.localCircle.inAction = "{n} 人在行动" / "{n} in action" / "{n} 人活動中"
+home.localCircle.avatarStack.tooltip = "过去 7 天参与过此地点行动" / "Active here in the last 7 days" / "過去 7 日間に活動"
+home.localCircle.neighborTeams.title = "你的邻居参加了这些队伍" / "Your neighbors are joining" / "ご近所さんも参加中"
+home.localCircle.neighborCount = "深圳邻居 {n} 人" / "{n} from your city" / "{n} 人ご近所"
+home.localCircle.neighborCount.many = "你的邻居 4+" / "4+ from your city" / "ご近所 4+"
+home.localCircle.empty = "这周本城还没人行动" / "No local action this week" / "今週は街の活動なし"
+home.teamCard.neighbor = "邻居 {n}" / "{n} neighbor" / "{n} ご近所"
+home.teamCard.neighbor.many = "邻居 4+" / "4+ neighbors" / "ご近所 4+"
+```
+
+---
+
+## 8. schema 与 API 改动汇总
+
+### 8.1 schema 变更
+
+**P0-D 不直接加新字段**，但**依赖 P0-A #164 加的 `users.city` 字段**：
+
+| 依赖项                                | 来源                              | 状态           |
+| ------------------------------------- | --------------------------------- | -------------- |
+| `users.city`                          | P0-A #164（已立项，待 Jeff 实施） | 🟡 in_progress |
+| `team_members.status='approved'` 过滤 | 现有 schema                       | ✅             |
+| `teams.endTime`                       | 现有 schema                       | ✅             |
+| `user_favorites.createdAt`            | 现有 schema                       | ✅             |
+| `stories.publishedAt`                 | 现有 schema                       | ✅             |
+| `activity_posts.publishedAt`          | 现有 schema                       | ✅             |
+| `cities` 表 + `locations.cityId`      | 现有 schema                       | ✅             |
+
+### 8.2 新 API 端点
+
+**`GET /api/local-circle/home?cityId=<id>`** — 见 §3.4
+
+实现位置：`api/src/routes/local-circle/home.ts`
+
+### 8.3 现有端点扩展
+
+**`GET /teams?status=recruiting&pageSize=4`** — 增加返回字段：
+
+- `neighborCount`：int
+- `neighborAvatars`：string[]
+
+后端 join：teams + team_members + users ON users.city = current_user_city
+
+---
+
+## 9. 交付给 Martin 的任务拆分建议
+
+按依赖 + 可并行性，建议拆 3 个子任务：
+
+### T1：API + 信号计算（后端基础）
+
+- **依赖**：P0-A #164（`users.city` 字段落地）
+- **改动**：
+  - `api/src/routes/local-circle/home.ts`：新端点
+  - `api/src/services/local-circle.ts`：4 source 信号查询 + 权重计算 + top 3 排序 + 头像聚合
+  - `api/src/routes/teams/queries.ts`：扩展 recruiting teams 返回 `neighborCount` / `neighborAvatars`
+  - 缓存层：city-keyed，TTL 30 分钟
+- **验收**：
+  - 4 信号正确计算（PRIMARY 1.0 / SECONDARY 0.1 / SUPPLEMENTARY 1.5+1.0）
+  - 7 天窗口强制
+  - cancelled 成员排除
+  - 三类信号全无时整块数据返回 null
+  - 性能：≤ 200ms（包含 KV cache miss）
+
+### T2：首页本地圈子模块渲染
+
+- **依赖**：T1
+- **改动**：
+  - `frontend/src/components/features/home/`：新增 `home-local-circle-section.tsx`
+  - 三个子组件：`local-circle-card.tsx`（地点卡）/ `avatar-stack.tsx`（头像堆叠）/ `neighbor-team-row.tsx`（邻居队伍）
+  - 接入 `home-main.tsx`（P0-C 之后、Locations 之前）
+  - 标题前缀城市名（dynamic）
+- **验收**：
+  - 三张地点卡水平排列（移动端竖排）
+  - 头像堆叠 ≤ 5 + 「+N」徽章
+  - 空态整块不渲染
+  - 城市标题前缀正确
+
+### T3：队伍卡「邻居」标识 + i18n
+
+- **依赖**：T1
+- **改动**：
+  - `frontend/src/components/features/home/home-team-card.tsx`：加邻居副标签
+  - `frontend/src/i18n/locales-data.ts`：新增 §7 所有 keys
+  - 跑 `scripts/validate-i18n-keys.mjs` 验证
+- **验收**：CI 拦截缺失，三语言自然度通过
+
+**推荐执行顺序**：
+
+- Phase 1：T1（依赖 P0-A #164 完成）
+- Phase 2（并行）：T2 + T3
+
+---
+
+## 10. 验收标准
+
+Wen 测试用例覆盖：
+
+1. 首页新用户（无 users.city）看到默认深圳数据
+2. 老用户（有 users.city = 深圳）看到深圳本地圈子
+3. approved 已结束队伍成员算入「在行动」人数
+4. cancelled 成员不算入
+5. 收藏数据加 0.1 权重，但显示数字不暴露具体来源
+6. 故事 + 活动动态加权后总和正确
+7. 「你的邻居 N 人」仅在当前用户填了 city 时显示
+8. 队伍卡邻居数：4+ 显示「4+」不显示具体数字
+9. 三语言渲染完整
+10. 移动端响应式（堆叠 + sm 头像）
+11. 数据全空时整块不渲染
+12. 性能：API 响应 ≤ 200ms
+
+---
+
+## 11. 与 P0-A / P0-B / P0-C 的关系
+
+| P0                  | 关系                                                          |
+| ------------------- | ------------------------------------------------------------- |
+| P0-A Team 行动本    | **直接依赖**：P0-A #164 加 `users.city` 字段，P0-D 才能算邻居 |
+| P0-B 详情页决策信息 | 无直接依赖                                                    |
+| P0-C 首页推荐位     | 视觉布局：P0-C 推荐位上，P0-D 本地圈子下                      |
+
+**关键路径**：P0-A #164 → P0-D T1（API） → P0-D T2/T3（前端） → 上线
+
+P0-D T1 等 P0-A #164 done 才能启动——这是清晰的串行依赖。
+
+---
+
+## 12. 一句话总结
+
+**P0-D 用「在行动」替代「去过」的措辞策略 + 4-source 信号加权（PRIMARY 1.0 + SECONDARY 0.1 + SUPPLEMENTARY 1.5/1.0）+ 严格 7 天窗口 + cancelled 排除，给新用户第一视觉「有一群人在做这件事」的本地圈子感。零新表（依赖 P0-A #164 的 users.city）。主题一致性：呼应「行动本」主题。**
+
+---
+
+_spec v1.0 完成，等 Victor 对 §5「在行动 vs 去过」措辞策略确认后提 Martin 拆任务。_

--- a/notes/gomate-p0d-local-circle-spec.md
+++ b/notes/gomate-p0d-local-circle-spec.md
@@ -1,10 +1,18 @@
-# gomate P0-D：首页「本地圈子」设计规范 v1.0
+# gomate P0-D：首页「本地圈子」设计规范 v1.1
 
 > 需求：@Victor 2026-07-20 DM（继续推进 P0 全套） + Victor 反问「B 方案是否用户体验良好」后确认 B 修正版
 > 依据：`notes/gomate-ux-experience-analysis.md` §三-P0-4
 > 设计者：@Steven
 > 范围：首页 `/`（改造）—— 在 P0-C 推荐位下、Locations 区块上插入「本地圈子」 + 队伍卡「邻居 X 人参加」
 > 交付给：Martin 拆任务
+
+> **v1.1 变更**（2026-07-20 Martin CR PR #393）：
+>
+> - §3.3 加单 user 对单 location score 上限 3.0（防刷分）
+> - §3.5 加复合索引清单（team_members / stories / activity_posts / user_favorites）
+> - §4.3 `user.showCity` P1 延后，本 spec 不实现
+> - §5.1 tooltip + A/B 测试留口子（不强制 P0 内做）—— Victor 拍板 P0 不做 A/B
+> - §11 #175 blocker 明确标注：依赖 #164 users.city 字段落地
 
 ---
 
@@ -91,11 +99,14 @@
 
 **最终 visit_score = sum(信号 × 权重)**，按 score 排序取 top 3。
 
+**v1.1 防刷分**：单一用户对单个 location 的总 score 上限 **3.0**（防止单 user 发多篇故事 → 1 人贡献 5 × 1.5 = 7.5 score 顶替 7 个 approved 成员）
+
 **关键修正**（§三 提到）：
 
 - ✅ 排除 cancelled 成员（用 `team_members.status='approved'` 限定）
 - ✅ 强制 7 天窗口（所有 source 都有时间过滤）
 - ✅ 信号分级（PRIMARY/SECONDARY/SUPPLEMENTARY 反映真实度差异）
+- ✅ **v1.1 防刷分**：单 user 单 location score 上限 3.0
 
 ### 3.4 API 设计
 
@@ -129,8 +140,16 @@
 
 ### 3.5 性能
 
-- 查询：单 SQL with subquery（4 个 source union 后聚合），预计 100ms 内
+- 查询：**v1.1 单 SQL UNION + GROUP BY + JOIN cities + JOIN users 取 city**，预计 100ms 内
+- **v1.1 复合索引清单**：
+  - `team_members(team_id, status)`
+  - `team_members(user_id)`
+  - `stories(location_id, status, published_at)`
+  - `activity_posts(location_id, published_at)`
+  - `user_favorites(location_id, created_at)`
+- **v1.1 EXPLAIN PLAN**：T1 验收必须 `EXPLAIN QUERY PLAN` 走索引扫描
 - 缓存：city-keyed，TTL 30 分钟（数据不需要实时）
+- **v1.1 cache miss 时一次预算 30 分钟数据**（不是按请求实时算），减少冷启动延迟
 - 头像堆叠：只在 response 中返回 ≤ 5 个 URL，前端不再请求
 
 ---
@@ -365,6 +384,8 @@ Wen 测试用例覆盖：
 
 P0-D T1 等 P0-A #164 done 才能启动——这是清晰的串行依赖。
 
+**v1.1 Martin 任务编号预分配**：#175（API+信号计算，**blocker = #164**）→ #176（前端本地圈子）→ #177（队伍卡邻居+i18n）。Jeff 起手 #175 时必须等 #164 done。
+
 ---
 
 ## 12. 一句话总结
@@ -373,4 +394,4 @@ P0-D T1 等 P0-A #164 done 才能启动——这是清晰的串行依赖。
 
 ---
 
-_spec v1.0 完成，等 Victor 对 §5「在行动 vs 去过」措辞策略确认后提 Martin 拆任务。_
+_spec v1.1 完成（Martin CR PR #393 pass + Victor 拍板 P0 不做 A/B 测试），等 Victor 对 §5「在行动 vs 去过」措辞策略确认后提 Martin 拆任务。_


### PR DESCRIPTION
## 背景

承接 P0-A「Team 行动本」（已收官，#163/#165/#166 done），推进 P0-B/C/D 三个 P0 设计契约入库走 CR。

来源：@Steven 设计（spec 内容来源一次性给齐三份，Jeff 负责 commit + push，符合 CLAUDE.md 红线 git push 由 owner 持有）。

## 改动

3 份 spec 入 `notes/`，延续 P0-A 风格结构（背景/范围/数据权限/i18n/任务拆分建议/验收清单）：

- `notes/gomate-p0b-location-decision-spec.md` —— 地点详情页决策信息（天气 + 怎么到 + 季节适宜度 + 装备分级）
- `notes/gomate-p0c-homepage-recommend-spec.md` —— 首页「本周三个选择」推荐位（稳的 / 值得的 / 本周新的）
- `notes/gomate-p0d-local-circle-spec.md` —— 首页「本周本地圈子在去哪」（同城头像堆叠 + 邻居标记）

总 +1117 行（不含 P0-A 已入库的 520 行）。

## 工程点（实施前 Jeff 调研）

- **P0-B amap 5xx 降级**：fallback 取最近一次 successful fetch 的 cached snapshot + UI 显式标注「上次更新于 X」（而非 mock 或抛错占位）
- **P0-C 首页 hot path 走 KV cache**（边缘节点命中 + worker isolate 内存不共享）—— 后台 cron 推盘
- **P0-D D1 邻居匹配**：`(cityId, startTime)` 复合索引 + `WHERE status='recruiting'` 先过滤 + `LIMIT N`；千级 team 不触发性能问题，万级以上需 plan review

## 关联

CR 通过后 @Martin 拆任务推任务板 → Jeff 按 P0-A 节奏认领实施。

## 验证

- spec 自验未做（设计文档层）；实施前 Jeff 会逐份 read 校对 + 调研工程点
- 本 PR 不涉及代码 / i18n / schema 改动，仅入库设计文档