### PR TITLE
fix(frontend): wrap Layout.astro critical CSS in @layer base (task #178)

### DIFF
--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -112,16 +112,18 @@ const criticalCSS = `
   --input: #38322a;
   --ring: #F59E0B;
 }
-*,*::before,*::after{box-sizing:border-box;border-color:var(--border)}
-html{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;text-rendering:optimizeLegibility;-webkit-text-size-adjust:100%;scrollbar-width:thin;scrollbar-color:var(--border) transparent}
-body{margin:0;font-family:"PingFang SC","Hiragino Sans GB","Microsoft YaHei","Noto Sans SC",system-ui,sans-serif;background-color:var(--background);color:var(--foreground);line-height:1.6;min-height:100vh}
-h1,h2,h3,h4,h5,h6{margin:0;line-height:1.25}
-p{margin:0}
-a{color:inherit;text-decoration:none}
-::selection{background-color:rgba(217,119,6,0.18)}
-.min-h-screen{min-height:100vh}
-.bg-background{background-color:var(--background)}
-.text-foreground{color:var(--foreground)}
+@layer base {
+  *,*::before,*::after{box-sizing:border-box;border-color:var(--border)}
+  html{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;text-rendering:optimizeLegibility;-webkit-text-size-adjust:100%;scrollbar-width:thin;scrollbar-color:var(--border) transparent}
+  body{margin:0;font-family:"PingFang SC","Hiragino Sans GB","Microsoft YaHei","Noto Sans SC",system-ui,sans-serif;background-color:var(--background);color:var(--foreground);line-height:1.6;min-height:100vh}
+  h1,h2,h3,h4,h5,h6{margin:0;line-height:1.25}
+  p{margin:0}
+  a{color:inherit;text-decoration:none}
+  ::selection{background-color:rgba(217,119,6,0.18)}
+  .min-h-screen{min-height:100vh}
+  .bg-background{background-color:var(--background)}
+  .text-foreground{color:var(--foreground)}
+}
 `.replace(/\n/g, '');
 
 // 页面级标题映射


### PR DESCRIPTION
## 问题
P0-C 首页推荐三卡的 emerald / amber / sky 三色边框在生产环境全部退回米色（`--border = #e8e0d7`），spec §3.3 视觉三色区分丢失。

## 根因（@Martin 定位，thread msg=1316b194）
`frontend/src/layouts/Layout.astro:115` 内联 critical CSS 里
```
*,*::before,*::after{box-sizing:border-box;border-color:var(--border)}
```
**未包 `@layer` 归属**。

CSS Cascade Layers 规则：**unlayered > utilities > components > base > properties**。无层归属的 `*` 通配符 reset 击败 `@layer utilities` 里的 `.border-l-emerald-500/60` / `.border-l-amber-500/60` / `.border-l-sky-500/60`，边框颜色回退 `var(--border)`。

**证据链**（Playwright + CDP `getMatchedStylesForNode`，from Wen msg=762c6b95）：
- `layer: ["base"]`  Tailwind preflight `*` 规则（正常）
- `layer: ["utilities"]`  `.border-l-emerald-500/60` 目标规则（存在但被覆盖）
- `layer: []`  Layout.astro 内联 `*` reset ← 罪魁祸首

## 修复
把 reset / typography / utilities 等价物统一包进 `@layer base { ... }`，让 `@layer utilities` 的规则自然胜出。

**`:root` / `.dark` 里的 CSS custom properties 保持无层**（Martin 强调：变量声明放层里会限定作用域，可能引起意外副作用）。

## Verify

### 本地全绿
- ✅ `pnpm --filter frontend build` PASS（server 18.39s + client 6.23s+5.70s）
- ✅ `pnpm --filter frontend test recommendation` 16/16 PASS

### Build 输出证据（SSR bundle）
```
$ grep -A11 '@layer base' frontend/dist/server/chunks/Layout_L2JAt_Zl.mjs
@layer base {
  *,*::before,*::after{box-sizing:border-box;border-color:var(--border)}
  html{-webkit-font-smoothing:antialiased;...;scrollbar-color:var(--border) transparent}
  body{margin:0;font-family:"PingFang SC",...;line-height:1.6;min-height:100vh}
  h1,h2,h3,h4,h5,h6{margin:0;line-height:1.25}
  p{margin:0}
  a{color:inherit;text-decoration:none}
  ::selection{background-color:rgba(217,119,6,0.18)}
  .min-h-screen{min-height:100vh}
  .bg-background{background-color:var(--background)}
  .text-foreground{color:var(--foreground)}
}
```

SSR 页面渲染时 `.replace(/\n/g, '')` 会压成单行注入到 `<style>`，layer 结构完整保留。

## Risk
- **范围**：单文件 CSS 结构调整，无 API / behavior 变化
- **影响面**：所有页面共享的 inline critical CSS，改动语义等价于原状 + 加了层归属
- **回滚**：`git revert <sha>`，无副作用

## QA 复测清单（@Wen）
staging deploy 后 Playwright 抓 `.border-l-4` 卡片 `borderLeftColor`，期望：

| 卡片类型 | class | 期望值（60% alpha） |
| --- | --- | --- |
| steady（稳） | `border-l-emerald-500/60` | `rgba(0,187,127,0.6)` / `#00bb7f99` |
| worthy（值得） | `border-l-amber-500/60` | `rgba(245,158,11,0.6)` / `#f59e0b99` |
| fresh（新） | `border-l-sky-500/60` | `rgba(14,165,233,0.6)` / `#0ea5e999` |

hard reload（cache bust）后抓取。

## 关联
- **root task**: task #178
- **原因来源**: P0-C hotfix PR #398 引入 border-l-{color}-500/60 类名后暴露此隐藏 bug（PR #396 本身正确，此 CSS layer 结构缺陷早于 P0-C）
- **thread**: #proj-gomate:a0c9184a

## Checklist
- [x] 单文件改动，无环境变量 / schema / secret 涉及
- [x] 本地 build + test 全绿
- [x] SSR bundle grep 验证 wrap 生效
- [ ] GitHub Checks（等 CI）
- [ ] Wen staging 复测（PR merge + deploy 后）

cc @Martin @Wen