### PR TITLE
fix(recommendations): P0-C hotfix — 三卡强制返足 (A+B+C)

### DIFF
--- a/api/src/__tests__/unit/recommendations.test.ts
+++ b/api/src/__tests__/unit/recommendations.test.ts
@@ -112,6 +112,21 @@ describe("recommendations: seasonMatches", () => {
   it("非数组 → false", () => {
     expect(seasonMatches('"spring"', "spring")).toBe(false);
   });
+
+  // spec v1.2 §4.1 A 补充：全年 / all / year-round → 任意季节命中
+  it('"全年" label → 任意季节都命中', () => {
+    expect(seasonMatches('["全年"]', "spring")).toBe(true);
+    expect(seasonMatches('["全年"]', "summer")).toBe(true);
+    expect(seasonMatches('["全年"]', "autumn")).toBe(true);
+    expect(seasonMatches('["全年"]', "winter")).toBe(true);
+  });
+
+  it('"all" / "year-round" 英文 sentinel → 任意季节都命中', () => {
+    expect(seasonMatches('["all"]', "summer")).toBe(true);
+    expect(seasonMatches('["year-round"]', "winter")).toBe(true);
+    // 混数组仍然命中
+    expect(seasonMatches('["spring","全年"]', "winter")).toBe(true);
+  });
 });
 
 // ==================== buildCandidate / computePool ====================
@@ -209,8 +224,8 @@ describe("recommendations: buildCandidate hit 位", () => {
     expect(c.hits.isNew).toBe(true);
   });
 
