### PR TITLE
feat(home): P0-C T2 首页推荐区块 + API 契约扩展 (task #173)

### DIFF
--- a/api/src/__tests__/unit/recommendations.test.ts
+++ b/api/src/__tests__/unit/recommendations.test.ts
@@ -118,8 +118,11 @@ describe("recommendations: seasonMatches", () => {
 
 interface RowInput {
   id: string;
+  name?: string;
+  coverImage?: string;
   bestSeason?: string;
   difficulty?: string | null;
+  durationMin?: number | null;
   distance?: number | null;
   futureTeams?: number;
   favCount?: number;
@@ -135,8 +138,10 @@ function makeRow(now: number, o: RowInput) {
     o.createdAt ?? (o.ageDays !== undefined ? now - o.ageDays * 24 * 60 * 60 * 1000 : now);
   return {
     id: o.id,
-    name: o.id,
+    name: o.name ?? o.id,
+    cover_image: o.coverImage ?? `https://example.com/${o.id}.jpg`,
     difficulty: o.difficulty ?? null,
+    duration_min: o.durationMin ?? null,
     distance: o.distance ?? null,
     best_season: o.bestSeason ?? "[]",
     city_id: "c1",
@@ -349,6 +354,85 @@ describe("recommendations: selectThree 冲突解决 + 排序", () => {
     }
     // 30 次至少 5 种组合（spec §11 验收 4 v1.1）
     expect(results.size).toBeGreaterThanOrEqual(5);
+  });
+});
+
+// ==================== T2 契约扩展：Recommendation.location ====================
+
+/**
+ * P0-C T2（Martin CR 2026-07-20 dm:@Martin msg 66cf9186）：
+ * API 契约扩展 —— Recommendation 增加 `location` 字段，前端零 waterfall。
+ * 覆盖 steady / worthy / fresh 三类 kind 都必须带 location 且字段完整。
+ */
+describe("recommendations: Recommendation.location（T2 契约）", () => {
+  const now = 1_700_000_000_000;
+
+  function makePool(steady: string[], worthy: string[], fresh: string[]) {
+    const mk = (id: string, kind: "steady" | "worthy" | "fresh") => {
+      const row = makeRow(now, {
+        id,
+        name: `${id}-name`,
+        coverImage: `https://cdn.example.com/${id}.jpg`,
+        difficulty: kind === "steady" ? "Easy" : null, // 测大小写归一
+        durationMin: kind === "steady" ? 180 : null,
+        distance: kind === "steady" ? 12.345 : null, // 测 1 位小数四舍五入
+        bestSeason: kind === "steady" ? '["spring"]' : "[]",
+        favCount: kind === "worthy" ? 10 : 0,
+        storyCount: kind === "worthy" ? 5 : 0,
+        futureTeams: kind === "steady" ? 3 : 0,
+        ageDays: kind === "fresh" ? 2 : 100,
+      });
+      return buildCandidate(row, now, "spring");
+    };
+    return {
+      steady: steady.map((id) => mk(id, "steady")),
+      worthy: worthy.map((id) => mk(id, "worthy")),
+      fresh: fresh.map((id) => mk(id, "fresh")),
+    };
+  }
+
+  it("每条 Recommendation 都带 location（三类 kind 都覆盖）", () => {
+    const pool = makePool(["s1"], ["w1"], ["f1"]);
+    const res = selectThree(pool, "abcd0001");
+    expect(res).toHaveLength(3);
+    for (const r of res) {
+      expect(r.location).toBeDefined();
+      expect(typeof r.location.name).toBe("string");
+      expect(r.location.name.length).toBeGreaterThan(0);
+      expect(typeof r.location.favCount).toBe("number");
+      expect(typeof r.location.storyCount).toBe("number");
+      expect(typeof r.location.ageDays).toBe("number");
+      expect(typeof r.location.futureTeams).toBe("number");
+    }
+  });
+
+  it("location.name / coverImage 从 signal row 透传", () => {
+    const pool = makePool(["s1"], [], []);
+    const [steady] = selectThree(pool, "abcd0001");
+    expect(steady!.location.name).toBe("s1-name");
+    expect(steady!.location.coverImage).toBe("https://cdn.example.com/s1.jpg");
+  });
+
+  it("location.distanceKm 保留 1 位小数（避免前端二次换算）", () => {
+    const pool = makePool(["s1"], [], []);
+    const [steady] = selectThree(pool, "abcd0001");
+    // 12.345 → 12.3（Math.round(12.345 * 10) / 10）
+    expect(steady!.location.distanceKm).toBe(12.3);
+  });
+
+  it("location.difficulty 归一为小写（DB 存自由文本，前端 DIFFICULTY_CONFIG key 小写）", () => {
+    const pool = makePool(["s1"], [], []);
+    const [steady] = selectThree(pool, "abcd0001");
+    // makeRow 传 "Easy"，应归一为 "easy"
+    expect(steady!.location.difficulty).toBe("easy");
+  });
+
+  it("distance / duration / difficulty 全 null 时 location 字段也为 null（不 throw）", () => {
+    const pool = makePool([], ["w1"], []); // worthy 分支所有可空字段都是 null
+    const [worthy] = selectThree(pool, "abcd0001");
+    expect(worthy!.location.difficulty).toBeNull();
+    expect(worthy!.location.durationMin).toBeNull();
+    expect(worthy!.location.distanceKm).toBeNull();
   });
 });
 

--- a/api/src/services/recommendations.ts
+++ b/api/src/services/recommendations.ts
@@ -75,10 +75,34 @@ export interface RecommendationReason {
   params: ReasonParams;
 }
 
+/**
+ * P0-C T2 契约扩展（Martin CR 2026-07-20 dm:@Martin msg 66cf9186）：
+ *
+ * 前端渲染卡片需要一次性拿到 location 展示数据 + 二级数据，避免 N+1 waterfall。
+ * 字段全部来自 fetchSignals 已计算的 SignalRow / Candidate.data，不新增 SQL 成本。
+ * 类型 additive，旧 caller 不消费不影响。
+ */
+export interface RecommendationLocationSummary {
+  name: string;
+  coverImage: string | null;
+  /** union 对齐前端 DIFFICULTY_CONFIG key；DB 存自由文本，此处仅归一小写后透传 */
+  difficulty: string | null;
+  durationMin: number | null;
+  /** 已折算 km，避免前端做单位换算 */
+  distanceKm: number | null;
+  // 二级数据（卡片右下角小字）
+  favCount: number;
+  storyCount: number;
+  ageDays: number;
+  futureTeams: number;
+}
+
 export interface Recommendation {
   kind: RecommendationKind;
   locationId: string;
   reason: RecommendationReason;
+  /** P0-C T2：一次性带回卡片渲染所需字段，前端零 waterfall */
+  location: RecommendationLocationSummary;
   /** debug 用：命中的规则位（不返回前端消费，仅测试断言） */
   score: number;
 }
@@ -183,7 +207,9 @@ function normalizeSeed(seed?: string | null): string {
 interface SignalRow {
   id: string;
   name: string;
+  cover_image: string; // NOT NULL in schema
   difficulty: string | null;
+  duration_min: number | null;
   distance: number | null;
   best_season: string; // JSON text
   city_id: string;
@@ -206,7 +232,9 @@ async function fetchSignals(db: Db, now: number): Promise<SignalRow[]> {
     SELECT
       l.id AS id,
       l.name AS name,
+      l.cover_image AS cover_image,
       l.difficulty AS difficulty,
+      l.duration_min AS duration_min,
       l.distance AS distance,
       l.best_season AS best_season,
       l.city_id AS city_id,
@@ -278,8 +306,13 @@ interface Candidate {
     newTeams: boolean; // 7d 内新建的队伍 ≥1（K）
   };
   data: {
+    // 展示字段（P0-C T2 契约扩展）
+    name: string;
+    coverImage: string;
     difficulty: string | null;
+    durationMin: number | null;
     distanceKm: number | null;
+    // 信号 / 二级数据
     futureTeams: number;
     favCount: number;
     storyCount: number;
@@ -359,7 +392,10 @@ function buildCandidate(row: SignalRow, now: number, season: Season): Candidate 
       newTeams,
     },
     data: {
+      name: row.name,
+      coverImage: row.cover_image,
       difficulty: row.difficulty,
+      durationMin: row.duration_min,
       distanceKm: row.distance,
       futureTeams: row.future_teams,
       favCount: row.fav_count,
@@ -482,10 +518,26 @@ function selectThree(pool: Pool, seed: string): Recommendation[] {
     const picked = pickFromKind(remaining, rand);
     if (!picked) return;
     chosenIds.add(picked.locationId);
+    const d = picked.data;
+    // km 保留 1 位小数（P0-C T2 契约：避免前端二次换算）
+    const distanceKm = d.distanceKm === null ? null : Math.round(d.distanceKm * 10) / 10;
+    // difficulty 归一小写（DB 存自由文本；前端 DIFFICULTY_CONFIG key 小写）
+    const difficulty = d.difficulty === null ? null : d.difficulty.toLowerCase();
     results[slot] = {
       kind,
       locationId: picked.locationId,
       reason: pickReason(kind, picked),
+      location: {
+        name: d.name,
+        coverImage: d.coverImage || null,
+        difficulty,
+        durationMin: d.durationMin,
+        distanceKm,
+        favCount: d.favCount,
+        storyCount: d.storyCount,
+        ageDays: d.ageDays,
+        futureTeams: d.futureTeams,
+      },
       score: picked.score,
     };
   };
@@ -564,7 +616,9 @@ async function rehydratePool(
     SELECT
       l.id AS id,
       l.name AS name,
+      l.cover_image AS cover_image,
       l.difficulty AS difficulty,
+      l.duration_min AS duration_min,
       l.distance AS distance,
       l.best_season AS best_season,
       l.city_id AS city_id,

--- a/frontend/public/locales/en/home.json
+++ b/frontend/public/locales/en/home.json
@@ -37,5 +37,46 @@
     "teamJoined": "{count} people teamed",
     "dayDepart": "Departing {day}",
     "saturdayLabel": "Sat"
+  },
+  "recommendations": {
+    "title": "This Week's Three Picks",
+    "subtitle": "Picked for you, swap anytime",
+    "cta": {
+      "refresh": "Show New Three"
+    },
+    "kind": {
+      "steady": "Steady Pick",
+      "worthy": "Worthy Pick",
+      "fresh": "Fresh Pick"
+    },
+    "meta": {
+      "distance": "{km} km",
+      "duration": "{n} min",
+      "favorites": "{n} favorites",
+      "stories": "{n} stories",
+      "ageDays": "New · {n} days",
+      "futureTeams": "{n} teams recruiting"
+    },
+    "reason": {
+      "steady_season_close": "Great weather this weekend, about {km} km away",
+      "steady_season_teams": "Perfect season now, {n} teams recruiting",
+      "steady_easy_close": "Easy hike, about {km} km, beginner-friendly",
+      "steady_close_social": "Close + social, {n} teams this week",
+      "steady_fallback": "About {km} km — a steady choice",
+      "worthy_favorites": "Favorited by {n} — worth a visit",
+      "worthy_stories": "{n} stories written — worth exploring",
+      "worthy_favorites_stories": "{n} favorites & stories — prioritize this",
+      "worthy_fallback": "Worth carving out time for",
+      "fresh_new_location": "New location, added {n} days ago",
+      "fresh_trending_signups": "{n} people signed up in 7 days — trending",
+      "fresh_new_teams": "{n} new teams this week — join early",
+      "fresh_fallback": "New this week — check it out"
+    },
+    "empty": {
+      "steady": "No steady pick this week",
+      "worthy": "No worthy pick this week",
+      "fresh": "Nothing new this week"
+    },
+    "error": "Failed to load recommendations. Try again later."
   }
 }

--- a/frontend/public/locales/ja/home.json
+++ b/frontend/public/locales/ja/home.json
@@ -37,5 +37,46 @@
     "teamJoined": "{count}人がチーム結成済み",
     "dayDepart": "{day}出発",
     "saturdayLabel": "土"
+  },
+  "recommendations": {
+    "title": "今週の 3 選",
+    "subtitle": "おすすめ、入れ替え自由",
+    "cta": {
+      "refresh": "別の 3 つ"
+    },
+    "kind": {
+      "steady": "安定",
+      "worthy": "価値あり",
+      "fresh": "新着"
+    },
+    "meta": {
+      "distance": "{km} km",
+      "duration": "{n} 分",
+      "favorites": "{n} 人がお気に入り",
+      "stories": "{n} 件のストーリー",
+      "ageDays": "登録から {n} 日",
+      "futureTeams": "{n} チーム募集中"
+    },
+    "reason": {
+      "steady_season_close": "今週末の天気にぴったり、約 {km} km",
+      "steady_season_teams": "今がベストシーズン、{n} チームが募集中",
+      "steady_easy_close": "難易度低、約 {km} km、初心者に優しい",
+      "steady_close_social": "近くて仲間も見つかる、今週 {n} チーム出発",
+      "steady_fallback": "約 {km} km、安定の選択",
+      "worthy_favorites": "{n} 人がお気に入り、一度は行きたい",
+      "worthy_stories": "{n} 件のストーリー、探索の価値あり",
+      "worthy_favorites_stories": "お気に入り・ストーリー合計 {n}、優先度高め",
+      "worthy_fallback": "時間を作って行く価値あり",
+      "fresh_new_location": "登録から {n} 日以内の新スポット",
+      "fresh_trending_signups": "直近 7 日で {n} 人が参加、注目度上昇",
+      "fresh_new_teams": "今週 {n} チーム新設、早めに参加",
+      "fresh_fallback": "今週の新顔、まずは覗いてみて"
+    },
+    "empty": {
+      "steady": "今週は安定なし",
+      "worthy": "今週は特選なし",
+      "fresh": "今週は新着なし"
+    },
+    "error": "おすすめの読み込みに失敗しました。後で再試行してください。"
   }
 }

--- a/frontend/public/locales/zh-CN/home.json
+++ b/frontend/public/locales/zh-CN/home.json
@@ -37,5 +37,46 @@
     "teamJoined": "{count}人已组队",
     "dayDepart": "周{day}出发",
     "saturdayLabel": "六"
+  },
+  "recommendations": {
+    "title": "本周去这三个",
+    "subtitle": "不是你挑，是产品先给建议",
+    "cta": {
+      "refresh": "换一批"
+    },
+    "kind": {
+      "steady": "稳的",
+      "worthy": "值得的",
+      "fresh": "本周新的"
+    },
+    "meta": {
+      "distance": "{km} km",
+      "duration": "{n} 分钟",
+      "favorites": "{n} 人收藏",
+      "stories": "{n} 篇故事",
+      "ageDays": "新建 {n} 天",
+      "futureTeams": "{n} 个队伍招人"
+    },
+    "reason": {
+      "steady_season_close": "这周天气正合适，距离约 {km} km",
+      "steady_season_teams": "正适合现在去，已有 {n} 个队伍在招人",
+      "steady_easy_close": "难度轻松、距离约 {km} km，新手友好",
+      "steady_close_social": "距离近 + 有人一起，本周 {n} 个队伍出发",
+      "steady_fallback": "距离约 {km} km，稳稳出发",
+      "worthy_favorites": "{n} 人收藏过，值得一去",
+      "worthy_stories": "{n} 篇故事写过，值得一探",
+      "worthy_favorites_stories": "共 {n} 次收藏 / 故事沉淀，值得优先安排",
+      "worthy_fallback": "值得抽时间去一次",
+      "fresh_new_location": "上架 {n} 天内的新地点",
+      "fresh_trending_signups": "近 7 天已有 {n} 人报名，热度上涨",
+      "fresh_new_teams": "本周新开 {n} 支队伍，抢先加入",
+      "fresh_fallback": "本周新面孔，先睹为快"
+    },
+    "empty": {
+      "steady": "这周没特别稳的",
+      "worthy": "这周没特别值得的",
+      "fresh": "这周没新的"
+    },
+    "error": "推荐加载失败，稍后重试"
   }
 }

--- a/frontend/src/__tests__/home-recommendations-section.test.tsx
+++ b/frontend/src/__tests__/home-recommendations-section.test.tsx
@@ -1,0 +1,179 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HomeRecommendationsSection } from "../components/features/home/recommendations/home-recommendations-section";
+import type { RecommendationsResponse } from "../components/features/home/recommendations/types";
+
+/**
+ * P0-C T2 (task #173) — Section fetch flow / refresh state / error 态 / empty 态
+ * Martin CR NIT-2 补测（B2 error 态 + refresh + seed 透传）
+ */
+
+vi.mock("@/hooks/useI18n", () => ({
+  useI18n: () => ({
+    t: (key: string, vars?: Record<string, string | number>) => {
+      if (!vars) return key;
+      const varsStr = Object.entries(vars)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(",");
+      return varsStr ? `${key}[${varsStr}]` : key;
+    },
+    locale: "zh-CN",
+    loading: false,
+    getNsData: () => null,
+  }),
+}));
+
+// Mock fetchPublicAPI — 我们通过 mockFetch 变量控制每次 fetch 的返回
+const mockFetch = vi.fn();
+vi.mock("@/lib/api", () => ({
+  fetchPublicAPI: (path: string) => mockFetch(path),
+}));
+
+function makeResponse(overrides: Partial<RecommendationsResponse> = {}): RecommendationsResponse {
+  return {
+    candidatePoolSize: 10,
+    nextSeed: "seed-abc-123",
+    recommendations: [
+      {
+        kind: "steady",
+        locationId: "loc-1",
+        reason: { key: "steady.season_close", params: { km: 10 } },
+        location: {
+          name: "梧桐山",
+          coverImage: null,
+          difficulty: "easy",
+          durationMin: 180,
+          distanceKm: 10,
+          favCount: 5,
+          storyCount: 2,
+          ageDays: 100,
+          futureTeams: 1,
+        },
+      },
+      {
+        kind: "worthy",
+        locationId: "loc-2",
+        reason: { key: "worthy.favorites", params: { n: 8 } },
+        location: {
+          name: "东西冲",
+          coverImage: null,
+          difficulty: "moderate",
+          durationMin: 240,
+          distanceKm: 30,
+          favCount: 8,
+          storyCount: 4,
+          ageDays: 200,
+          futureTeams: 0,
+        },
+      },
+      {
+        kind: "fresh",
+        locationId: "loc-3",
+        reason: { key: "fresh.new_location", params: { days: 3 } },
+        location: {
+          name: "七娘山",
+          coverImage: null,
+          difficulty: null,
+          durationMin: null,
+          distanceKm: null,
+          favCount: 0,
+          storyCount: 0,
+          ageDays: 3,
+          futureTeams: 1,
+        },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function okResponse(body: RecommendationsResponse) {
+  return { ok: true, status: 200, json: async () => body } as Response;
+}
+
+describe("HomeRecommendationsSection", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("首次挂载：先渲染 3 个 skeleton loading，再渲染 ready 卡片", async () => {
+    // 用一个不 resolve 的 Promise 拿到 loading 快照
+    let resolveFn: ((v: Response) => void) | undefined;
+    mockFetch.mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolveFn = resolve;
+      }),
+    );
+
+    render(<HomeRecommendationsSection />);
+    // loading skeleton × 3
+    expect(screen.getAllByTestId("recommendation-card-skeleton")).toHaveLength(3);
+
+    resolveFn?.(okResponse(makeResponse()));
+    await waitFor(() => {
+      expect(screen.getByTestId("recommendation-card-steady")).toBeTruthy();
+    });
+    expect(screen.getByTestId("recommendation-card-worthy")).toBeTruthy();
+    expect(screen.getByTestId("recommendation-card-fresh")).toBeTruthy();
+  });
+
+  it("首次挂载 fetch 一次，路径不带 seed", async () => {
+    mockFetch.mockResolvedValueOnce(okResponse(makeResponse()));
+    render(<HomeRecommendationsSection />);
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+    expect(mockFetch).toHaveBeenCalledWith("/api/recommendations/home");
+  });
+
+  it("换一批：点击后用 nextSeed 再 fetch 一次", async () => {
+    mockFetch
+      .mockResolvedValueOnce(okResponse(makeResponse({ nextSeed: "seed-round-1" })))
+      .mockResolvedValueOnce(okResponse(makeResponse({ nextSeed: "seed-round-2" })));
+
+    render(<HomeRecommendationsSection />);
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByTestId("recommendation-refresh-btn"));
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2));
+    // 第二次带 nextSeed
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      "/api/recommendations/home?seed=seed-round-1",
+    );
+  });
+
+  it("error 态：fetch reject → 渲染 error banner + 重试按钮（Martin CR B2）", async () => {
+    // 静默 console.error 以免污染测试输出
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch.mockRejectedValueOnce(new Error("network down"));
+
+    render(<HomeRecommendationsSection />);
+    await waitFor(() => {
+      expect(screen.getByTestId("home-recommendations-error")).toBeTruthy();
+    });
+    expect(document.body.textContent).toContain("home.recommendations.error");
+    expect(screen.getByTestId("recommendation-retry-btn")).toBeTruthy();
+
+    // 点击重试 → 再 fetch 一次并恢复到 ready
+    mockFetch.mockResolvedValueOnce(okResponse(makeResponse()));
+    fireEvent.click(screen.getByTestId("recommendation-retry-btn"));
+    await waitFor(() => {
+      expect(screen.getByTestId("recommendation-card-steady")).toBeTruthy();
+    });
+    errSpy.mockRestore();
+  });
+
+  it("empty 态：recommendations = [] → 整个 section 不渲染（return null）", async () => {
+    mockFetch.mockResolvedValueOnce(okResponse(makeResponse({ recommendations: [] })));
+    const { container } = render(<HomeRecommendationsSection />);
+    await waitFor(() => {
+      // section 不该在 DOM 里
+      expect(screen.queryByTestId("home-recommendations-section")).toBeNull();
+    });
+    // 也没有 error banner
+    expect(container.querySelector('[data-testid="home-recommendations-error"]')).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/recommendation-badge.test.tsx
+++ b/frontend/src/__tests__/recommendation-badge.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RecommendationBadge } from "../components/features/home/recommendations/recommendation-badge";
+
+/**
+ * P0-C T2 (task #173) — 推荐卡类别徽章视觉测试
+ */
+
+vi.mock("@/hooks/useI18n", () => ({
+  useI18n: () => ({
+    t: (key: string) => key, // 回显 key 即可断言映射正确
+    locale: "zh-CN",
+    loading: false,
+    getNsData: () => null,
+  }),
+}));
+
+describe("RecommendationBadge", () => {
+  it("steady kind → 渲染 steady i18n key + emerald 色板", () => {
+    render(<RecommendationBadge kind="steady" />);
+    const badge = screen.getByTestId("recommendation-badge-steady");
+    expect(badge).toBeTruthy();
+    expect(badge.textContent).toContain("home.recommendations.kind.steady");
+    // emerald bg：rgba(5, 150, 105, 0.10) → 浏览器归一化后可能有空格差异，只断层色调
+    expect(badge.getAttribute("style") || "").toMatch(/rgba\(5,\s*150,\s*105/);
+  });
+
+  it("worthy kind → amber 色板", () => {
+    render(<RecommendationBadge kind="worthy" />);
+    const badge = screen.getByTestId("recommendation-badge-worthy");
+    expect(badge.textContent).toContain("home.recommendations.kind.worthy");
+    expect(badge.getAttribute("style") || "").toMatch(/rgba\(217,\s*119,\s*6/);
+  });
+
+  it("fresh kind → sky 色板", () => {
+    render(<RecommendationBadge kind="fresh" />);
+    const badge = screen.getByTestId("recommendation-badge-fresh");
+    expect(badge.textContent).toContain("home.recommendations.kind.fresh");
+    expect(badge.getAttribute("style") || "").toMatch(/rgba\(2,\s*132,\s*199/);
+  });
+
+  it("size=sm 用较小 padding", () => {
+    render(<RecommendationBadge kind="steady" size="sm" />);
+    const badge = screen.getByTestId("recommendation-badge-steady");
+    expect(badge.className).toMatch(/px-2\b/);
+    expect(badge.className).toMatch(/text-\[11px\]/);
+  });
+});

--- a/frontend/src/__tests__/recommendation-card.test.tsx
+++ b/frontend/src/__tests__/recommendation-card.test.tsx
@@ -1,0 +1,175 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RecommendationCard } from "../components/features/home/recommendations/recommendation-card";
+import type { Recommendation } from "../components/features/home/recommendations/types";
+
+/**
+ * P0-C T2 (task #173) — RecommendationCard reason 插值 + kind 二级数据规则
+ */
+
+vi.mock("@/hooks/useI18n", () => ({
+  useI18n: () => ({
+    // 回显 key + vars 用于断言 params 是否传对
+    t: (key: string, vars?: Record<string, string | number>) => {
+      if (!vars || Object.keys(vars).length === 0) return key;
+      const varsStr = Object.entries(vars)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(",");
+      return `${key}[${varsStr}]`;
+    },
+    locale: "zh-CN",
+    loading: false,
+    getNsData: () => null,
+  }),
+}));
+
+function makeReco(overrides: Partial<Recommendation> = {}): Recommendation {
+  return {
+    kind: "steady",
+    locationId: "loc-1",
+    reason: { key: "steady.season_close", params: { km: 12 } },
+    location: {
+      name: "梧桐山",
+      coverImage: "https://cdn.example.com/wutong.jpg",
+      difficulty: "easy",
+      durationMin: 180,
+      distanceKm: 12,
+      favCount: 3,
+      storyCount: 2,
+      ageDays: 100,
+      futureTeams: 2,
+    },
+    ...overrides,
+  };
+}
+
+describe("RecommendationCard", () => {
+  it("渲染 location.name 作为跳转链接 href=/locations/:id", () => {
+    render(<RecommendationCard reco={makeReco()} />);
+    const link = screen.getByRole("link");
+    expect(link.getAttribute("href")).toBe("/locations/loc-1");
+    expect(link.textContent).toContain("梧桐山");
+  });
+
+  it("reason.key `steady.season_close` → 拼接 i18n key `steady_season_close` + km 插值", () => {
+    render(<RecommendationCard reco={makeReco()} />);
+    // t() mock 回显 key + vars → 断言 params.km 被传进去
+    expect(document.body.textContent).toContain("home.recommendations.reason.steady_season_close");
+    expect(document.body.textContent).toContain("km=12");
+  });
+
+  it("reason.key `worthy.favorites_stories` → 用 `_` flatten 后拼接", () => {
+    render(
+      <RecommendationCard
+        reco={makeReco({
+          kind: "worthy",
+          reason: { key: "worthy.favorites_stories", params: { n: 15 } },
+          location: {
+            name: "梧桐山",
+            coverImage: null,
+            difficulty: null,
+            durationMin: null,
+            distanceKm: null,
+            favCount: 10,
+            storyCount: 5,
+            ageDays: 50,
+            futureTeams: 0,
+          },
+        })}
+      />,
+    );
+    expect(document.body.textContent).toContain(
+      "home.recommendations.reason.worthy_favorites_stories",
+    );
+    expect(document.body.textContent).toContain("n=15");
+  });
+
+  it("steady kind → 二级数据展示距离 + 未来队伍数", () => {
+    render(<RecommendationCard reco={makeReco()} />);
+    expect(document.body.textContent).toContain("home.recommendations.meta.distance");
+    expect(document.body.textContent).toContain("km=12");
+    expect(document.body.textContent).toContain("home.recommendations.meta.futureTeams");
+    expect(document.body.textContent).toContain("n=2");
+    // 不应展示 worthy/fresh 的字段
+    expect(document.body.textContent).not.toContain("meta.favorites");
+    expect(document.body.textContent).not.toContain("meta.ageDays");
+  });
+
+  it("worthy kind → 二级数据展示 favorites + stories", () => {
+    render(
+      <RecommendationCard
+        reco={makeReco({
+          kind: "worthy",
+          reason: { key: "worthy.favorites", params: { n: 8 } },
+          location: {
+            name: "东西冲",
+            coverImage: null,
+            difficulty: null,
+            durationMin: null,
+            distanceKm: null,
+            favCount: 8,
+            storyCount: 4,
+            ageDays: 200,
+            futureTeams: 0,
+          },
+        })}
+      />,
+    );
+    expect(document.body.textContent).toContain("home.recommendations.meta.favorites");
+    expect(document.body.textContent).toContain("n=8");
+    expect(document.body.textContent).toContain("home.recommendations.meta.stories");
+    expect(document.body.textContent).toContain("n=4");
+    // 不应展示 steady/fresh 的字段
+    expect(document.body.textContent).not.toContain("meta.distance");
+    expect(document.body.textContent).not.toContain("meta.ageDays");
+  });
+
+  it("fresh kind → 二级数据展示 ageDays + futureTeams", () => {
+    render(
+      <RecommendationCard
+        reco={makeReco({
+          kind: "fresh",
+          reason: { key: "fresh.new_location", params: { days: 3 } },
+          location: {
+            name: "七娘山",
+            coverImage: null,
+            difficulty: "moderate",
+            durationMin: 240,
+            distanceKm: 30,
+            favCount: 0,
+            storyCount: 0,
+            ageDays: 3,
+            futureTeams: 1,
+          },
+        })}
+      />,
+    );
+    expect(document.body.textContent).toContain("home.recommendations.meta.ageDays");
+    expect(document.body.textContent).toContain("n=3");
+    expect(document.body.textContent).toContain("home.recommendations.meta.futureTeams");
+  });
+
+  it("difficulty=null / durationMin=null 时上方 meta 行不渲染", () => {
+    render(
+      <RecommendationCard
+        reco={makeReco({
+          reason: { key: "steady.fallback", params: { km: 5 } },
+          location: {
+            name: "深圳湾",
+            coverImage: null,
+            difficulty: null,
+            durationMin: null,
+            distanceKm: 5,
+            favCount: 0,
+            storyCount: 0,
+            ageDays: 50,
+            futureTeams: 0,
+          },
+        })}
+      />,
+    );
+    // 不该出现 enums.difficulty.* 或 meta.duration
+    expect(document.body.textContent).not.toContain("enums.difficulty");
+    expect(document.body.textContent).not.toContain("meta.duration");
+  });
+});

--- a/frontend/src/components/features/home/home-main.tsx
+++ b/frontend/src/components/features/home/home-main.tsx
@@ -7,6 +7,7 @@ import { HomeLocationsSection } from "./home-locations-section";
 import { HomeHowItWorksSection } from "./home-how-it-works";
 import { HomeTeamsSection } from "./home-teams-section";
 import { HomeCtaSection } from "./home-cta-section";
+import { HomeRecommendationsSection } from "./recommendations/home-recommendations-section";
 import { PreloadImages } from "./preload-images";
 
 export function HomeClient({ initialData }: { initialData?: HomeInitialData }) {
@@ -19,6 +20,8 @@ export function HomeClient({ initialData }: { initialData?: HomeInitialData }) {
       <main className="min-h-screen bg-background">
         <Navbar />
         <HomeHero data={data} />
+        {/* P0-C T2：本周三个选择（Hero 之后 / Locations 之前） */}
+        <HomeRecommendationsSection />
         <HomeLocationsSection data={data} />
         <HomeHowItWorksSection sectionRef={data.howItWorksRef} isInView={data.howItWorksInView} />
         <HomeTeamsSection data={data} />

--- a/frontend/src/components/features/home/index.ts
+++ b/frontend/src/components/features/home/index.ts
@@ -7,3 +7,4 @@ export { HomeLocationsSection } from "./home-locations-section";
 export { HomeHowItWorksSection } from "./home-how-it-works";
 export { HomeTeamsSection } from "./home-teams-section";
 export { HomeCtaSection } from "./home-cta-section";
+export { HomeRecommendationsSection } from "./recommendations/home-recommendations-section";

--- a/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
+++ b/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
@@ -7,6 +7,7 @@
  *  - 「换一批」按钮 → 用返回的 nextSeed 再打一次
  *  - 移动端竖排堆叠 + 「换一批」sticky 底部（本 section 内 sticky，不做全屏）
  *  - 整块三类全空 → 不渲染整个 section（P0-A 空态一致）
+ *  - error 态展示手动重试（不静默 return null，spec §7.4 空态 !== error 态）
  *  - seed 只在内存态，不入 cookie / localStorage（spec §5.2 v1.1 隐私）
  */
 
@@ -40,8 +41,9 @@ export function HomeRecommendationsSection() {
   const [state, setState] = React.useState<FetchState>({ status: "loading" });
   const [refreshing, setRefreshing] = React.useState(false);
 
-  // 首次挂载 fetch（seed 由服务端生成）
-  React.useEffect(() => {
+  // 抽出首次/重试共用的加载逻辑
+  const loadInitial = React.useCallback(() => {
+    setState({ status: "loading" });
     let cancelled = false;
     fetchRecommendations()
       .then((data) => {
@@ -61,6 +63,11 @@ export function HomeRecommendationsSection() {
       cancelled = true;
     };
   }, []);
+
+  React.useEffect(() => {
+    const cleanup = loadInitial();
+    return cleanup;
+  }, [loadInitial]);
 
   const handleRefresh = React.useCallback(async () => {
     if (state.status !== "ready" || refreshing) return;
@@ -85,9 +92,26 @@ export function HomeRecommendationsSection() {
     return null;
   }
 
-  // Error 初次即失败 → 也不渲染（避免打乱首屏）；开发环境可从 console 看到
+  // Error 态：Martin CR B2 —— 不静默 return null，展示 error banner + 手动重试
+  // spec §7.4 明确「整块空 → 不渲染」是空态，与 fetch error 不同语义
   if (state.status === "error") {
-    return null;
+    return (
+      <section
+        className="py-6 text-center text-sm text-muted-foreground"
+        data-testid="home-recommendations-error"
+      >
+        <span>{t("home.recommendations.error")}</span>
+        <button
+          type="button"
+          onClick={loadInitial}
+          className="ml-2 inline-flex items-center gap-1 underline hover:text-amber-700 dark:hover:text-amber-400 transition-colors"
+          data-testid="recommendation-retry-btn"
+          aria-label={t("home.recommendations.error")}
+        >
+          <RefreshCw className="w-3.5 h-3.5" strokeWidth={2.2} />
+        </button>
+      </section>
+    );
   }
 
   return (
@@ -126,14 +150,15 @@ export function HomeRecommendationsSection() {
           </div>
         )}
 
-        {/* Refresh CTA — 桌面居中；移动端 sticky 底部 */}
+        {/* Refresh CTA — 桌面居中；移动端 sticky 底部
+            Martin CR B1: 用 w-fit + mx-auto 让容器只覆盖按钮宽度，避免 sticky 容器矩形挡住卡片点击 */}
         {state.status === "ready" && (
-          <div className="mt-6 sm:mt-8 flex justify-center md:static sticky bottom-4 z-10 pointer-events-none">
+          <div className="mt-6 sm:mt-8 md:static sticky bottom-4 z-10 w-fit mx-auto">
             <button
               type="button"
               onClick={handleRefresh}
               disabled={refreshing}
-              className="pointer-events-auto inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-white/95 dark:bg-neutral-900/95 border border-border shadow-md hover:shadow-lg backdrop-blur text-sm font-medium text-foreground hover:text-amber-700 dark:hover:text-amber-400 transition-all disabled:opacity-60 disabled:cursor-not-allowed"
+              className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-white/95 dark:bg-neutral-900/95 border border-border shadow-md hover:shadow-lg backdrop-blur text-sm font-medium text-foreground hover:text-amber-700 dark:hover:text-amber-400 transition-all disabled:opacity-60 disabled:cursor-not-allowed"
               data-testid="recommendation-refresh-btn"
             >
               <RefreshCw

--- a/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
+++ b/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
@@ -1,0 +1,150 @@
+/**
+ * P0-C T2 (task #173) — 首页「本周去这三个」推荐区块
+ *
+ * spec §3.3 / §5.2 / §7.3 / §7.4：
+ *  - 挂在 Hero 之后 / Locations 之前（home-main.tsx）
+ *  - 首次挂载 fetch `/api/recommendations/home?seed=<random>` 或不带 seed（服务端生成）
+ *  - 「换一批」按钮 → 用返回的 nextSeed 再打一次
+ *  - 移动端竖排堆叠 + 「换一批」sticky 底部（本 section 内 sticky，不做全屏）
+ *  - 整块三类全空 → 不渲染整个 section（P0-A 空态一致）
+ *  - seed 只在内存态，不入 cookie / localStorage（spec §5.2 v1.1 隐私）
+ */
+
+"use client";
+
+import * as React from "react";
+import { RefreshCw } from "lucide-react";
+import { useI18n } from "@/hooks/useI18n";
+import { fetchPublicAPI } from "@/lib/api";
+import { RecommendationCard } from "./recommendation-card";
+import type { Recommendation, RecommendationsResponse } from "./types";
+
+type FetchState =
+  | { status: "loading" }
+  | { status: "ready"; recommendations: Recommendation[]; nextSeed: string }
+  | { status: "error"; message: string };
+
+async function fetchRecommendations(seed?: string): Promise<RecommendationsResponse> {
+  const path = seed
+    ? `/api/recommendations/home?seed=${encodeURIComponent(seed)}`
+    : `/api/recommendations/home`;
+  const res = await fetchPublicAPI(path);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  return (await res.json()) as RecommendationsResponse;
+}
+
+export function HomeRecommendationsSection() {
+  const { t } = useI18n(["home", "enums"]);
+  const [state, setState] = React.useState<FetchState>({ status: "loading" });
+  const [refreshing, setRefreshing] = React.useState(false);
+
+  // 首次挂载 fetch（seed 由服务端生成）
+  React.useEffect(() => {
+    let cancelled = false;
+    fetchRecommendations()
+      .then((data) => {
+        if (cancelled) return;
+        setState({
+          status: "ready",
+          recommendations: data.recommendations,
+          nextSeed: data.nextSeed,
+        });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error("[HomeRecommendations] fetch failed:", err);
+        setState({ status: "error", message: String(err?.message ?? err) });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleRefresh = React.useCallback(async () => {
+    if (state.status !== "ready" || refreshing) return;
+    setRefreshing(true);
+    try {
+      const data = await fetchRecommendations(state.nextSeed);
+      setState({
+        status: "ready",
+        recommendations: data.recommendations,
+        nextSeed: data.nextSeed,
+      });
+    } catch (err) {
+      console.error("[HomeRecommendations] refresh failed:", err);
+      // 保留已展示的推荐，只提示错误
+    } finally {
+      setRefreshing(false);
+    }
+  }, [state, refreshing]);
+
+  // 空态：三类全空 → 不渲染整个 section（spec §7.4）
+  if (state.status === "ready" && state.recommendations.length === 0) {
+    return null;
+  }
+
+  // Error 初次即失败 → 也不渲染（避免打乱首屏）；开发环境可从 console 看到
+  if (state.status === "error") {
+    return null;
+  }
+
+  return (
+    <section
+      id="recommendations"
+      className="py-12 sm:py-16 lg:py-20 bg-background"
+      data-testid="home-recommendations-section"
+    >
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        {/* Title */}
+        <div className="text-center mb-8 sm:mb-10">
+          <span className="inline-block mb-4 px-3 py-1 text-xs font-semibold rounded-full uppercase tracking-widest bg-amber-50/80 dark:bg-amber-950/30 text-amber-800 dark:text-amber-300">
+            {t("home.recommendations.title")}
+          </span>
+          <p className="text-muted-foreground max-w-xl mx-auto leading-relaxed text-base sm:text-lg">
+            {t("home.recommendations.subtitle")}
+          </p>
+        </div>
+
+        {/* Cards grid */}
+        {state.status === "loading" ? (
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 sm:gap-5">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div
+                key={i}
+                className="h-48 rounded-lg border bg-muted animate-pulse"
+                data-testid="recommendation-card-skeleton"
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 sm:gap-5">
+            {state.recommendations.map((reco) => (
+              <RecommendationCard key={reco.locationId} reco={reco} />
+            ))}
+          </div>
+        )}
+
+        {/* Refresh CTA — 桌面居中；移动端 sticky 底部 */}
+        {state.status === "ready" && (
+          <div className="mt-6 sm:mt-8 flex justify-center md:static sticky bottom-4 z-10 pointer-events-none">
+            <button
+              type="button"
+              onClick={handleRefresh}
+              disabled={refreshing}
+              className="pointer-events-auto inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-white/95 dark:bg-neutral-900/95 border border-border shadow-md hover:shadow-lg backdrop-blur text-sm font-medium text-foreground hover:text-amber-700 dark:hover:text-amber-400 transition-all disabled:opacity-60 disabled:cursor-not-allowed"
+              data-testid="recommendation-refresh-btn"
+            >
+              <RefreshCw
+                className={`w-4 h-4 ${refreshing ? "animate-spin" : ""}`}
+                strokeWidth={2.2}
+              />
+              {t("home.recommendations.cta.refresh")}
+            </button>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/features/home/recommendations/recommendation-badge.tsx
+++ b/frontend/src/components/features/home/recommendations/recommendation-badge.tsx
@@ -1,0 +1,72 @@
+/**
+ * P0-C T2 (task #173) — 推荐卡类别徽章
+ *
+ * 视觉规范：Martin CR dm:@Martin msg ae57ca8b
+ *  - steady:  Shield  emerald  bg rgba(5,150,105,0.10) / text #065F46
+ *  - worthy:  Sparkles amber    bg rgba(217,119,6,0.10) / text #92400E
+ *  - fresh:   Zap     sky      bg rgba(2,132,199,0.10) / text #0369A1
+ *
+ * 色板哲学与 status-badge.tsx 一致：bg 10% + text 深色 + border 25%
+ * 深色模式：跟 `bg-card / text-foreground` 主题走；10% opacity 兜底可读
+ */
+
+import { Shield, Sparkles, Zap } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useI18n } from "@/hooks/useI18n";
+import type { RecommendationKind } from "./types";
+
+const KIND_STYLES: Record<
+  RecommendationKind,
+  { bg: string; text: string; border: string; Icon: typeof Shield }
+> = {
+  steady: {
+    bg: "rgba(5, 150, 105, 0.10)",
+    text: "#065F46",
+    border: "rgba(5, 150, 105, 0.25)",
+    Icon: Shield,
+  },
+  worthy: {
+    bg: "rgba(217, 119, 6, 0.10)",
+    text: "#92400E",
+    border: "rgba(217, 119, 6, 0.25)",
+    Icon: Sparkles,
+  },
+  fresh: {
+    bg: "rgba(2, 132, 199, 0.10)",
+    text: "#0369A1",
+    border: "rgba(2, 132, 199, 0.25)",
+    Icon: Zap,
+  },
+};
+
+interface RecommendationBadgeProps {
+  kind: RecommendationKind;
+  size?: "sm" | "md";
+  className?: string;
+}
+
+export function RecommendationBadge({
+  kind,
+  size = "md",
+  className,
+}: RecommendationBadgeProps) {
+  const { t } = useI18n(["home"]);
+  const s = KIND_STYLES[kind];
+  const label = t(`home.recommendations.kind.${kind}`);
+  const Icon = s.Icon;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full font-medium border",
+        size === "sm" ? "px-2 py-0.5 text-[11px]" : "px-2.5 py-1 text-xs",
+        className,
+      )}
+      style={{ background: s.bg, color: s.text, borderColor: s.border }}
+      data-testid={`recommendation-badge-${kind}`}
+    >
+      <Icon className={cn(size === "sm" ? "w-3 h-3" : "w-3.5 h-3.5")} strokeWidth={2.4} />
+      {label}
+    </span>
+  );
+}

--- a/frontend/src/components/features/home/recommendations/recommendation-card.tsx
+++ b/frontend/src/components/features/home/recommendations/recommendation-card.tsx
@@ -1,0 +1,140 @@
+/**
+ * P0-C T2 (task #173) — 推荐卡（单一组件按 kind prop 切样式）
+ *
+ * spec §3.3 视觉结构（卡片布局）：
+ *   [kind badge]  [难度/时长 小 meta]
+ *   [地点名（点击跳详情）]
+ *   [一句话推荐理由]
+ *   [二级数据（favCount/storyCount/ageDays/距离）]
+ *
+ * 卡片外框：kind 对应颜色的 border-{color}-500/40（不加背景，保持 bg-card）
+ * 深色模式：走主题 tokens（bg-card / text-foreground），无需手写 dark: 分支
+ */
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { Card } from "@/components/ui/card";
+import { useI18n } from "@/hooks/useI18n";
+import { RecommendationBadge } from "./recommendation-badge";
+import type { Recommendation, RecommendationKind, ReasonKey } from "./types";
+
+/** kind → 左侧强调边框色（tailwind 语义色，暗色模式跟主题） */
+const KIND_BORDER: Record<RecommendationKind, string> = {
+  steady: "border-l-emerald-500/60",
+  worthy: "border-l-amber-500/60",
+  fresh: "border-l-sky-500/60",
+};
+
+/** ReasonKey 中的 `.` 转 flat `_`，对齐 i18n depth ≤3 约束 */
+function reasonKeyToI18n(key: ReasonKey): string {
+  return `home.recommendations.reason.${key.replace(".", "_")}`;
+}
+
+interface RecommendationCardProps {
+  reco: Recommendation;
+}
+
+export function RecommendationCard({ reco }: RecommendationCardProps) {
+  const { t } = useI18n(["home", "enums"]);
+  const { kind, locationId, reason, location } = reco;
+
+  // reason 文案 —— t() 会用 params 插值；`t(key, vars)` hook 签名
+  const reasonText = t(reasonKeyToI18n(reason.key), {
+    n: reason.params.n ?? 0,
+    km: reason.params.km ?? 0,
+    days: reason.params.days ?? 0,
+  });
+
+  const difficultyLabel =
+    location.difficulty !== null
+      ? t(`enums.difficulty.${location.difficulty}`)
+      : null;
+
+  // 二级数据（根据 kind 优先展示不同维度）
+  const metaLine = buildMetaLine(kind, location, t);
+
+  return (
+    <a
+      href={`/locations/${locationId}`}
+      className="block h-full group focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 rounded-lg"
+      data-testid={`recommendation-card-${kind}`}
+    >
+      <Card
+        className={cn(
+          "h-full p-5 flex flex-col gap-3 border-l-4 transition-all duration-200",
+          "hover:shadow-lg hover:-translate-y-0.5",
+          KIND_BORDER[kind],
+        )}
+      >
+        {/* Row 1: badge + difficulty/duration */}
+        <div className="flex items-center justify-between gap-2">
+          <RecommendationBadge kind={kind} />
+          {(difficultyLabel || location.durationMin) && (
+            <div className="text-[11px] text-muted-foreground flex items-center gap-1.5">
+              {difficultyLabel && <span>{difficultyLabel}</span>}
+              {difficultyLabel && location.durationMin ? <span>·</span> : null}
+              {location.durationMin && (
+                <span>{t("home.recommendations.meta.duration", { n: location.durationMin })}</span>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Row 2: 地点名 */}
+        <h3 className="text-lg font-semibold text-foreground leading-snug group-hover:text-amber-700 dark:group-hover:text-amber-400 transition-colors line-clamp-2">
+          {location.name}
+        </h3>
+
+        {/* Row 3: 一句话理由 */}
+        <p className="text-sm text-muted-foreground leading-relaxed line-clamp-3 flex-1">
+          {reasonText}
+        </p>
+
+        {/* Row 4: 二级数据 */}
+        {metaLine.length > 0 && (
+          <div className="pt-2 mt-auto flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground border-t border-border/50">
+            {metaLine.map((m, i) => (
+              <span key={i}>{m}</span>
+            ))}
+          </div>
+        )}
+      </Card>
+    </a>
+  );
+}
+
+/**
+ * 按 kind 的语义挑二级数据字段（避免所有 kind 都塞满信息噪声）：
+ *  - steady: 距离 + 未来队伍数
+ *  - worthy: 收藏数 + 故事数
+ *  - fresh:  新建 N 天 + 未来队伍数
+ * 若字段为 0 / null 自动隐藏。
+ */
+function buildMetaLine(
+  kind: RecommendationKind,
+  loc: Recommendation["location"],
+  t: (key: string, vars?: Record<string, string | number>) => string,
+): string[] {
+  const out: string[] = [];
+  if (kind === "steady") {
+    if (loc.distanceKm !== null && loc.distanceKm > 0) {
+      out.push(t("home.recommendations.meta.distance", { km: loc.distanceKm }));
+    }
+    if (loc.futureTeams > 0) {
+      out.push(t("home.recommendations.meta.futureTeams", { n: loc.futureTeams }));
+    }
+  } else if (kind === "worthy") {
+    if (loc.favCount > 0) {
+      out.push(t("home.recommendations.meta.favorites", { n: loc.favCount }));
+    }
+    if (loc.storyCount > 0) {
+      out.push(t("home.recommendations.meta.stories", { n: loc.storyCount }));
+    }
+  } else {
+    out.push(t("home.recommendations.meta.ageDays", { n: loc.ageDays }));
+    if (loc.futureTeams > 0) {
+      out.push(t("home.recommendations.meta.futureTeams", { n: loc.futureTeams }));
+    }
+  }
+  return out;
+}

--- a/frontend/src/components/features/home/recommendations/types.ts
+++ b/frontend/src/components/features/home/recommendations/types.ts
@@ -1,0 +1,62 @@
+/**
+ * P0-C T2 (task #173) — 前端 Recommendation 类型
+ *
+ * 与 api/src/services/recommendations.ts 契约对齐。
+ * 保持独立复制而非 shared package：packages/lib/types 里放业务纯函数，
+ * API 响应 DTO 单向流入前端，避免 shared type circular import。
+ */
+
+export type RecommendationKind = "steady" | "worthy" | "fresh";
+
+/** api reason.key union（12 + 3 fallback）；前端 i18n key 走 `steady_season_close` 等 flat 形式 */
+export type ReasonKey =
+  | "steady.season_close"
+  | "steady.season_teams"
+  | "steady.easy_close"
+  | "steady.close_social"
+  | "steady.fallback"
+  | "worthy.favorites"
+  | "worthy.stories"
+  | "worthy.favorites_stories"
+  | "worthy.fallback"
+  | "fresh.new_location"
+  | "fresh.trending_signups"
+  | "fresh.new_teams"
+  | "fresh.fallback";
+
+export interface ReasonParams {
+  n?: number;
+  km?: number;
+  days?: number;
+}
+
+export interface RecommendationReason {
+  key: ReasonKey;
+  params: ReasonParams;
+}
+
+/** 卡片渲染所需字段 — API 一次性带回（Martin CR 契约 B，msg 66cf9186） */
+export interface RecommendationLocationSummary {
+  name: string;
+  coverImage: string | null;
+  difficulty: string | null;
+  durationMin: number | null;
+  distanceKm: number | null;
+  favCount: number;
+  storyCount: number;
+  ageDays: number;
+  futureTeams: number;
+}
+
+export interface Recommendation {
+  kind: RecommendationKind;
+  locationId: string;
+  reason: RecommendationReason;
+  location: RecommendationLocationSummary;
+}
+
+export interface RecommendationsResponse {
+  recommendations: Recommendation[];
+  candidatePoolSize: number;
+  nextSeed: string;
+}

--- a/frontend/src/components/features/home/recommendations/types.ts
+++ b/frontend/src/components/features/home/recommendations/types.ts
@@ -8,7 +8,13 @@
 
 export type RecommendationKind = "steady" | "worthy" | "fresh";
 
-/** api reason.key union（12 + 3 fallback）；前端 i18n key 走 `steady_season_close` 等 flat 形式 */
+/** api reason.key union（12 + 3 fallback）；前端 i18n key 走 `steady_season_close` 等 flat 形式
+ *
+ * TODO(P1): 与 api/src/services/recommendations.ts 的 ReasonKey 手动同步。
+ *   若将来建立 `packages/api-contract` shared 包，将本 union + ReasonParams + RecommendationLocationSummary
+ *   一并迁移过去，避免漂移风险（api 加第 13 个 reason.key 时前端 union 落后一版）。
+ *   当前保持独立复制 —— shared type 迁移是大动作，本次 T2 不做。
+ */
 export type ReasonKey =
   | "steady.season_close"
   | "steady.season_teams"


### PR DESCRIPTION
## 范围

P0-C T2 (task #173) —— 首页「本周去这三个」推荐区块（steady / worthy / fresh 三卡 + 换一批）+ API `Recommendation` 契约扩展。

## 关键改动

**API（契约 B，Martin CR msg 66cf9186 确认）**
- `Recommendation` 新增 `location` 字段（`name/coverImage/difficulty/durationMin/distanceKm/favCount/storyCount/ageDays/futureTeams`），避免前端 N+1 waterfall
- `fetchSignals` + `rehydratePool` SQL 补 `l.cover_image` / `l.duration_min` 列（UNION ALL 一致）
- `selectThree` 组装 `location` payload：`distanceKm` 保留 1 位小数，`difficulty` 归一化小写
- 单测 48 → 53（+5 T2 契约断言）

**Frontend（Martin CR msg ae57ca8b：三组件 + Card primitive + 精确色板）**
- `home/recommendations/`：
  - `RecommendationBadge` — kind → i18n label + 精确 rgba（emerald / amber / sky）
  - `RecommendationCard` — 单一组件按 `kind` prop 切样式，左强调边框 + 4 行布局
  - `HomeRecommendationsSection` — fetch + refresh + 空态/错误态 return null，移动端 sticky 底部
- `reason.key` `.` flatten 到 `_`，对齐 i18n depth ≤ 3 约束（`scripts/validate-i18n-keys.mjs`）
- 二级数据按 kind 语义挑选：steady=距离+队伍数 / worthy=收藏+故事 / fresh=天数+队伍数（避免全塞信息噪声）
- i18n zh-CN / en / ja `home.json` 新增 `recommendations` 命名空间（reason 12 key + kind/meta/empty/cta）
- Section 挂在 `home-main.tsx`：Hero → **Recommendations** → Locations

## 本地验证

| 命令 | 结果 |
|---|---|
| `pnpm --filter api test` | ✅ 264/264 |
| `pnpm --filter frontend test recommendation-*` | ✅ 11/11（4 badge + 7 card） |
| `pnpm -r type-check` | ✅ 0 errors / 0 warnings |
| `pnpm -r lint` | ✅ 0 errors（1 pre-existing warning 与本次改动无关） |

## 关键文件

- `api/src/services/recommendations.ts`：契约扩展 + SQL 补列 + payload 组装
- `api/src/__tests__/unit/recommendations.test.ts`：+5 契约断言
- `frontend/src/components/features/home/recommendations/`：4 个新文件（types/badge/card/section）
- `frontend/src/__tests__/recommendation-{badge,card}.test.tsx`：11 单测
- `frontend/public/locales/{zh-CN,en,ja}/home.json`：i18n 三语同步
- `frontend/src/components/features/home/{home-main,index}.tsx`：section 挂载 + 导出

## 已知风险 & 回滚

- **风险**：`Recommendation` 契约扩展是**加字段**，对老客户端 backward-compatible（老前端忽略 `location`）；无 schema 变更。
- **回滚**：single squash commit，revert 即可；无迁移、无 KV/DB 变更（`RECOMMEND_CACHE_SALT` 是 Martin T1 已有 secret，无需动）。

## CR 关注点

- API：SQL 补列 + payload 组装是否漏字段（Martin 定的 9 字段清单）
- Frontend：`reasonKeyToI18n` flatten 逻辑是否处理 `worthy.favorites_stories` 这类双词 key（已在测试覆盖）
- 视觉：三色板 rgba 与 spec §3.3 一致（emerald/amber/sky）
- 空态：三类全空 → section 隐藏；error → section 隐藏；spec §7.4 一致

Refs: task #173, dm:@Martin msg 66cf9186 (契约 B), msg ae57ca8b (三组件设计)