### PR TITLE
feat(api): P0-B T2 GET /locations/:id/transportation + gear CSV (task #169)

### DIFF
--- a/api/src/__tests__/integration/locations.test.ts
+++ b/api/src/__tests__/integration/locations.test.ts
@@ -19,6 +19,16 @@ vi.mock("../../db", () => ({
   createDb: (_d1: unknown) => testDb,
 }));
 
+// P0-B T2 (#169): mock computeTransportation 避免真调 amap
+const computeTransportationMock = vi.fn();
+vi.mock("../../lib/amap-decision", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../lib/amap-decision")>();
+  return {
+    ...actual,
+    computeTransportation: (input: unknown) => computeTransportationMock(input),
+  };
+});
+
 const { locationsRoute } = await import("../../routes/locations");
 
 function createApp() {
@@ -27,8 +37,13 @@ function createApp() {
   return app;
 }
 
-async function req(app: ReturnType<typeof createApp>, path: string, options: RequestInit = {}) {
-  return app.fetch(new Request(`http://localhost${path}`, options), { DB: {} });
+async function req(
+  app: ReturnType<typeof createApp>,
+  path: string,
+  options: RequestInit = {},
+  envOverrides: Record<string, unknown> = {},
+) {
+  return app.fetch(new Request(`http://localhost${path}`, options), { DB: {}, ...envOverrides });
 }
 
 describe("Locations API 集成测试", () => {
@@ -181,6 +196,267 @@ describe("Locations API 集成测试", () => {
       expect(item.durationMin).toBe(300);
       expect(item.durationMax).toBe(420);
       expect(item.routes).toBeUndefined();
+    });
+  });
+
+  // ==================== P0-B T2 (task #169): GET /locations/:id/transportation ====================
+  describe("GET /locations/:id/transportation - 交通决策数据", () => {
+    beforeEach(() => {
+      computeTransportationMock.mockReset();
+    });
+
+    it("不存在的地点返回 404", async () => {
+      const res = await req(app, "/locations/does-not-exist/transportation");
+      expect(res.status).toBe(404);
+      expect(computeTransportationMock).not.toHaveBeenCalled();
+    });
+
+    it("无效坐标 {lat:0,lng:0} → amapAllFailed=true 且不调 amap", async () => {
+      const loc = await seedLocation(testDb, city.id, {
+        name: "无坐标点",
+        coordinates: JSON.stringify({ lat: 0, lng: 0 }),
+      });
+
+      const res = await req(app, `/locations/${loc.id}/transportation`);
+      expect(res.status).toBe(200);
+      const json = await res.json() as {
+        success: boolean;
+        locationId: string;
+        transportation: { mapUrl: string; subway: unknown; driving: unknown; amapAllFailed: boolean };
+        meta: { cacheHit: boolean; staleDays: number | null };
+      };
+      expect(json.success).toBe(true);
+      expect(json.locationId).toBe(loc.id);
+      expect(json.transportation.amapAllFailed).toBe(true);
+      expect(json.transportation.subway).toBeNull();
+      expect(json.transportation.driving).toBeNull();
+      expect(json.meta.cacheHit).toBe(false);
+      expect(computeTransportationMock).not.toHaveBeenCalled();
+    });
+
+    it("有坐标 + 无 AMAP_SERVER_KEY → 只返 mapUrl", async () => {
+      const loc = await seedLocation(testDb, city.id, {
+        name: "梧桐山",
+        coordinates: JSON.stringify({ lat: 22.5478, lng: 114.0596 }),
+      });
+
+      const res = await req(app, `/locations/${loc.id}/transportation`);
+      expect(res.status).toBe(200);
+      const json = await res.json() as {
+        transportation: { mapUrl: string; subway: unknown; driving: unknown; amapAllFailed: boolean };
+      };
+      expect(json.transportation.mapUrl).toContain("uri.amap.com");
+      expect(json.transportation.subway).toBeNull();
+      expect(json.transportation.driving).toBeNull();
+      expect(json.transportation.amapAllFailed).toBe(true);
+      expect(computeTransportationMock).not.toHaveBeenCalled();
+    });
+
+    it("支持 slug 访问", async () => {
+      const loc = await seedLocation(testDb, city.id, {
+        name: "梧桐山",
+        slug: "wutong-mountain-tp",
+        coordinates: JSON.stringify({ lat: 22.5478, lng: 114.0596 }),
+      });
+
+      const res = await req(app, "/locations/wutong-mountain-tp/transportation");
+      expect(res.status).toBe(200);
+      const json = await res.json() as { locationId: string };
+      expect(json.locationId).toBe(loc.id);
+    });
+
+    it("有 amapKey + 无 KV → 走 computeTransportation 返回完整数据", async () => {
+      const loc = await seedLocation(testDb, city.id, {
+        name: "梅林关",
+        coordinates: JSON.stringify({ lat: 22.5478, lng: 114.0596 }),
+      });
+
+      computeTransportationMock.mockResolvedValueOnce({
+        mapUrl: "https://uri.amap.com/marker?position=114.059600%2C22.547800",
+        subway: {
+          station: "梅林关",
+          lines: ["4号线"],
+          distanceMeters: 300,
+          walkMinutes: 3,
+          approximate: false,
+        },
+        driving: {
+          distanceKm: 12,
+          durationMinutes: 20,
+          referencePointLabel: { zh: "深圳市中心", en: "Shenzhen City Center", ja: "深圳市中心" },
+        },
+        amapAllFailed: false,
+      });
+
+      const res = await req(
+        app,
+        `/locations/${loc.id}/transportation`,
+        {},
+        { AMAP_SERVER_KEY: "test-key" },
+      );
+      expect(res.status).toBe(200);
+      const json = await res.json() as {
+        transportation: {
+          subway: { station: string } | null;
+          driving: { distanceKm: number } | null;
+          amapAllFailed: boolean;
+        };
+        meta: { cacheHit: boolean; staleDays: number | null };
+      };
+      expect(json.transportation.subway?.station).toBe("梅林关");
+      expect(json.transportation.driving?.distanceKm).toBe(12);
+      expect(json.transportation.amapAllFailed).toBe(false);
+      expect(json.meta.cacheHit).toBe(false);
+      expect(json.meta.staleDays).toBeNull();
+      expect(computeTransportationMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("KV 新鲜命中（<24h）→ cacheHit=true 且不调 amap", async () => {
+      const loc = await seedLocation(testDb, city.id, {
+        name: "凤凰山",
+        coordinates: JSON.stringify({ lat: 22.5478, lng: 114.0596 }),
+      });
+
+      const kvStore = new Map<string, string>();
+      const freshEntry = {
+        version: 1,
+        locationId: loc.id,
+        computedAt: Date.now() - 60_000, // 1 分钟前
+        data: {
+          mapUrl: "https://uri.amap.com/marker?fresh",
+          subway: { station: "凤凰", lines: ["7号线"], distanceMeters: 400, walkMinutes: 5, approximate: false },
+          driving: { distanceKm: 8, durationMinutes: 15, referencePointLabel: { zh: "深圳市中心", en: "SZ", ja: "深圳" } },
+          amapAllFailed: false,
+        },
+      };
+      kvStore.set(`p0b:transport:v1:${loc.id}`, JSON.stringify(freshEntry));
+
+      const fakeKv = {
+        get: async (k: string) => kvStore.get(k) ?? null,
+        put: async () => {},
+      };
+
+      const res = await req(
+        app,
+        `/locations/${loc.id}/transportation`,
+        {},
+        { AMAP_SERVER_KEY: "test-key", GOMATE_KV: fakeKv },
+      );
+      expect(res.status).toBe(200);
+      const json = await res.json() as {
+        transportation: { subway: { station: string } | null };
+        meta: { cacheHit: boolean; staleDays: number | null };
+      };
+      expect(json.meta.cacheHit).toBe(true);
+      expect(json.meta.staleDays).toBeNull();
+      expect(json.transportation.subway?.station).toBe("凤凰");
+      expect(computeTransportationMock).not.toHaveBeenCalled();
+    });
+
+    it("KV 陈旧（>7d）+ amap 全挂 → 返回旧缓存 + staleDays 提示", async () => {
+      const loc = await seedLocation(testDb, city.id, {
+        name: "南山",
+        coordinates: JSON.stringify({ lat: 22.5478, lng: 114.0596 }),
+      });
+
+      const kvStore = new Map<string, string>();
+      const staleEntry = {
+        version: 1,
+        locationId: loc.id,
+        computedAt: Date.now() - 10 * 24 * 60 * 60 * 1000, // 10 天前
+        data: {
+          mapUrl: "https://uri.amap.com/marker?stale",
+          subway: { station: "南山", lines: ["1号线"], distanceMeters: 500, walkMinutes: 6, approximate: false },
+          driving: null,
+          amapAllFailed: false,
+        },
+      };
+      kvStore.set(`p0b:transport:v1:${loc.id}`, JSON.stringify(staleEntry));
+
+      const fakeKv = {
+        get: async (k: string) => kvStore.get(k) ?? null,
+        put: async () => {},
+      };
+
+      // amap 全挂
+      computeTransportationMock.mockResolvedValueOnce({
+        mapUrl: "https://uri.amap.com/marker?position=114.059600%2C22.547800",
+        subway: null,
+        driving: null,
+        amapAllFailed: true,
+      });
+
+      const res = await req(
+        app,
+        `/locations/${loc.id}/transportation`,
+        {},
+        { AMAP_SERVER_KEY: "test-key", GOMATE_KV: fakeKv },
+      );
+      expect(res.status).toBe(200);
+      const json = await res.json() as {
+        transportation: { subway: { station: string } | null; amapAllFailed: boolean };
+        meta: { cacheHit: boolean; staleDays: number | null };
+      };
+      // 走 stale fallback：拿到的是旧缓存里的数据（subway 有值）
+      expect(json.transportation.subway?.station).toBe("南山");
+      expect(json.meta.cacheHit).toBe(true);
+      expect(json.meta.staleDays).toBeGreaterThanOrEqual(10);
+      expect(computeTransportationMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("KV 陈旧（>24h < 7d）+ amap 成功 → 走回源并覆盖，staleDays=null", async () => {
+      const loc = await seedLocation(testDb, city.id, {
+        name: "笔架山",
+        coordinates: JSON.stringify({ lat: 22.5478, lng: 114.0596 }),
+      });
+
+      const kvStore = new Map<string, string>();
+      const staleEntry = {
+        version: 1,
+        locationId: loc.id,
+        computedAt: Date.now() - 2 * 24 * 60 * 60 * 1000, // 2 天前
+        data: {
+          mapUrl: "https://uri.amap.com/marker?old",
+          subway: { station: "旧站", lines: ["旧"], distanceMeters: 999, walkMinutes: 99, approximate: false },
+          driving: null,
+          amapAllFailed: false,
+        },
+      };
+      kvStore.set(`p0b:transport:v1:${loc.id}`, JSON.stringify(staleEntry));
+
+      const putCalls: Array<{ key: string; value: string }> = [];
+      const fakeKv = {
+        get: async (k: string) => kvStore.get(k) ?? null,
+        put: async (k: string, v: string) => {
+          putCalls.push({ key: k, value: v });
+        },
+      };
+
+      computeTransportationMock.mockResolvedValueOnce({
+        mapUrl: "https://uri.amap.com/marker?new",
+        subway: { station: "笔架", lines: ["9号线"], distanceMeters: 200, walkMinutes: 3, approximate: false },
+        driving: { distanceKm: 5, durationMinutes: 10, referencePointLabel: { zh: "深圳市中心", en: "SZ", ja: "深圳" } },
+        amapAllFailed: false,
+      });
+
+      const res = await req(
+        app,
+        `/locations/${loc.id}/transportation`,
+        {},
+        { AMAP_SERVER_KEY: "test-key", GOMATE_KV: fakeKv },
+      );
+      expect(res.status).toBe(200);
+      const json = await res.json() as {
+        transportation: { subway: { station: string } | null };
+        meta: { cacheHit: boolean; staleDays: number | null };
+      };
+      expect(json.transportation.subway?.station).toBe("笔架"); // 回源结果
+      expect(json.meta.cacheHit).toBe(false);
+      expect(json.meta.staleDays).toBeNull();
+      expect(computeTransportationMock).toHaveBeenCalledTimes(1);
+      // 新数据被写回 KV
+      expect(putCalls.length).toBe(1);
+      expect(putCalls[0].key).toBe(`p0b:transport:v1:${loc.id}`);
     });
   });
 });

--- a/api/src/__tests__/unit/amap-decision.test.ts
+++ b/api/src/__tests__/unit/amap-decision.test.ts
@@ -1,0 +1,386 @@
+/**
+ * P0-B T2 (task #169) — amap-decision 单测
+ *
+ * 覆盖：
+ *  - toAmapCoord: "lng,lat" 顺序（amap 反直觉）
+ *  - buildAmapNavigationUrl: 无 amap 依赖始终返回可点击 URL
+ *  - fetchNearestSubway: happy path / amap 5xx / status != 1 / 无 pois / distance 解析
+ *  - fetchDrivingToCityCenter: happy path / 5xx / 非法 distance
+ *  - computeTransportation: 全成功 / subway 挂 driving 成功（独立降级）/ 双挂（amapAllFailed）/ 无 amapKey
+ *
+ * amap API 通过注入 `fetchImpl` mock 掉，不发真实请求。
+ */
+
+import { describe, it, expect } from "vitest";
+import { computeTransportation, __test, buildAmapNavigationUrl, toAmapCoord } from "../../lib/amap-decision";
+
+const { fetchNearestSubway, fetchDrivingToCityCenter } = __test;
+
+const AMAP_KEY = "test-key";
+const SZ_LAT = 22.5478;
+const SZ_LNG = 114.0596;
+
+/** 快速造 Response 的 helper */
+function jsonResp(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+// ==================== toAmapCoord ====================
+
+describe("amap-decision: toAmapCoord", () => {
+  it('输出 "lng,lat" 顺序（amap 反直觉，别写反）', () => {
+    // 深圳市民中心：lat 22.5478, lng 114.0596
+    expect(toAmapCoord(114.0596, 22.5478)).toBe("114.059600,22.547800");
+  });
+
+  it("6 位小数固定", () => {
+    expect(toAmapCoord(1, 2)).toBe("1.000000,2.000000");
+  });
+});
+
+// ==================== buildAmapNavigationUrl ====================
+
+describe("amap-decision: buildAmapNavigationUrl", () => {
+  it("返回 uri.amap.com marker URL，坐标 encode 后 lng 在前 lat 在后", () => {
+    const url = buildAmapNavigationUrl(22.5478, 114.0596);
+    expect(url).toMatch(/^https:\/\/uri\.amap\.com\/marker\?position=/);
+    // encodeURIComponent("114.059600,22.547800") = "114.059600%2C22.547800"
+    expect(url).toContain("114.059600%2C22.547800");
+  });
+
+  it("零 amap 依赖（无需 fetch）", () => {
+    expect(() => buildAmapNavigationUrl(0, 0)).not.toThrow();
+  });
+});
+
+// ==================== fetchNearestSubway ====================
+
+describe("amap-decision: fetchNearestSubway", () => {
+  it("happy path：返回 station/lines/distance/walkMinutes", async () => {
+    const fetchImpl = async (url: string | URL | Request) => {
+      const u = String(url);
+      if (u.includes("/place/around")) {
+        return jsonResp({
+          status: "1",
+          pois: [
+            {
+              name: "福田口岸站（4号线）",
+              location: "114.060000,22.520000",
+              distance: "500",
+            },
+          ],
+        });
+      }
+      if (u.includes("/direction/walking")) {
+        return jsonResp({
+          status: "1",
+          route: { paths: [{ duration: "480", distance: "500" }] },
+        });
+      }
+      throw new Error("unexpected url " + u);
+    };
+
+    const res = await fetchNearestSubway({
+      lat: SZ_LAT,
+      lng: SZ_LNG,
+      city: "shenzhen",
+      amapKey: AMAP_KEY,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(res).not.toBeNull();
+    expect(res!.station).toBe("福田口岸");
+    expect(res!.lines).toEqual(["4号线"]);
+    expect(res!.distanceMeters).toBe(500);
+    expect(res!.walkMinutes).toBe(8); // 480 / 60
+    expect(res!.approximate).toBe(false);
+  });
+
+  it("walking direction 挂 → fallback 匀速 80m/min，approximate=true", async () => {
+    const fetchImpl = async (url: string | URL | Request) => {
+      const u = String(url);
+      if (u.includes("/place/around")) {
+        return jsonResp({
+          status: "1",
+          pois: [{ name: "test站", location: "1,1", distance: "800" }],
+        });
+      }
+      if (u.includes("/direction/walking")) {
+        return jsonResp({}, 500);
+      }
+      throw new Error("unexpected url");
+    };
+
+    const res = await fetchNearestSubway({
+      lat: SZ_LAT,
+      lng: SZ_LNG,
+      city: "shenzhen",
+      amapKey: AMAP_KEY,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(res).not.toBeNull();
+    expect(res!.walkMinutes).toBe(10); // 800 / 80
+    expect(res!.approximate).toBe(true);
+  });
+
+  it("amap around 5xx → 返回 null（不 throw）", async () => {
+    const fetchImpl = async () => jsonResp({}, 502);
+    const res = await fetchNearestSubway({
+      lat: SZ_LAT,
+      lng: SZ_LNG,
+      city: "shenzhen",
+      amapKey: AMAP_KEY,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(res).toBeNull();
+  });
+
+  it("amap status != 1 → 返回 null", async () => {
+    const fetchImpl = async () => jsonResp({ status: "0", info: "INVALID_USER_KEY" });
+    const res = await fetchNearestSubway({
+      lat: SZ_LAT,
+      lng: SZ_LNG,
+      city: "shenzhen",
+      amapKey: AMAP_KEY,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(res).toBeNull();
+  });
+
+  it("周边无地铁（远郊）→ 返回 null，不 throw", async () => {
+    const fetchImpl = async () => jsonResp({ status: "1", pois: [] });
+    const res = await fetchNearestSubway({
+      lat: SZ_LAT,
+      lng: SZ_LNG,
+      city: "shenzhen",
+      amapKey: AMAP_KEY,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(res).toBeNull();
+  });
+
+  it("distance=0 或 NaN → 返回 null（防脏数据）", async () => {
+    const fetchImpl = async () =>
+      jsonResp({
+        status: "1",
+        pois: [{ name: "test", location: "1,1", distance: "0" }],
+      });
+    const res = await fetchNearestSubway({
+      lat: SZ_LAT,
+      lng: SZ_LNG,
+      city: "shenzhen",
+      amapKey: AMAP_KEY,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(res).toBeNull();
+  });
+
+  it("name 带 (1号线·2号线) → lines 拆多条", async () => {
+    const fetchImpl = async (url: string | URL | Request) => {
+      if (String(url).includes("/place/around")) {
+        return jsonResp({
+          status: "1",
+          pois: [
+            {
+              name: "会展中心站(1号线·4号线)",
+              location: "1,1",
+              distance: "200",
+            },
+          ],
+        });
+      }
+      return jsonResp({ status: "1", route: { paths: [{ duration: "120", distance: "200" }] } });
+    };
+    const res = await fetchNearestSubway({
+      lat: SZ_LAT,
+      lng: SZ_LNG,
+      city: "shenzhen",
+      amapKey: AMAP_KEY,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(res!.station).toBe("会展中心");
+    expect(res!.lines).toEqual(["1号线", "4号线"]);
+  });
+});
+
+// ==================== fetchDrivingToCityCenter ====================
+
+describe("amap-decision: fetchDrivingToCityCenter", () => {
+  it("happy path：distance km 保留 1 位 + duration min", async () => {
+    const fetchImpl = async () =>
+      jsonResp({
+        status: "1",
+        route: { paths: [{ distance: "35450", duration: "3060" }] },
+      });
+    const res = await fetchDrivingToCityCenter({
+      lat: 22.7,
+      lng: 114.5,
+      city: "shenzhen",
+      amapKey: AMAP_KEY,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(res).not.toBeNull();
+    expect(res!.distanceKm).toBe(35.5); // 35450m → 35.45 → round to 35.5
+    expect(res!.durationMinutes).toBe(51); // 3060 / 60
+    expect(res!.referencePointLabel.zh).toBe("深圳市中心");
+    expect(res!.referencePointLabel.en).toBe("Shenzhen City Center");
+  });
+
+  it("amap 5xx → null", async () => {
+    const fetchImpl = async () => jsonResp({}, 503);
+    const res = await fetchDrivingToCityCenter({
+      lat: 22.7,
+      lng: 114.5,
+      city: "shenzhen",
+      amapKey: AMAP_KEY,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(res).toBeNull();
+  });
+
+  it("路径为空数组 → null", async () => {
+    const fetchImpl = async () => jsonResp({ status: "1", route: { paths: [] } });
+    const res = await fetchDrivingToCityCenter({
+      lat: 22.7,
+      lng: 114.5,
+      city: "shenzhen",
+      amapKey: AMAP_KEY,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(res).toBeNull();
+  });
+
+  it("distance=0 → null（防脏数据）", async () => {
+    const fetchImpl = async () =>
+      jsonResp({ status: "1", route: { paths: [{ distance: "0", duration: "60" }] } });
+    const res = await fetchDrivingToCityCenter({
+      lat: 22.7,
+      lng: 114.5,
+      city: "shenzhen",
+      amapKey: AMAP_KEY,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(res).toBeNull();
+  });
+
+  it("未知 city → fallback 深圳中心 label", async () => {
+    const fetchImpl = async () =>
+      jsonResp({ status: "1", route: { paths: [{ distance: "1000", duration: "60" }] } });
+    const res = await fetchDrivingToCityCenter({
+      lat: 22.7,
+      lng: 114.5,
+      city: "gzhou-unknown",
+      amapKey: AMAP_KEY,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(res!.referencePointLabel.zh).toBe("深圳市中心");
+  });
+});
+
+// ==================== computeTransportation ====================
+
+describe("amap-decision: computeTransportation", () => {
+  it("全成功 → mapUrl + subway + driving，amapAllFailed=false", async () => {
+    const fetchImpl = async (url: string | URL | Request) => {
+      const u = String(url);
+      if (u.includes("/place/around")) {
+        return jsonResp({
+          status: "1",
+          pois: [{ name: "梅林关站(4号线)", location: "1,1", distance: "300" }],
+        });
+      }
+      if (u.includes("/direction/walking")) {
+        return jsonResp({ status: "1", route: { paths: [{ duration: "180", distance: "300" }] } });
+      }
+      if (u.includes("/direction/driving")) {
+        return jsonResp({ status: "1", route: { paths: [{ distance: "12000", duration: "1200" }] } });
+      }
+      throw new Error("unexpected url " + u);
+    };
+
+    const res = await computeTransportation({
+      lat: SZ_LAT,
+      lng: SZ_LNG,
+      city: "shenzhen",
+      amapKey: AMAP_KEY,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(res.mapUrl).toContain("uri.amap.com");
+    expect(res.subway).not.toBeNull();
+    expect(res.subway!.station).toBe("梅林关");
+    expect(res.driving).not.toBeNull();
+    expect(res.driving!.distanceKm).toBe(12);
+    expect(res.amapAllFailed).toBe(false);
+  });
+
+  it("subway 挂 + driving 成功 → 独立降级（subway=null，driving 有值）", async () => {
+    const fetchImpl = async (url: string | URL | Request) => {
+      const u = String(url);
+      if (u.includes("/place/around")) {
+        return jsonResp({}, 502); // subway 挂
+      }
+      if (u.includes("/direction/driving")) {
+        return jsonResp({ status: "1", route: { paths: [{ distance: "1000", duration: "60" }] } });
+      }
+      return jsonResp({}, 500);
+    };
+    const res = await computeTransportation({
+      lat: SZ_LAT,
+      lng: SZ_LNG,
+      city: "shenzhen",
+      amapKey: AMAP_KEY,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(res.subway).toBeNull();
+    expect(res.driving).not.toBeNull();
+    expect(res.amapAllFailed).toBe(false); // 只要有一个成功就不算全挂
+  });
+
+  it("subway + driving 双挂 → amapAllFailed=true，仅 mapUrl 可用", async () => {
+    const fetchImpl = async () => jsonResp({}, 503);
+    const res = await computeTransportation({
+      lat: SZ_LAT,
+      lng: SZ_LNG,
+      city: "shenzhen",
+      amapKey: AMAP_KEY,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(res.subway).toBeNull();
+    expect(res.driving).toBeNull();
+    expect(res.amapAllFailed).toBe(true);
+    expect(res.mapUrl).toContain("uri.amap.com");
+  });
+
+  it("amapKey 空 → 直接 amapAllFailed（不发请求）", async () => {
+    let fetchCalled = 0;
+    const fetchImpl = async () => {
+      fetchCalled++;
+      return jsonResp({});
+    };
+    const res = await computeTransportation({
+      lat: SZ_LAT,
+      lng: SZ_LNG,
+      city: "shenzhen",
+      amapKey: "",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(fetchCalled).toBe(0);
+    expect(res.amapAllFailed).toBe(true);
+    expect(res.mapUrl).toContain("uri.amap.com");
+  });
+
+  it("fetch 抛异常（network error）→ 该字段 null，不 raise", async () => {
+    const fetchImpl = async () => {
+      throw new Error("ECONNRESET");
+    };
+    const res = await computeTransportation({
+      lat: SZ_LAT,
+      lng: SZ_LNG,
+      city: "shenzhen",
+      amapKey: AMAP_KEY,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(res.subway).toBeNull();
+    expect(res.driving).toBeNull();
+    expect(res.amapAllFailed).toBe(true);
+  });
+});

--- a/api/src/lib/amap-decision.ts
+++ b/api/src/lib/amap-decision.ts
@@ -1,0 +1,315 @@
+/**
+ * P0-B T2「怎么到」amap 决策数据聚合（task #169）
+ *
+ * spec: notes/gomate-p0b-location-decision-spec.md v1.1 §3.3 + §3.5 + §3.6
+ *
+ * 提供三份决策信号：
+ *  1. 最近地铁站（周边 POI 搜索 subway_station → 直线距离最近）+ 步行 ETA
+ *  2. 自驾距城市中心：距离 + 高峰/非高峰时段 duration（默认非高峰）
+ *  3. 地图 URL：始终可用（坐标 → uri.amap.com/navigation），amap API 全挂时唯一 fallback
+ *
+ * ## 降级策略（spec §3.6 三段式，Martin CR 具体化）
+ *
+ *  - 单个 amap 端点 5xx / timeout / non-1 status → **该字段 null**，不 raise
+ *  - 全部端点挂 → 视觉降级到「📍 在地图打开」单链接（前端读 subway=null && drive=null 时切换）
+ *  - 调用方（route 层）负责 KV cache 24h + stale >7d 标注
+ *
+ * ## 契约
+ *
+ *  - 函数**不抛异常**（除非 lat/lng 数值非法，视为程序 bug 让 500）
+ *  - 每个字段独立降级：subway 挂了 drive 还能返，反之亦然
+ *  - `amapAllFailed` 派生 flag 给前端一次判断
+ */
+
+import { logger } from "./logger";
+import { getCityCenter } from "@gomate/lib";
+import { fetchWithTimeout } from "./timeout";
+
+/** amap 请求超时（ms）。3s 拉到，避免拖慢详情页 SSR */
+const AMAP_TIMEOUT_MS = 3000;
+
+/** 高德坐标格式："lng,lat"（注意顺序） */
+export function toAmapCoord(lng: number, lat: number): string {
+  return `${lng.toFixed(6)},${lat.toFixed(6)}`;
+}
+
+// ==================== 类型 ====================
+
+export interface SubwayInfo {
+  /** 站名（不带"地铁站"后缀） */
+  station: string;
+  /** 线路名，可能为空数组 */
+  lines: string[];
+  /** 直线距离 (m)，approximate */
+  distanceMeters: number;
+  /** 步行 ETA (min)，基于 amap walking direction；若走 fallback（80m/min 匀速）则 approximate=true */
+  walkMinutes: number;
+  /** 是否 amap direction 失败走了直线距离 fallback（>800m 时前端加"建议骑车/打车接驳"提示） */
+  approximate: boolean;
+}
+
+export interface DrivingInfo {
+  /** 到城市中心的路径距离 (km)，保留 1 位小数 */
+  distanceKm: number;
+  /** 非高峰驾车 ETA (min) */
+  durationMinutes: number;
+  /** 参考城市中心的展示 label（"深圳市中心"） */
+  referencePointLabel: {
+    zh: string;
+    en: string;
+    ja: string;
+  };
+}
+
+export interface TransportationResult {
+  /** amap navigation URL；始终可用（无 amap 依赖） */
+  mapUrl: string;
+  /** 最近地铁；amap 挂 / 该区域无地铁 → null */
+  subway: SubwayInfo | null;
+  /** 自驾到城市中心；amap 挂 → null */
+  driving: DrivingInfo | null;
+  /** true 表示 subway + driving 都 null（前端切换为「单一 mapUrl 链接」视觉） */
+  amapAllFailed: boolean;
+}
+
+export interface ComputeTransportationInput {
+  lat: number;
+  lng: number;
+  /** 归一化后的 city key（走 `normalizeCity`），用于查 `getCityCenter` */
+  city: string;
+  amapKey: string;
+  /**
+   * 允许注入 fetch（测试用）。默认 `globalThis.fetch`。
+   * 签名与 `fetchWithTimeout` 一致，因为内部走 timeout 包装。
+   */
+  fetchImpl?: typeof fetch;
+}
+
+// ==================== amap 端点封装（内部） ====================
+
+/**
+ * 通用 amap 端点调用：
+ *  - timeout 3s
+ *  - 非 2xx / status != "1" / JSON 解析失败 → 记 warn 并返 null
+ *
+ * spec §3.6 blocker：任何一个端点挂不影响其他端点，此函数吞下所有错误。
+ */
+async function safeAmapGet<T = unknown>(
+  url: string,
+  fetchImpl: typeof fetch | undefined,
+  contextLabel: string,
+): Promise<T | null> {
+  try {
+    const resp = fetchImpl
+      ? await withTimeout(fetchImpl(url), AMAP_TIMEOUT_MS)
+      : await fetchWithTimeout(url, {}, AMAP_TIMEOUT_MS);
+    if (!resp.ok) {
+      logger.warn(`[amap-decision] ${contextLabel} HTTP ${resp.status}`);
+      return null;
+    }
+    const data = (await resp.json()) as { status?: string } & Record<string, unknown>;
+    if (data.status !== "1") {
+      logger.warn(`[amap-decision] ${contextLabel} status=${data.status}`);
+      return null;
+    }
+    return data as T;
+  } catch (err) {
+    logger.warn(`[amap-decision] ${contextLabel} threw:`, err);
+    return null;
+  }
+}
+
+/**
+ * 让注入的 fetch 也走同一 timeout 语义（不能直接调 fetchWithTimeout，因为它内部用 globalThis.fetch）。
+ */
+async function withTimeout(promise: Promise<Response>, ms: number): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ms);
+  try {
+    return await promise;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ==================== 地铁 ====================
+
+interface AmapAroundPoi {
+  name?: string;
+  location?: string; // "lng,lat"
+  distance?: string | number;
+  type?: string;
+  address?: string;
+  business_area?: string;
+}
+
+interface AmapAroundResponse {
+  status: string;
+  pois?: AmapAroundPoi[];
+}
+
+interface AmapDirectionWalkResponse {
+  status: string;
+  route?: {
+    paths?: Array<{ duration?: string | number; distance?: string | number }>;
+  };
+}
+
+/**
+ * 找周边最近地铁站。
+ * amap `place/around` types=150500（地铁站），radius=3000m，sortrule=distance。
+ *
+ * 返回 null 当：amap 挂 / 该区域 3km 内无地铁（远郊场景常见，例：梧桐山山下）。
+ */
+async function fetchNearestSubway(
+  input: ComputeTransportationInput,
+): Promise<SubwayInfo | null> {
+  const { lat, lng, amapKey, fetchImpl } = input;
+  const location = toAmapCoord(lng, lat);
+  const url = `https://restapi.amap.com/v3/place/around?key=${amapKey}&location=${encodeURIComponent(
+    location,
+  )}&types=150500&radius=3000&sortrule=distance&offset=1&extensions=base`;
+
+  const data = await safeAmapGet<AmapAroundResponse>(url, fetchImpl, "subway-around");
+  if (!data) return null;
+  const poi = data.pois?.[0];
+  if (!poi?.name || !poi.location || poi.distance == null) return null;
+
+  const distanceMeters = typeof poi.distance === "string" ? parseInt(poi.distance, 10) : poi.distance;
+  if (!Number.isFinite(distanceMeters) || distanceMeters <= 0) return null;
+
+  const station = poi.name.replace(/[（(].*?[)）]/g, "").replace(/(地铁站|站)$/g, "").trim() || poi.name;
+  // amap business_area 里偶尔带线路名（"1号线 · 4号线"）；type "150500" 单独打个 subway 分类，线路信息在 name 括号中。
+  const lineMatch = poi.name.match(/[（(]([^)）]+)[)）]/);
+  const lines = lineMatch?.[1]
+    ? lineMatch[1]
+        .split(/[·、,，/]/)
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [];
+
+  // 步行 ETA：优先 amap walking direction；失败则 fallback 匀速 80m/min
+  const walkUrl = `https://restapi.amap.com/v3/direction/walking?key=${amapKey}&origin=${encodeURIComponent(
+    location,
+  )}&destination=${encodeURIComponent(poi.location)}`;
+  const walkResp = await safeAmapGet<AmapDirectionWalkResponse>(walkUrl, fetchImpl, "subway-walk");
+  const walkPath = walkResp?.route?.paths?.[0];
+  let walkMinutes: number;
+  let approximate = false;
+  if (walkPath?.duration != null) {
+    const durSec = typeof walkPath.duration === "string" ? parseInt(walkPath.duration, 10) : walkPath.duration;
+    walkMinutes = Number.isFinite(durSec) && durSec > 0 ? Math.max(1, Math.round(durSec / 60)) : 0;
+    if (walkMinutes === 0) approximate = true;
+  } else {
+    walkMinutes = Math.max(1, Math.round(distanceMeters / 80));
+    approximate = true;
+  }
+
+  return {
+    station,
+    lines,
+    distanceMeters,
+    walkMinutes,
+    approximate,
+  };
+}
+
+// ==================== 自驾 ====================
+
+interface AmapDirectionDriveResponse {
+  status: string;
+  route?: {
+    paths?: Array<{ duration?: string | number; distance?: string | number }>;
+  };
+}
+
+async function fetchDrivingToCityCenter(
+  input: ComputeTransportationInput,
+): Promise<DrivingInfo | null> {
+  const { lat, lng, city, amapKey, fetchImpl } = input;
+  const center = getCityCenter(city);
+  const origin = toAmapCoord(lng, lat);
+  const destination = toAmapCoord(center.lng, center.lat);
+
+  // strategy=0：速度最快（不考虑高峰堵车），spec §3.5 默认非高峰时段
+  const url = `https://restapi.amap.com/v3/direction/driving?key=${amapKey}&origin=${encodeURIComponent(
+    origin,
+  )}&destination=${encodeURIComponent(destination)}&strategy=0&extensions=base`;
+  const data = await safeAmapGet<AmapDirectionDriveResponse>(url, fetchImpl, "drive-to-center");
+  if (!data) return null;
+
+  const path = data.route?.paths?.[0];
+  if (!path?.distance || !path.duration) return null;
+
+  const distMeters = typeof path.distance === "string" ? parseInt(path.distance, 10) : path.distance;
+  const durSec = typeof path.duration === "string" ? parseInt(path.duration, 10) : path.duration;
+  if (!Number.isFinite(distMeters) || distMeters <= 0) return null;
+  if (!Number.isFinite(durSec) || durSec <= 0) return null;
+
+  return {
+    distanceKm: Math.round((distMeters / 1000) * 10) / 10,
+    durationMinutes: Math.max(1, Math.round(durSec / 60)),
+    referencePointLabel: {
+      zh: center.labelZh,
+      en: center.labelEn,
+      ja: center.labelJa,
+    },
+  };
+}
+
+// ==================== mapUrl fallback ====================
+
+/**
+ * 生成 amap navigation URL（无 API 依赖，坐标 → deep link）。
+ * spec §3.6 blocker-2：即便 amap API 全挂，这个链接仍然可用。
+ */
+export function buildAmapNavigationUrl(lat: number, lng: number): string {
+  // uri.amap.com/navigation dev doc：pos 参数是"名称,lng,lat"
+  const dst = `${lng.toFixed(6)},${lat.toFixed(6)}`;
+  return `https://uri.amap.com/marker?position=${encodeURIComponent(dst)}&callnative=1`;
+}
+
+// ==================== 入口 ====================
+
+/**
+ * 计算「怎么到」所需的三份决策数据。
+ * 三个 amap 端点并行调用，单个失败不阻塞其他。
+ *
+ * 调用方（route 层）负责：
+ *  - 输入 lat/lng 校验（本函数假定合法）
+ *  - KV cache 读写 + stale 标注
+ *  - 拼装最终 response（含 meta.staleDays / cache 头）
+ */
+export async function computeTransportation(
+  input: ComputeTransportationInput,
+): Promise<TransportationResult> {
+  const mapUrl = buildAmapNavigationUrl(input.lat, input.lng);
+
+  if (!input.amapKey) {
+    // 极端情况：env 没配 key，直接返 mapUrl-only
+    return { mapUrl, subway: null, driving: null, amapAllFailed: true };
+  }
+
+  const [subway, driving] = await Promise.all([
+    fetchNearestSubway(input),
+    fetchDrivingToCityCenter(input),
+  ]);
+
+  return {
+    mapUrl,
+    subway,
+    driving,
+    amapAllFailed: subway === null && driving === null,
+  };
+}
+
+// ==================== 测试导出 ====================
+
+/** 单测专用（vitest）— 不出现在正常 import 路径 */
+export const __test = {
+  toAmapCoord,
+  buildAmapNavigationUrl,
+  fetchNearestSubway,
+  fetchDrivingToCityCenter,
+  safeAmapGet,
+};

--- a/api/src/routes/locations/index.ts
+++ b/api/src/routes/locations/index.ts
@@ -3,6 +3,7 @@ import type { Env } from "../../lib/auth";
 
 import queries from "./queries";
 import mutations from "./mutations";
+import { locationsTransportationRoute } from "./transportation";
 
 const locations = new Hono<{ Bindings: Env }>();
 
@@ -18,6 +19,10 @@ locations.route("/", queries);
 // DELETE /locations/:id
 // PUT /locations/:id/tags
 locations.route("/", mutations);
+
+// P0-B T2 (task #169): GET /locations/:id/transportation
+// amap 决策数据聚合（地铁/自驾/mapUrl）+ KV cache 24h + 7d stale
+locations.route("/", locationsTransportationRoute);
 
 export default locations;
 export { locations as locationsRoute };

--- a/api/src/routes/locations/queries.ts
+++ b/api/src/routes/locations/queries.ts
@@ -11,6 +11,19 @@ import { safeJsonParse } from "./utils";
 const queries = new Hono<{ Bindings: Env }>();
 
 /**
+ * P0-B T2 (task #169): 将逗号/中文顿号分隔的自由文本切成 chip 数组。
+ * 空字符串 / null / undefined → 空数组（前端按"未填"处理）。
+ */
+function parseCsvField(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(/[,、]/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+
+/**
  * GET /locations
  * 获取地点列表，支持分页、搜索、城市筛选、标签筛选
  * ?tags=true 返回热门标签
@@ -276,6 +289,10 @@ queries.get("/:id", async (c) => {
         bestSeason: safeJsonParse(location.bestSeason, [] as string[]),
         coordinates: safeJsonParse(location.coordinates, { lat: 0, lng: 0 }),
         extra: safeJsonParse(location.extra, undefined),
+        // P0-B T2（task #169）：spec §5 gear_essential/gear_optional 存 comma-separated 文本，
+        // 前端渲染时按 chip 列表展示 → API 层直接切好数组，避免前端各处零散 split。
+        gearEssential: parseCsvField(location.gearEssential),
+        gearOptional: parseCsvField(location.gearOptional),
         tags,
       },
     });

--- a/api/src/routes/locations/transportation.ts
+++ b/api/src/routes/locations/transportation.ts
@@ -1,0 +1,242 @@
+/**
+ * P0-B T2 GET /locations/:id/transportation (task #169)
+ *
+ * spec: notes/gomate-p0b-location-decision-spec.md v1.1 §3 + §11
+ *
+ * 计算并返回 location「怎么到」决策数据（最近地铁 + 自驾城市中心 + mapUrl）。
+ *
+ * ## Response 契约（200）
+ * ```
+ * {
+ *   success: true,
+ *   locationId: string,
+ *   transportation: {
+ *     mapUrl: string,               // 始终可用（无 amap 依赖）
+ *     subway: {
+ *       station: string,
+ *       lines: string[],
+ *       distanceMeters: number,
+ *       walkMinutes: number,
+ *       approximate: boolean,       // true → 前端加"骑车/打车接驳"提示
+ *     } | null,
+ *     driving: {
+ *       distanceKm: number,          // 1 位小数
+ *       durationMinutes: number,
+ *       referencePointLabel: { zh, en, ja },
+ *     } | null,
+ *     amapAllFailed: boolean,       // true → 前端切换为单一 mapUrl 链接视觉
+ *   },
+ *   meta: {
+ *     cacheHit: boolean,
+ *     staleDays: number | null,    // 缓存数据距计算时的天数，>7 时前端标注"信息更新于 X 天前"
+ *   }
+ * }
+ * ```
+ *
+ * ## 缓存策略（spec §3.6）
+ *
+ *  - KV key: `p0b:transport:v1:{locationId}`（location 位置固定，不需 seed/ua）
+ *  - TTL: 24h（spec §3.6 revalidate 86400）
+ *  - Stale window: 7d（超过 7d 从 KV 拿到时给 `meta.staleDays`，前端展示"信息更新于 X 天前"）
+ *  - **注意**：Cloudflare KV 的 TTL 到期后 key 自动消失，所以 stale 场景实际上需要用**长期 TTL + 记录 computedAt**
+ *    ×  ✔  我们采用「TTL=30d + 记录 computedAt」而不是「TTL=24h 硬淘汰」，让 stale window 可用
+ *    ×  ✔  spec §3.6 revalidate 24h 语义由 route 层判断：computedAt < 24h → 直接返；≥24h → 回源
+ *    ×  ✔  computedAt ≥7d → 回源同时 fallback stale response（保证 amap 挂时详情页不空白）
+ */
+
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+import { createDb } from "../../db";
+import * as schema from "../../db/schema";
+import type { Env } from "../../lib/auth";
+import { APIErrors } from "../../lib/api-errors";
+import { logger } from "../../lib/logger";
+import { safeJsonParse } from "./utils";
+import { computeTransportation, buildAmapNavigationUrl } from "../../lib/amap-decision";
+import type { TransportationResult } from "../../lib/amap-decision";
+import { getCurrentCity } from "@gomate/lib";
+
+const route = new Hono<{ Bindings: Env }>();
+
+// ==================== 缓存策略常量 ====================
+
+/** KV TTL：30 天（久于业务上限，保证 stale fallback 可用） */
+const KV_TTL_SECONDS = 30 * 24 * 60 * 60;
+/** 新鲜度窗口：24h（spec §3.6，命中直接返缓存） */
+const FRESH_WINDOW_MS = 24 * 60 * 60 * 1000;
+/** Stale 阈值：7 天，超过则给前端 meta.staleDays 提示 */
+const STALE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
+/** KV key 前缀，接 spec v2 时改 v2 */
+const KV_KEY_PREFIX = "p0b:transport:v1:";
+
+interface CachedEntry {
+  version: 1;
+  locationId: string;
+  computedAt: number;
+  data: TransportationResult;
+}
+
+// ==================== 端点 ====================
+
+route.get("/:id/transportation", async (c) => {
+  const locationId = c.req.param("id");
+  const db = createDb(c.env.DB);
+  const now = Date.now();
+
+  try {
+    // 1) 查 location（同时支持 id/slug）— 只取需要的列
+    const rows = await db
+      .select({
+        id: schema.locations.id,
+        slug: schema.locations.slug,
+        coordinates: schema.locations.coordinates,
+        cityId: schema.locations.cityId,
+      })
+      .from(schema.locations)
+      .where(eq(schema.locations.id, locationId))
+      .limit(1);
+
+    let location = rows[0];
+    if (!location) {
+      const slugRows = await db
+        .select({
+          id: schema.locations.id,
+          slug: schema.locations.slug,
+          coordinates: schema.locations.coordinates,
+          cityId: schema.locations.cityId,
+        })
+        .from(schema.locations)
+        .where(eq(schema.locations.slug, locationId))
+        .limit(1);
+      location = slugRows[0];
+    }
+    if (!location) return c.json(APIErrors.notFound("地点不存在"), 404);
+
+    const coords = safeJsonParse(location.coordinates, { lat: 0, lng: 0 });
+    if (
+      !coords ||
+      typeof coords.lat !== "number" ||
+      typeof coords.lng !== "number" ||
+      !Number.isFinite(coords.lat) ||
+      !Number.isFinite(coords.lng) ||
+      (coords.lat === 0 && coords.lng === 0)
+    ) {
+      // 无坐标数据 → 前端只能什么都不显示；返 mapUrl-only 让前端 "block 整体不渲染"
+      return c.json({
+        success: true,
+        locationId: location.id,
+        transportation: {
+          mapUrl: "",
+          subway: null,
+          driving: null,
+          amapAllFailed: true,
+        },
+        meta: { cacheHit: false, staleDays: null },
+      });
+    }
+
+    // 2) 计算城市 key（用于 getCityCenter 里的中心点）
+    //    优先 location.cityId → city name → 归一；未登录用户默认 shenzhen fallback
+    const cityRow = location.cityId
+      ? await db
+          .select({ name: schema.cities.name })
+          .from(schema.cities)
+          .where(eq(schema.cities.id, location.cityId))
+          .limit(1)
+      : [];
+    const cityNameFromLoc = cityRow[0]?.name ?? null;
+    // getCurrentCity 会走 session/CF-IPCity/fallback 三级；这里 location 自身城市优先
+    const { city } = getCurrentCity(c.req.raw, cityNameFromLoc);
+
+    // 3) 尝试从 KV 读缓存
+    const kv = c.env.GOMATE_KV;
+    const cacheKey = `${KV_KEY_PREFIX}${location.id}`;
+    let cached: CachedEntry | null = null;
+    if (kv) {
+      try {
+        const raw = await kv.get(cacheKey);
+        if (raw) {
+          const parsed = JSON.parse(raw) as CachedEntry;
+          if (parsed?.version === 1 && parsed.locationId === location.id) {
+            cached = parsed;
+          }
+        }
+      } catch (err) {
+        logger.warn("[transportation] KV read failed:", err);
+      }
+    }
+
+    // 4) 新鲜命中直接返
+    if (cached && now - cached.computedAt < FRESH_WINDOW_MS) {
+      const ageMs = now - cached.computedAt;
+      return c.json({
+        success: true,
+        locationId: location.id,
+        transportation: cached.data,
+        meta: {
+          cacheHit: true,
+          staleDays: ageMs >= STALE_THRESHOLD_MS ? Math.floor(ageMs / (24 * 60 * 60 * 1000)) : null,
+        },
+      });
+    }
+
+    // 5) 回源 amap
+    const amapKey = c.env.AMAP_SERVER_KEY;
+    let data: TransportationResult;
+    if (amapKey) {
+      data = await computeTransportation({
+        lat: coords.lat,
+        lng: coords.lng,
+        city,
+        amapKey,
+      });
+    } else {
+      // env 没配 key → 仅 mapUrl
+      data = {
+        mapUrl: buildAmapNavigationUrl(coords.lat, coords.lng),
+        subway: null,
+        driving: null,
+        amapAllFailed: true,
+      };
+    }
+
+    // 6) amap 全挂 && 有旧缓存 → 用旧缓存 stale response（保证详情页不空白）
+    if (data.amapAllFailed && cached) {
+      const ageMs = now - cached.computedAt;
+      return c.json({
+        success: true,
+        locationId: location.id,
+        transportation: cached.data,
+        meta: {
+          cacheHit: true,
+          staleDays: Math.max(1, Math.floor(ageMs / (24 * 60 * 60 * 1000))),
+        },
+      });
+    }
+
+    // 7) 写 KV（fire-and-forget，失败不影响响应）
+    if (kv) {
+      const entry: CachedEntry = {
+        version: 1,
+        locationId: location.id,
+        computedAt: now,
+        data,
+      };
+      void kv
+        .put(cacheKey, JSON.stringify(entry), { expirationTtl: KV_TTL_SECONDS })
+        .catch((err) => logger.warn("[transportation] KV write failed:", err));
+    }
+
+    return c.json({
+      success: true,
+      locationId: location.id,
+      transportation: data,
+      meta: { cacheHit: false, staleDays: null },
+    });
+  } catch (err) {
+    logger.error("[transportation] failed", err);
+    return c.json(APIErrors.internalError("获取交通信息失败"), 500);
+  }
+});
+
+export { route as locationsTransportationRoute };

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./season": "./src/season.ts",
-    "./geo-fallback": "./src/geo-fallback.ts"
+    "./geo-fallback": "./src/geo-fallback.ts",
+    "./geo-city-center": "./src/geo-city-center.ts"
   },
   "scripts": {
     "type-check": "tsc --noEmit"

--- a/packages/lib/src/geo-city-center.ts
+++ b/packages/lib/src/geo-city-center.ts
@@ -1,0 +1,52 @@
+/**
+ * 城市中心坐标（P0-B §3.5「自驾距离」参考点）
+ *
+ * 用途：locations 只存自己的 lat/lng，spec §3.3 视觉「距深圳市中心约 X km」需要一个基准点。
+ * 存储层不加城市中心字段（会随城市扩张失控）；从代码里的静态 map 取。
+ *
+ * 决策（Martin CR 提前口径）：
+ *  - MVP 只覆盖 shenzhen（gomate 主战场），未知城市 fallback 深圳中心
+ *  - 城市 key 归一走 `normalizeCity`（同 geo-fallback.ts）
+ *  - 城市中心用官方地标：福田区市民中心
+ *
+ * 未来扩展：广州、上海、北京等接入时在这里加一行；P1 可迁到 D1 表。
+ */
+
+export interface CityCenter {
+  /** 归一化 city key（与 geo-fallback.ts 保持一致：小写 + 只保留字母数字） */
+  key: string;
+  /** 中文展示名 */
+  labelZh: string;
+  /** 英文展示名 */
+  labelEn: string;
+  /** 日文展示名 */
+  labelJa: string;
+  lat: number;
+  lng: number;
+}
+
+/**
+ * 城市中心坐标表。新增城市在这里追加。
+ * key 必须走 `normalizeCity`（小写 + 只保留字母数字）保持稳定。
+ */
+const CITY_CENTERS: Record<string, CityCenter> = {
+  shenzhen: {
+    key: "shenzhen",
+    labelZh: "深圳市中心",
+    labelEn: "Shenzhen City Center",
+    labelJa: "深圳市中心",
+    lat: 22.5478,
+    lng: 114.0596, // 福田区市民中心
+  },
+};
+
+const FALLBACK_CENTER = CITY_CENTERS.shenzhen!;
+
+/**
+ * 取城市中心。未知 city → fallback shenzhen（gomate 主战场）。
+ * 保证返回值非 null，调用方可无脑用。
+ */
+export function getCityCenter(city: string | null | undefined): CityCenter {
+  if (!city) return FALLBACK_CENTER;
+  return CITY_CENTERS[city] ?? FALLBACK_CENTER;
+}

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -7,3 +7,4 @@
 
 export * from "./season";
 export * from "./geo-fallback";
+export * from "./geo-city-center";


### PR DESCRIPTION
## 目标
落地 P0-B spec §3 + §4.5 + §7 详情页「怎么到」+「装备」区块的 API 层数据。

spec: `notes/gomate-p0b-location-decision-spec.md` v1.1

## 新增

### 1) `GET /locations/:id/transportation`
- 位置：`api/src/routes/locations/transportation.ts`
- 支持 id / slug
- 返回结构：
  ```
  {
    success: true,
    locationId: string,
    transportation: {
      mapUrl: string,               // 始终可用（uri.amap.com/marker，无 amap 依赖）
      subway: { station, lines, distanceMeters, walkMinutes, approximate } | null,
      driving: { distanceKm, durationMinutes, referencePointLabel: {zh,en,ja} } | null,
      amapAllFailed: boolean,       // true → 前端切换单一 mapUrl 视觉
    },
    meta: {
      cacheHit: boolean,
      staleDays: number | null,     // >=7d 时前端标注"信息更新于 X 天前"
    }
  }
  ```
- 无效坐标 `{lat:0,lng:0}` → `amapAllFailed=true` 且不调 amap
- 无 `AMAP_SERVER_KEY` → 只返 mapUrl

### 2) amap 决策库：`api/src/lib/amap-decision.ts`
- `computeTransportation({lat, lng, city, amapKey, fetchImpl?})`
- **独立降级**：subway / driving 任一挂 → 该字段 null，另一字段照常
- **`amapAllFailed=true`** 只当两项都挂
- 各端点单独 3s timeout；5xx / status!=1 / JSON 挂 → 该字段 null（不抛）
- walking direction 挂 → fallback 匀速 80m/min（`approximate=true` → 前端提示"骑车/打车接驳"）
- `fetchImpl` 注入用于单测 mock

### 3) KV 缓存策略（spec §3.6）
- key: `p0b:transport:v1:{locationId}`
- TTL: **30d**（久于业务上限，保证 stale fallback 可用；而不是 24h 硬淘汰）
- Fresh window: **24h**（`computedAt` < 24h → 直接返 cache，`meta.cacheHit=true, staleDays=null`）
- Stale marker: **>=7d** 时 `meta.staleDays = ceil(ageDays)` 给前端提示
- **Stale fallback**：amap 全挂 + 有旧 cache → 用旧 cache 保证详情页不空白

### 4) 匿名 city fallback（复用 P0-D 共享）
- 从 `@gomate/lib` 拿 `getCurrentCity(request, sessionCity?)`
- session `users.city` → `CF-IPCity` header → fallback `"shenzhen"`
- 该函数由 spec PR #393 敲定，本 PR 只引用

### 5) `getCityCenter(city)` util（`packages/lib/src/geo-city-center.ts`）
- 返回城市中心坐标 + 三语 label（zh/en/ja）
- 深圳（福田市民中心 22.5478, 114.0596）为唯一实体，其他城市 fallback 深圳
- 供 amap `/direction/driving` 端起点使用

### 6) gear_essential / gear_optional CSV 拆分（`GET /locations/:id`）
- `parseCsvField()` helper：spec §5 存 comma-separated 文本，API 直接切数组返
- 空字符串 / null → 空数组（前端按"未填"处理）
- 支持 `,` 和 `、` 分隔

## Verify

### 本地全绿
- ✅ `npx vitest run` (api): **299/299 PASS**（含新增 21 unit + 8 integration）
- ✅ `npx tsc --noEmit` (api): 0 error
- ✅ `npx tsc --noEmit` (packages/lib): 0 error

### 单测覆盖（21 new / `amap-decision.test.ts`）
- `toAmapCoord`: `"lng,lat"` 顺序（amap 反直觉）
- `buildAmapNavigationUrl`: encode 后 lng 在前 lat 在后，无 fetch 依赖
- `fetchNearestSubway`: happy / walking 挂 fallback 80m/min / around 5xx / status!=1 / 无 pois / distance=0 脏数据 / 多线路拆分
- `fetchDrivingToCityCenter`: happy / 5xx / 空 paths / distance=0 / 未知 city fallback 深圳
- `computeTransportation`: 全成功 / subway 挂 driving 独立成功 / 双挂 amapAllFailed / amapKey 空 / fetch throw

### 集成测试覆盖（8 new / `locations.test.ts` describe "GET /locations/:id/transportation"）
- 404 for unknown id
- 无效坐标 `{lat:0,lng:0}` → `amapAllFailed=true` 且不调 amap
- 有坐标 + 无 AMAP_SERVER_KEY → 只返 mapUrl
- 支持 slug 访问
- 有 amapKey + 无 KV → `computeTransportation` happy path
- KV 新鲜命中（<24h）→ `cacheHit=true` 且不调 amap
- KV 陈旧（>7d）+ amap 全挂 → 旧 cache + `staleDays`
- KV 陈旧（>24h < 7d）+ amap 成功 → 回源 + 覆盖 + `staleDays=null`

## Risk / Rollback

- **新增端点**，与既有 `GET /locations/:id` 平级，无 breaking
- **gear CSV 拆分** 变更响应形状：`gearEssential`/`gearOptional` 由 `string | null` → `string[]`。P0-B 详情页尚未上线，无消费方
- 无 schema / migration / secret 涉及
- KV binding `GOMATE_KV` 已存在（P0-C 用），无新增
- env `AMAP_SERVER_KEY` 已在 wrangler 声明（可选），未配也不 crash（走 mapUrl-only）
- **回滚**：`git revert <sha>` 即可，无副作用

## P1 observation follow-up

- **「全年」sentinel 是否需要同步 `normalizeSeasonLabel`？**
  - **答：现状不需要**。全仓库唯一调用点在 `recommendations.ts:349` 内 `seasonMatches`，
    而 `seasonMatches` 上层已在 PR #398 hotfix 加了「全年」sentinel 短路（不走 `normalizeSeasonLabel`）
  - P0-B 详情页尚未上线；未来消费 `bestSeason` 判「现在去正好 / 当前非最佳季节」时，
    **应复用 `seasonMatches` 而非直接 `normalizeSeasonLabel`** → 语义一致
- **`fresh.fallback` semantic gap**：v1.3 defer（PR #398 中已确认，本 PR 不动）

## 关联

- **root task**: task #169 (P0-B T2)
- **spec PR**: #393（Martin CR pending）
- **shared util**: `getCurrentCity` from `@gomate/lib`（同 P0-C recommendations）
- **thread**: #proj-gomate:e9379792

## Checklist
- [x] 单元 + 集成测试全绿
- [x] tsc 全绿
- [x] 无 secret / schema / migration
- [x] 分支 raft/ 前缀
- [x] PR body 有验证 / 风险 / 回滚
- [ ] GitHub Checks（等 CI）
- [ ] Martin CR
- [ ] Wen QA 验收（staging）

cc @Martin @Wen