-  it("ageDays >7 → 非 isNew", () => {
-    const c = buildCandidate(makeRow(now, { id: "l1", ageDays: 15 }), now, "summer");
+  it("ageDays >30 → 非 isNew（spec v1.2 阈值 30d）", () => {
+    const c = buildCandidate(makeRow(now, { id: "l1", ageDays: 45 }), now, "summer");
     expect(c.hits.isNew).toBe(false);
   });
 
@@ -340,6 +355,45 @@ describe("recommendations: selectThree 冲突解决 + 排序", () => {
     const pool = makePool([], [], []);
     const res = selectThree(pool, "seed-x");
     expect(res).toEqual([]);
+  });
+
+  // spec v1.2 §6.4 跨 kind 兜底：worthy / fresh 空 → steady 剩余次优补位
+  it("worthy 空 + steady 有余量 → worthy slot 用 steady 兜底，kind=worthy reason=fallback", () => {
+    const pool = makePool(["s1", "s2"], [], []);
+    const res = selectThree(pool, "seed-x");
+    // steady 只有 2 个，一个占 steady slot 一个填 worthy slot；fresh 无兜底源
+    expect(res.length).toBe(2);
+    const worthySlot = res.find((r) => r.kind === "worthy");
+    expect(worthySlot).toBeDefined();
+    expect(worthySlot!.reason.key).toBe<ReasonKey>("worthy.fallback");
+  });
+
+  it("fresh 空 + steady 有余量 → fresh slot 用 steady 兜底，kind=fresh reason=fallback", () => {
+    const pool = makePool(["s1", "s2"], ["w1"], []);
+    const res = selectThree(pool, "seed-x");
+    expect(res.length).toBe(3);
+    const freshSlot = res.find((r) => r.kind === "fresh");
+    expect(freshSlot).toBeDefined();
+    expect(freshSlot!.reason.key).toBe<ReasonKey>("fresh.fallback");
+  });
+
+  it("worthy + fresh 都空 + steady 有 3 个 → 三张全出，两张 fallback", () => {
+    const pool = makePool(["s1", "s2", "s3"], [], []);
+    const res = selectThree(pool, "seed-x");
+    expect(res.length).toBe(3);
+    expect(res.map((r) => r.kind).sort()).toEqual(["fresh", "steady", "worthy"]);
+    const ids = new Set(res.map((r) => r.locationId));
+    expect(ids.size).toBe(3); // 三张不同 loc
+    // steady slot 用 steady reason（有 season+distance 双命中→season_close），worthy/fresh 用 fallback
+    expect(res.find((r) => r.kind === "worthy")!.reason.key).toBe<ReasonKey>("worthy.fallback");
+    expect(res.find((r) => r.kind === "fresh")!.reason.key).toBe<ReasonKey>("fresh.fallback");
+  });
+
+  it("兜底不违反去重：steady 只有 1 个 → 三个 slot 只能填 1 张", () => {
+    const pool = makePool(["only"], [], []);
+    const res = selectThree(pool, "seed-x");
+    expect(res.length).toBe(1);
+    expect(res[0]!.kind).toBe("steady");
   });
 
   it("同池 3+ 条，不同 seed 选出不同 candidate", () => {
@@ -523,8 +577,8 @@ describe("recommendations: pickReason fresh", () => {
   });
 
   it("均未命中 → fresh.fallback", () => {
-    // ageDays=30 → 非 isNew；无 signup7d/newTeams7d
-    const c = mk({ id: "l1", ageDays: 30 });
+    // ageDays=60 → 非 isNew（spec v1.2 阈值 30d）；无 signup7d/newTeams7d
+    const c = mk({ id: "l1", ageDays: 60 });
     expect(pickReason("fresh", c).key).toBe<ReasonKey>("fresh.fallback");
   });
 });

--- a/api/src/services/recommendations.ts
+++ b/api/src/services/recommendations.ts
@@ -331,6 +331,9 @@ interface Candidate {
  * 从而同时兼容中文 label 数据和未来的英文 key 数据。
  *
  * Martin CR PR #395 blocker-1：修复 prod 数据 100% miss。
+ *
+ * spec v1.2 §4.1 A 补充：bestSeason 含 "全年" / "all" / "year-round" 视为**任意季节均命中**
+ * （prod 有 6 个 loc 是全年可去，如阳台山/梅沙尖，之前统一被归一到 null 拿不到 seasonMatch 加分）。
  */
 function seasonMatches(bestSeasonJson: string, season: Season): boolean {
   try {
@@ -338,6 +341,11 @@ function seasonMatches(bestSeasonJson: string, season: Season): boolean {
     if (!Array.isArray(arr)) return false;
     return arr.some((label) => {
       if (typeof label !== "string") return false;
+      // 全年 / all / year-round → 任意季节命中
+      const trimmed = label.trim().toLowerCase();
+      if (trimmed === "全年" || trimmed === "all" || trimmed === "year-round") {
+        return true;
+      }
       return normalizeSeasonLabel(label) === season;
     });
   } catch {
@@ -355,9 +363,12 @@ function buildCandidate(row: SignalRow, now: number, season: Season): Candidate 
   const closeDistance = row.distance !== null && row.distance <= 50;
   const hasTeams = row.future_teams >= 1;
   const manyTeams = row.future_teams >= 2;
-  const manyFavorites = row.fav_count >= 5;
-  const manyStories = row.story_count >= 3;
-  const isNew = ageDays >= 0 && ageDays <= 7;
+  // spec v1.2 §4.2/§4.3 数据饥荒版阈值降级（P0-C MVP）：
+  //   manyFavorites 5→3、manyStories 3→1、isNew 7d→30d
+  //   等 favorites/stories 有真实业务量后，Martin 通过 spec v1.3 回收到 spec §4.2 原阈值。
+  const manyFavorites = row.fav_count >= 3;
+  const manyStories = row.story_count >= 1;
+  const isNew = ageDays >= 0 && ageDays <= 30;
   const trendingSignups = row.signup_7d >= 5;
   const newTeams = row.new_teams_7d >= 1;
 
@@ -498,6 +509,13 @@ function pickFromKind(pool: Candidate[], rand: () => number): Candidate | null {
 /**
  * 冲突解决（spec §6.3）：worthy 优先，其次 steady，最后 fresh
  * 三张卡必须不同 location；若某 kind 池内候选都冲突 → 该 kind 空
+ *
+ * spec v1.2 §6.4 跨 kind 兜底填充（Martin 2026-07-20 blocker 修复）：
+ *   worthy/fresh 池天然为空时，从 steady 剩余次优（未被 steady slot 选走且未被本轮选走）补位；
+ *   kind 标签保持（前端仍显示 worthy/fresh 徽章 + 边框色），reason 用 kind.fallback；
+ *   chosenIds 依然生效，保证三张不同 loc。
+ *
+ * 保证任意时刻返 3 张（除非全 35 loc 都不通过 steady 5-way OR，几乎不可能）。
  */
 function selectThree(pool: Pool, seed: string): Recommendation[] {
   const rand = mulberry32(seedToUint32(seed));
@@ -506,24 +524,13 @@ function selectThree(pool: Pool, seed: string): Recommendation[] {
   const chosenIds = new Set<string>();
   const results: (Recommendation | null)[] = [null, null, null]; // [steady, worthy, fresh]
 
-  const takeFromKind = (
-    kind: RecommendationKind,
-    kindPool: Candidate[],
-    slot: number,
-  ) => {
-    if (kindPool.length === 0) return;
-    // 从池中过滤未被占用的候选
-    const remaining = kindPool.filter((c) => !chosenIds.has(c.locationId));
-    if (remaining.length === 0) return; // 全冲突 → 该 kind 空
-    const picked = pickFromKind(remaining, rand);
-    if (!picked) return;
-    chosenIds.add(picked.locationId);
+  const buildRecord = (kind: RecommendationKind, picked: Candidate): Recommendation => {
     const d = picked.data;
     // km 保留 1 位小数（P0-C T2 契约：避免前端二次换算）
     const distanceKm = d.distanceKm === null ? null : Math.round(d.distanceKm * 10) / 10;
     // difficulty 归一小写（DB 存自由文本；前端 DIFFICULTY_CONFIG key 小写）
     const difficulty = d.difficulty === null ? null : d.difficulty.toLowerCase();
-    results[slot] = {
+    return {
       kind,
       locationId: picked.locationId,
       reason: pickReason(kind, picked),
@@ -542,10 +549,40 @@ function selectThree(pool: Pool, seed: string): Recommendation[] {
     };
   };
 
+  const takeFromKind = (
+    kind: RecommendationKind,
+    kindPool: Candidate[],
+    slot: number,
+  ) => {
+    if (kindPool.length === 0) return;
+    // 从池中过滤未被占用的候选
+    const remaining = kindPool.filter((c) => !chosenIds.has(c.locationId));
+    if (remaining.length === 0) return; // 全冲突 → 该 kind 空
+    const picked = pickFromKind(remaining, rand);
+    if (!picked) return;
+    chosenIds.add(picked.locationId);
+    results[slot] = buildRecord(kind, picked);
+  };
+
   // 顺序：worthy(idx=1) → steady(idx=0) → fresh(idx=2)
   takeFromKind("worthy", pool.worthy, 1);
   takeFromKind("steady", pool.steady, 0);
   takeFromKind("fresh", pool.fresh, 2);
+
+  // spec v1.2 §6.4：worthy / fresh 空槽 → 从 steady 剩余次优补位
+  // 保持 kind 标签，reason 走 fallback（前端 kind 徽章 + 边框 + fallback 文案）
+  const fillEmptySlot = (kind: RecommendationKind, slot: number) => {
+    if (results[slot] !== null) return;
+    const remaining = pool.steady.filter((c) => !chosenIds.has(c.locationId));
+    if (remaining.length === 0) return; // steady 也用完，只能返少于 3
+    const picked = pickFromKind(remaining, rand);
+    if (!picked) return;
+    chosenIds.add(picked.locationId);
+    // buildRecord 用传入的 kind → pickReason(kind, ...) 命中 kind.fallback（无 hits 加分）
+    results[slot] = buildRecord(kind, picked);
+  };
+  fillEmptySlot("worthy", 1);
+  fillEmptySlot("fresh", 2);
 
   // payload 顺序 [steady, worthy, fresh]（UI 期望）
   return results.filter((r): r is Recommendation => r !== null);


### PR DESCRIPTION
## 事故
线上 `/api/public/recommendations` 只返 1 张（steady），worthy/fresh 天然空池。Wen QA 定位：prod 数据饥荒，所有 loc favCount<5 / storyCount<3 / age>7d / signup_7d=0，worthy 5 规则 + fresh 3 规则全 miss；spec v1.1 §6.3 无跨 kind 兜底 → 只出 1 张。

## 修复（Martin 2026-07-20 admin decision，30min 内 hotfix）

### A. `selectThree` 跨 kind 兜底（新增 spec v1.2 §6.4）
worthy / fresh 空槽 → 从 steady 剩余次优补位；kind 标签保持（前端徽章 + 边框色不变），reason 走 `kind.fallback`（无 hits 加分）；`chosenIds` 依然生效，三张必然不同 loc。
抽出 `buildRecord(kind, picked)` helper 避免 takeFromKind / fillEmptySlot 重复逻辑。

### B. 阈值降级（spec v1.2 §4.2/§4.3 数据饥荒版）
- `manyFavorites` 5 → 3
- `manyStories` 3 → 1
- `isNew` 7d → 30d

等 favorites/stories 有真实业务量后 Martin 通过 spec v1.3 回收到 §4.2 原阈值。

### C. `seasonMatches` "全年" 归一（新增 spec v1.2 §4.1 补充）
`bestSeason` 含 `"全年"` / `"all"` / `"year-round"` → 任意 season 均命中。prod 6 个 loc 是全年可去（阳台山、梅沙尖等），之前统一归一到 null 拿不到 seasonMatch 加分。

## 本地验证
- `api npx vitest run` — **270/270 PASS**（新增 6 个针对 A/B/C 的单测）
- `api npx tsc --noEmit` — clean
- `frontend npx vitest run` — **187/187 PASS**
- `frontend npx tsc --noEmit` — clean

## 契约兼容
- `Recommendation.reason.key` 保持 v1 契约 12 keys（`worthy.fallback` / `fresh.fallback` 早已存在）
- 前端 i18n zh/en/ja 三语已覆盖 fallback keys（PR #397 T3）

## 风险与回滚
- 纯代码改动，**无 schema / migration / env vars 变更**
- 回滚：revert 本 commit + `wrangler deploy`（不影响 KV 缓存 key，5min 后自然刷新）
- KV cache 未清理时最坏情况：5min 内还是旧的 1 张卡；wrangler deploy 后新 request 立刻走新代码

## 关联
- Task: #172 (T1) / #173 (T2) hotfix — post-merge fix
- Spec: 需要 Martin 起 v1.2 补丁记录 §4.1 A / §4.2/§4.3 / §6.4（不阻塞本 hotfix）
