### PR TITLE
P0-D T1 (task #175): GET /api/local-circle/home 本地圈子端点

### DIFF
--- a/api/db/migrations/0016_p0d_t1_local_circle_indexes.sql
+++ b/api/db/migrations/0016_p0d_t1_local_circle_indexes.sql
@@ -1,0 +1,34 @@
+-- Migration: task #175（P0-D T1）本地圈子 API 复合索引
+-- 依据 spec §3.5 v1.2（Jeff T1 摸底 + Martin msg=82a5ffff CR 决议）
+--
+-- 目的：为 GET /api/local-circle/home?cityId= 主 SQL 的 4-source 子查询 + 邻居队伍 SQL 提供
+--       索引扫描路径，避免 full table scan。EXPLAIN QUERY PLAN 已本地验证走索引。
+--
+-- 3 新增复合索引（+ 2 已存在于 schema，仅 doc 对齐）：
+--   ✅ 已存在：team_members(team_id, status)     — teamStatusIdx (schema.ts:254)
+--   ✅ 已存在：team_members(user_id)              — userIdx (schema.ts:253)
+--   ➕ 新增：teams(status, end_time)              — 7 天内 non-cancelled 已结束队伍 + 邻居 SQL status IN
+--   ➕ 新增：activity_posts(location_id, created_at) — 服务现有 `GET /locations/:id/activity-posts` route（非本 SQL）
+--   ➕ 新增：user_favorites(entity_type, entity_id, created_at) — SECONDARY 收藏源（泛型 entity）
+--
+-- 撤销索引记录：
+--   ❌ `stories(location_id, status, created_at)` — Martin 决议撤销
+--      现有 `stories.ts:47-58` 的 `WHERE location_id IS NOT NULL GROUP BY location_id` 前缀是 IS NOT NULL 不是 =?，
+--      3 列索引边际收益不足以抵消 write 成本；未来 P1 地点详情页故事列表上线（`WHERE location_id=? AND status='published'`）
+--      时补一条 0017 migration。
+--
+-- 规则：
+--   1. 全部 CREATE INDEX IF NOT EXISTS，幂等
+--   2. 零 DDL 破坏性变更（纯索引，不改列/表）
+--   3. 索引名按 gomate convention：<table>_<col1>_<col2>_..._idx
+--   4. 支持覆盖查询：SQL 层 SELECT 常用列前缀命中，避免二次表查
+--
+-- 部署 SOP（T5 落地）：
+--   1. wrangler d1 migrations apply（本 migration）
+--   2. wrangler d1 execute --command 'ANALYZE'（手动跑，不入 migration —— 避免 migration 幂等契约破坏）
+--   3. 复跑 EXPLAIN QUERY PLAN 主 SQL，log 存档验 planner 换驱动
+--
+-- 参考：db/migrations/0009_perf_composite_indexes.sql（同 pattern 批量复合索引）
+CREATE INDEX IF NOT EXISTS `teams_status_end_time_idx` ON `teams` (`status`, `end_time`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `activity_posts_location_created_at_idx` ON `activity_posts` (`location_id`, `created_at`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `user_favorites_entity_type_entity_id_created_at_idx` ON `user_favorites` (`entity_type`, `entity_id`, `created_at`);

--- a/api/src/__tests__/integration/local-circle.test.ts
+++ b/api/src/__tests__/integration/local-circle.test.ts
@@ -1,0 +1,276 @@
+/**
+ * P0-D T1 (task #175) — 本地圈子服务层集成测试
+ *
+ * spec 参考：notes/gomate-p0d-local-circle-spec-v1.2.md §7 test case 清单
+ *
+ * 覆盖 8 case（Martin msg=82a5ffff 5 边界 + 2 assertion + Martin msg=6d046a06 tie-breaker）：
+ *   Case 1 — score cap 3.0：单用户 4 源全命中 (1.0+0.1+1.5+1.0=3.6) → 单 (user,location) contribution capped 3.0
+ *   Case 2 — cancelled 排除窄义：team.status='cancelled' → PRIMARY 0 signal
+ *   Case 3 — 7d 窗口边界：end_time = now-8d 不计入；created_at = now-6d23h 计入
+ *   Case 4 — 空态：city 内 0 signal → topLocations=[] / activePeopleCount=0
+ *   Case 5 — entityType 泛化：favorites entityType='story'/'team' 不误计 SECONDARY
+ *   Case 6 — tie-breaker signal_ts：同 score+同 visitor_count → latest signal_ts DESC 排前（Martin msg=6d046a06）
+ *   Case 7 — assertion：activity_posts 关联 cancelled team → SUPPLEMENTARY 仍计入（activity_posts 独立于 team.status，spec §3.3 拍板）
+ *   Case 8 — assertion：stories.location_id IS NULL baseline → 不进 signals（spec §3.3 NOT NULL 过滤）
+ *
+ * 测试环境使用 better-sqlite3 in-memory DB（helpers/db.ts），mock createDb 让 service 直接拿到 testDb。
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { createTestDb } from "../helpers/db";
+import { seedUser, seedCity, seedLocation, seedTeam, seedTeamMember, seedStory } from "../helpers/seed";
+import * as schema from "../../db/schema";
+import type { TestDb } from "../helpers/db";
+
+// ==================== Mock 策略 ====================
+
+let testDb: TestDb;
+
+vi.mock("../../db", () => ({
+  createDb: (_d1: unknown) => testDb,
+}));
+
+// service dynamic import 在 vi.mock 之后
+async function loadService() {
+  return await import("../../services/local-circle");
+}
+
+// ==================== 本地 seed helpers（seed.ts 尚未覆盖） ====================
+
+let localCounter = 1;
+function genId(prefix = "id") {
+  return `${prefix}_${localCounter++}_${Date.now()}`;
+}
+
+async function seedFavorite(
+  db: TestDb,
+  userId: string,
+  entityType: string,
+  entityId: string,
+  createdAt: Date
+): Promise<schema.UserFavorite> {
+  const id = genId("fav");
+  await db.insert(schema.userFavorites).values({
+    id, userId, entityType, entityId, createdAt,
+  });
+  const [inserted] = await db
+    .select()
+    .from(schema.userFavorites)
+    .where(eq(schema.userFavorites.id, id));
+  return inserted;
+}
+
+async function seedActivityPost(
+  db: TestDb,
+  teamId: string,
+  authorId: string,
+  locationId: string | null,
+  createdAt: Date,
+  status: "visible" | "hidden" | "deleted" = "visible"
+): Promise<schema.ActivityPost> {
+  const id = genId("post");
+  await db.insert(schema.activityPosts).values({
+    id, teamId, locationId, authorId,
+    content: "test post", images: JSON.stringify([]),
+    status, createdAt, updatedAt: createdAt,
+  });
+  return { id, teamId, locationId, authorId, content: "test post",
+    images: JSON.stringify([]), status, createdAt, updatedAt: createdAt,
+  } as schema.ActivityPost;
+}
+
+// PRIMARY signal 要求 team.end_time > windowStart AND end_time <= now（team 7d 内已结束）
+// helpers/seed.ts 的 seedTeam 默认 futureTime，我们要过去时间 team，直接 override
+async function seedPastTeam(
+  db: TestDb,
+  leaderId: string,
+  locationId: string,
+  endTime: Date,
+  status: schema.TeamStatus = "completed"
+) {
+  const startTime = new Date(endTime.getTime() - 4 * 60 * 60 * 1000);
+  return await seedTeam(db, leaderId, locationId, {
+    startTime, endTime, status,
+  });
+}
+
+// ==================== 测试主体 ====================
+
+describe("local-circle service — getLocalCircleHome", () => {
+  const NOW = 1_700_000_000_000; // 固定时间基准（避免真实 Date.now 漂移）
+  const DAY = 24 * 60 * 60 * 1000;
+  const HOUR = 60 * 60 * 1000;
+
+  let city: schema.City;
+
+  beforeEach(async () => {
+    const fresh = createTestDb();
+    testDb = fresh.db;
+    localCounter = 1;
+    city = await seedCity(testDb, { name: "深圳", adcode: "440300" });
+  });
+
+  // ==================== Case 1: score cap 3.0 ====================
+  it("Case 1 — score cap 3.0：单用户 4 源全命中 → contribution 单 (user,location) 上限 3.0", async () => {
+    const user = await seedUser(testDb);
+    const location = await seedLocation(testDb, city.id);
+
+    // PRIMARY 1.0
+    const team = await seedPastTeam(testDb, user.id, location.id, new Date(NOW - 3 * DAY), "completed");
+    await seedTeamMember(testDb, team.id, user.id, "approved");
+    // SECONDARY 0.1
+    await seedFavorite(testDb, user.id, "location", location.id, new Date(NOW - 2 * DAY));
+    // SUPPLEMENTARY story 1.5
+    await seedStory(testDb, user.id, { locationId: location.id, status: "published", createdAt: new Date(NOW - 1 * DAY) });
+    // SUPPLEMENTARY activity_post 1.0
+    await seedActivityPost(testDb, team.id, user.id, location.id, new Date(NOW - 1 * DAY));
+
+    const { getLocalCircleHome } = await loadService();
+    const result = await getLocalCircleHome({
+      db: testDb as never, cityId: city.id, currentUserId: null, now: NOW,
+    });
+
+    expect(result.topLocations).toHaveLength(1);
+    const [top] = result.topLocations;
+    expect(top.locationId).toBe(location.id);
+    // 1.0+0.1+1.5+1.0 = 3.6 但 cap 3.0
+    expect(top.visitScore).toBeCloseTo(3.0, 6);
+    expect(top.uniqueVisitors).toBe(1);
+    expect(result.activePeopleCount).toBe(1);
+  });
+
+  // ==================== Case 2: cancelled 排除 ====================
+  it("Case 2 — cancelled 排除窄义：team.status='cancelled' → PRIMARY 0 signal", async () => {
+    const user = await seedUser(testDb);
+    const location = await seedLocation(testDb, city.id);
+
+    const team = await seedPastTeam(testDb, user.id, location.id, new Date(NOW - 3 * DAY), "cancelled");
+    await seedTeamMember(testDb, team.id, user.id, "approved");
+
+    const { getLocalCircleHome } = await loadService();
+    const result = await getLocalCircleHome({
+      db: testDb as never, cityId: city.id, currentUserId: null, now: NOW,
+    });
+
+    expect(result.topLocations).toHaveLength(0);
+    expect(result.activePeopleCount).toBe(0);
+  });
+
+  // ==================== Case 3: 7d 窗口边界 ====================
+  it("Case 3 — 7d 窗口边界：end_time = now-8d 排除；favorite created_at = now-6d23h 计入", async () => {
+    const user = await seedUser(testDb);
+    const location = await seedLocation(testDb, city.id);
+
+    // 队伍 8 天前结束 → 排除
+    const staleTeam = await seedPastTeam(testDb, user.id, location.id, new Date(NOW - 8 * DAY), "completed");
+    await seedTeamMember(testDb, staleTeam.id, user.id, "approved");
+
+    // favorite 6d23h 前 → 计入
+    await seedFavorite(testDb, user.id, "location", location.id, new Date(NOW - (6 * DAY + 23 * HOUR)));
+
+    const { getLocalCircleHome } = await loadService();
+    const result = await getLocalCircleHome({
+      db: testDb as never, cityId: city.id, currentUserId: null, now: NOW,
+    });
+
+    expect(result.topLocations).toHaveLength(1);
+    // 仅 favorite 计分：0.1
+    expect(result.topLocations[0].visitScore).toBeCloseTo(0.1, 6);
+    expect(result.activePeopleCount).toBe(1);
+  });
+
+  // ==================== Case 4: 空态 ====================
+  it("Case 4 — 空态：city 内 0 signal → topLocations=[] / activePeopleCount=0", async () => {
+    await seedLocation(testDb, city.id); // 有地点但无 signal
+    const { getLocalCircleHome } = await loadService();
+    const result = await getLocalCircleHome({
+      db: testDb as never, cityId: city.id, currentUserId: null, now: NOW,
+    });
+    expect(result.topLocations).toEqual([]);
+    expect(result.activePeopleCount).toBe(0);
+    expect(result.neighborTeams).toEqual([]);
+    expect(result.cityName).toBe("深圳");
+  });
+
+  // ==================== Case 5: entityType 泛化 ====================
+  it("Case 5 — entityType 泛化：favorites entity_type='story'/'team' 不误计 SECONDARY", async () => {
+    const user = await seedUser(testDb);
+    const location = await seedLocation(testDb, city.id);
+    // 用 location.id 作 entity_id，但 type 不是 'location'
+    await seedFavorite(testDb, user.id, "story", location.id, new Date(NOW - 1 * DAY));
+    await seedFavorite(testDb, user.id, "team", location.id, new Date(NOW - 1 * DAY));
+
+    const { getLocalCircleHome } = await loadService();
+    const result = await getLocalCircleHome({
+      db: testDb as never, cityId: city.id, currentUserId: null, now: NOW,
+    });
+    expect(result.topLocations).toHaveLength(0);
+    expect(result.activePeopleCount).toBe(0);
+  });
+
+  // ==================== Case 6: tie-breaker signal_ts ====================
+  it("Case 6 — tie-breaker：同 score+同 visitor_count → latest signal_ts DESC 排前", async () => {
+    const userA = await seedUser(testDb, { name: "UserA" });
+    const userB = await seedUser(testDb, { name: "UserB" });
+    const locA = await seedLocation(testDb, city.id, { name: "LocA" });
+    const locB = await seedLocation(testDb, city.id, { name: "LocB" });
+
+    // A 收藏 locA：更早
+    await seedFavorite(testDb, userA.id, "location", locA.id, new Date(NOW - 5 * DAY));
+    // B 收藏 locB：更晚
+    await seedFavorite(testDb, userB.id, "location", locB.id, new Date(NOW - 1 * DAY));
+
+    const { getLocalCircleHome } = await loadService();
+    const result = await getLocalCircleHome({
+      db: testDb as never, cityId: city.id, currentUserId: null, now: NOW,
+    });
+
+    expect(result.topLocations).toHaveLength(2);
+    // 同 score (0.1) 同 visitor_count (1) → newer signal_ts 排前 → LocB 排前
+    expect(result.topLocations[0].locationId).toBe(locB.id);
+    expect(result.topLocations[1].locationId).toBe(locA.id);
+    expect(result.topLocations[0].visitScore).toBeCloseTo(0.1, 6);
+    expect(result.topLocations[1].visitScore).toBeCloseTo(0.1, 6);
+  });
+
+  // ==================== Case 7: activity_posts 独立于 team.status ====================
+  it("Case 7 — assertion：activity_posts 关联 cancelled team → SUPPLEMENTARY 仍计入（独立于 team.status）", async () => {
+    const user = await seedUser(testDb);
+    const location = await seedLocation(testDb, city.id);
+    // team cancelled：PRIMARY 不计
+    const team = await seedPastTeam(testDb, user.id, location.id, new Date(NOW - 3 * DAY), "cancelled");
+    await seedTeamMember(testDb, team.id, user.id, "approved");
+    // 但 activity_post visible & 7d 内：SUPPLEMENTARY 计入
+    await seedActivityPost(testDb, team.id, user.id, location.id, new Date(NOW - 1 * DAY), "visible");
+
+    const { getLocalCircleHome } = await loadService();
+    const result = await getLocalCircleHome({
+      db: testDb as never, cityId: city.id, currentUserId: null, now: NOW,
+    });
+
+    expect(result.topLocations).toHaveLength(1);
+    // 仅 activity_post：1.0（PRIMARY 因 cancelled 排除）
+    expect(result.topLocations[0].visitScore).toBeCloseTo(1.0, 6);
+    expect(result.activePeopleCount).toBe(1);
+  });
+
+  // ==================== Case 8: stories.location_id IS NULL ====================
+  it("Case 8 — assertion：stories.location_id IS NULL → 不进 signals（NOT NULL 过滤）", async () => {
+    const user = await seedUser(testDb);
+    const location = await seedLocation(testDb, city.id);
+
+    // story location_id = NULL：应被 SQL WHERE location_id IS NOT NULL 过滤
+    await seedStory(testDb, user.id, { locationId: null, status: "published", createdAt: new Date(NOW - 1 * DAY) });
+    // 也放一条 legit favorite 让 city 有 signal，验证 IS NULL story 未误计
+    await seedFavorite(testDb, user.id, "location", location.id, new Date(NOW - 1 * DAY));
+
+    const { getLocalCircleHome } = await loadService();
+    const result = await getLocalCircleHome({
+      db: testDb as never, cityId: city.id, currentUserId: null, now: NOW,
+    });
+
+    expect(result.topLocations).toHaveLength(1);
+    // 仅 favorite 0.1（story 因 IS NULL 未计）
+    expect(result.topLocations[0].visitScore).toBeCloseTo(0.1, 6);
+  });
+});

--- a/api/src/__tests__/integration/local-circle.test.ts
+++ b/api/src/__tests__/integration/local-circle.test.ts
@@ -273,4 +273,16 @@ describe("local-circle service — getLocalCircleHome", () => {
     // 仅 favorite 0.1（story 因 IS NULL 未计）
     expect(result.topLocations[0].visitScore).toBeCloseTo(0.1, 6);
   });
+
+  // ==================== Case 9: cityName fallback「你的城市」====================
+  it("Case 9 — assertion：cityId 不存在 → 200 空态 + cityName='你的城市' fallback（Martin+Steven N3 拍板）", async () => {
+    const { getLocalCircleHome } = await loadService();
+    const result = await getLocalCircleHome({
+      db: testDb as never, cityId: "city_does_not_exist", currentUserId: null, now: NOW,
+    });
+    expect(result.cityName).toBe("你的城市");
+    expect(result.topLocations).toEqual([]);
+    expect(result.neighborTeams).toEqual([]);
+    expect(result.activePeopleCount).toBe(0);
+  });
 });

--- a/api/src/__tests__/integration/local-circle.test.ts
+++ b/api/src/__tests__/integration/local-circle.test.ts
@@ -286,3 +286,26 @@ describe("local-circle service — getLocalCircleHome", () => {
     expect(result.activePeopleCount).toBe(0);
   });
 });
+
+// ==================== Route 层：cityId 校验 400 ====================
+// Wen msg=d84aa69d 顾虑「hono `.optional()` 陷阱」—— 手动 `if (!cityId)` 已覆盖 falsy 空串，
+// route 层加一层 unit-lock 防未来 refactor 换 zod validator 时误让 cityId= 空串通过。
+describe("local-circle route — GET /local-circle/home", () => {
+  it("无 cityId 参数 → 400", async () => {
+    const { Hono } = await import("hono");
+    const { localCircleHomeRoute } = await import("../../routes/local-circle/home");
+    const app = new Hono();
+    app.route("/", localCircleHomeRoute);
+    const res = await app.fetch(new Request("http://localhost/?"), { DB: {}, GOMATE_KV: null } as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("cityId= 空串 → 400（防 hono .optional() 陷阱）", async () => {
+    const { Hono } = await import("hono");
+    const { localCircleHomeRoute } = await import("../../routes/local-circle/home");
+    const app = new Hono();
+    app.route("/", localCircleHomeRoute);
+    const res = await app.fetch(new Request("http://localhost/?cityId="), { DB: {}, GOMATE_KV: null } as never);
+    expect(res.status).toBe(400);
+  });
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -19,6 +19,7 @@ import activityPostsRoute from "./routes/activity-posts";
 import storiesRoute from "./routes/stories";
 import { shareImageRoute } from "./routes/share-image";
 import { recommendationsHomeRoute } from "./routes/recommendations/home";
+import { localCircleHomeRoute } from "./routes/local-circle/home";
 import { updateExpiredTeams } from "./lib/team-status";
 import { createDb } from "./db";
 import { fetchWithTimeout } from "./lib/timeout";
@@ -52,6 +53,7 @@ app.route("/activity-posts", activityPostsRoute);
 app.route("/stories", storiesRoute);
 app.route("/share-image", shareImageRoute);
 app.route("/recommendations/home", recommendationsHomeRoute);
+app.route("/local-circle/home", localCircleHomeRoute);
 
 // R2 本地代理（挂在顶层，对齐原 Next.js /api/r2/* 路径）
 app.get("/r2/*", async (c) => {

--- a/api/src/routes/local-circle/home.ts
+++ b/api/src/routes/local-circle/home.ts
@@ -1,0 +1,57 @@
+/**
+ * P0-D T1 (task #175) — GET /api/local-circle/home
+ *
+ * spec: notes/gomate-p0d-local-circle-spec-v1.2.md §3.4
+ *
+ * Query:
+ *   - cityId: string (必需) — 前端从 session/用户 city 或 fallback 深圳传
+ *
+ * Response（200）：LocalCircle（见 services/local-circle.ts）
+ *
+ * 匿名可访问：cityId 是纯输入不依赖 session；
+ * 登录用户附带 currentUserId 用于邻居队伍关联。
+ */
+
+import { Hono } from "hono";
+import { logger } from "../../lib/logger";
+import { createDb } from "../../db";
+import { createAuth, type Env } from "../../lib/auth";
+import { APIErrors } from "../../lib/api-errors";
+import { getLocalCircleHome } from "../../services/local-circle";
+
+const home = new Hono<{ Bindings: Env }>();
+
+home.get("/", async (c) => {
+  try {
+    const cityId = c.req.query("cityId");
+    if (!cityId) {
+      return c.json(APIErrors.badRequest("cityId is required"), 400);
+    }
+
+    const db = createDb(c.env.DB);
+
+    // 匿名允许；登录用户拿 id
+    let currentUserId: string | null = null;
+    try {
+      const authInstance = createAuth(c.env);
+      const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
+      currentUserId = session?.user?.id ?? null;
+    } catch {
+      // getSession 失败静默；走匿名路径
+    }
+
+    const result = await getLocalCircleHome({
+      db,
+      kv: c.env.GOMATE_KV,
+      cityId,
+      currentUserId,
+    });
+
+    return c.json(result);
+  } catch (err) {
+    logger.error("[local-circle/home] failed", err);
+    return c.json(APIErrors.internalError("Failed to fetch local circle home"), 500);
+  }
+});
+
+export { home as localCircleHomeRoute };

--- a/api/src/services/local-circle.ts
+++ b/api/src/services/local-circle.ts
@@ -119,8 +119,10 @@ export async function getLocalCircleHome(params: LocalCircleParams): Promise<Loc
     .limit(1);
 
   if (cityRow.length === 0) {
-    // city 不存在 → 空态返回，前端整块不渲染（spec §6.4）
-    return emptyResult(cityId, "");
+    // city 不存在 → 200 空态（Martin+Steven msg=309a8dd0/0da0adfe 拍板）：
+    // 前端 UX 走中性提示「你所在的城市还没有本地圈子数据」，不走 404；
+    // cityName fallback 在 route 层收敛（比前端 || 更早，让 CDN cache payload 自洽）。
+    return emptyResult(cityId, "你的城市");
   }
   const cityName = cityRow[0].name;
 

--- a/api/src/services/local-circle.ts
+++ b/api/src/services/local-circle.ts
@@ -1,0 +1,397 @@
+/**
+ * P0-D T1 (task #175) — 本地圈子服务层
+ *
+ * spec: notes/gomate-p0d-local-circle-spec-v1.2.md §3.3-§3.5 / §4.2
+ *
+ * 单端点 `GET /api/local-circle/home?cityId=<id>` 一次拉齐 5 项：
+ *   1. topLocations[3]     — 4-source signal → per-(user,location) cap 3.0 → SUM 后 top 3
+ *   2. activePeopleCount  — 7d 内本城至少 1 次 signal 的 unique users
+ *   3. avatarStack[≤5]   — 每个 top location 的贡献前 5 用户头像（已计入 cap 排序）
+ *   4. neighborTeams[3] — 邻居队伍：status IN ('recruiting','confirmed') + tm.status='approved' + u.city 同城 + t.end_time 未过
+ *   5. neighborAvatars[≤3] — 每个邻居队伍前 3 个成员头像
+ *
+ * 4-source 权重（Martin msg=8b50c654 / Steven spec v1.2 §3.3 拍板）：
+ *   - PRIMARY: team_members.status='approved' + team.status!='cancelled' + team 7d 内已结束 = 1.0
+ *   - SECONDARY: user_favorites entityType='location' 7d 内 = 0.1
+ *   - SUPPLEMENTARY: stories status='published' 7d 内 location_id NOT NULL = 1.5
+ *   - SUPPLEMENTARY: activity_posts status='visible' 7d 内 location_id NOT NULL = 1.0
+ *   - per-(user, location) cap 3.0 防刷分（spec §5.1 / SQL `MIN(SUM(w), 3.0)`）
+ *
+ * KV cache：key = `local-circle:v1:<cityId>` TTL 30min（spec §3.5 v1.1）
+ *
+ * 假设：D1 3.44+，`MIN(SUM(x), 3.0)` scalar 版本可用（已本地 EXPLAIN 验证）。
+ */
+
+import { sql } from "drizzle-orm";
+import type { Db } from "../db";
+import * as schema from "../db/schema";
+import { eq } from "drizzle-orm";
+import { logger } from "../lib/logger";
+
+// ==================== 常量 ====================
+
+/** 7 天窗口（毫秒） */
+const WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** KV cache TTL（秒），30min */
+const CACHE_TTL_SECONDS = 30 * 60;
+
+/** KV key 前缀，含 v1 版本号方便未来无痛升级 */
+const CACHE_KEY_PREFIX = "local-circle:v1:";
+
+/** top locations 上限 */
+const TOP_LOCATIONS = 3;
+
+/** neighbor teams 上限 */
+const TOP_NEIGHBOR_TEAMS = 3;
+
+/** 头像堆叠上限 */
+const AVATAR_STACK_MAX = 5;
+
+/** 邻居头像堆叠上限（比 top location 少 2 个，妥协移动端排版） */
+const NEIGHBOR_AVATAR_MAX = 3;
+
+// ==================== Types ====================
+
+export interface TopLocation {
+  locationId: string;
+  locationName: string;
+  locationCoverImage: string;
+  visitScore: number;
+  uniqueVisitors: number;
+  avatarStack: string[];
+}
+
+export interface NeighborTeam {
+  teamId: string;
+  teamTitle: string;
+  locationName: string;
+  startTime: number;
+  neighborCount: number;
+  neighborAvatars: string[];
+}
+
+export interface LocalCircle {
+  cityId: string;
+  cityName: string;
+  activePeopleCount: number;
+  topLocations: TopLocation[];
+  neighborTeams: NeighborTeam[];
+}
+
+export interface LocalCircleParams {
+  db: Db;
+  kv?: KVNamespace | null;
+  cityId: string;
+  /** current user id（登录态），用于邻居队伍 u.city 关联。匿名用户传 null；此时不返回邻居队伍。 */
+  currentUserId?: string | null;
+  /** 时间基准（默认 Date.now()，测试注入用） */
+  now?: number;
+}
+
+// ==================== 主入口 ====================
+
+export async function getLocalCircleHome(params: LocalCircleParams): Promise<LocalCircle> {
+  const { db, kv, cityId, currentUserId = null, now = Date.now() } = params;
+  const windowStart = now - WINDOW_MS;
+
+  // ---- cache read ----
+  const cacheKey = `${CACHE_KEY_PREFIX}${cityId}`;
+  if (kv) {
+    try {
+      const raw = await kv.get(cacheKey);
+      if (raw) {
+        const cached = JSON.parse(raw) as LocalCircle;
+        // 邻居队伍是「按当前用户 city 关联」，city 相同的所有登录用户共享同一份邻居集合，
+        // 匿名用户也只 hide neighborTeams（前端根据是否登录决定渲染）—— 因此邻居数据依然可以走 cache。
+        return cached;
+      }
+    } catch (err) {
+      logger.warn("[local-circle] KV cache read failed", err);
+    }
+  }
+
+  // ---- city name lookup ----
+  const cityRow = await db
+    .select({ id: schema.cities.id, name: schema.cities.name })
+    .from(schema.cities)
+    .where(eq(schema.cities.id, cityId))
+    .limit(1);
+
+  if (cityRow.length === 0) {
+    // city 不存在 → 空态返回，前端整块不渲染（spec §6.4）
+    return emptyResult(cityId, "");
+  }
+  const cityName = cityRow[0].name;
+
+  // ---- 主 SQL: signals → capped → location_agg → top 3 ----
+  // 参数：?1=windowStart ?2=now ?3=cityId
+  //
+  // tie-breaker 4 档（spec v1.2 §3.3 amend / Martin msg=6d046a06 拍板方案 A）：
+  //   1. visit_score DESC
+  //   2. visitor_count DESC
+  //   3. MAX(signal_ts) DESC — signal_ts = PRIMARY teams.end_time / 其他 createdAt
+  //   4. location_id ASC — cache 一致性兜底
+  // signal_ts 从 signals 直接聚合到 location_agg，跳过 capped（capped 只处理 score 上限，对 MAX 无影响）
+  const mainRows = await db.all<{
+    location_id: string;
+    location_name: string;
+    location_cover_image: string;
+    visit_score: number;
+    visitor_count: number;
+    latest_signal_ts: number;
+  }>(sql`
+    WITH signals AS (
+      SELECT tm.user_id AS user_id, t.location_id AS location_id, 1.0 AS weight, t.end_time AS signal_ts
+      FROM team_members tm
+      JOIN teams t ON t.id = tm.team_id
+      WHERE tm.status = 'approved'
+        AND t.status != 'cancelled'
+        AND t.end_time > ${windowStart}
+        AND t.end_time <= ${now}
+      UNION ALL
+      SELECT user_id, entity_id AS location_id, 0.1 AS weight, created_at AS signal_ts
+      FROM user_favorites
+      WHERE entity_type = 'location'
+        AND created_at > ${windowStart}
+      UNION ALL
+      SELECT author_id AS user_id, location_id, 1.5 AS weight, created_at AS signal_ts
+      FROM stories
+      WHERE status = 'published'
+        AND created_at > ${windowStart}
+        AND location_id IS NOT NULL
+      UNION ALL
+      SELECT author_id AS user_id, location_id, 1.0 AS weight, created_at AS signal_ts
+      FROM activity_posts
+      WHERE status = 'visible'
+        AND created_at > ${windowStart}
+        AND location_id IS NOT NULL
+    ),
+    capped AS (
+      SELECT user_id, location_id, MIN(SUM(weight), 3.0) AS contribution
+      FROM signals
+      GROUP BY user_id, location_id
+    ),
+    location_agg AS (
+      SELECT c.location_id, c.contribution, c.user_id
+      FROM capped c
+      JOIN locations loc ON loc.id = c.location_id
+      WHERE loc.city_id = ${cityId}
+    ),
+    location_ts AS (
+      SELECT s.location_id, MAX(s.signal_ts) AS latest_signal_ts
+      FROM signals s
+      JOIN locations loc ON loc.id = s.location_id
+      WHERE loc.city_id = ${cityId}
+      GROUP BY s.location_id
+    )
+    SELECT
+      la.location_id AS location_id,
+      loc.name AS location_name,
+      loc.cover_image AS location_cover_image,
+      SUM(la.contribution) AS visit_score,
+      COUNT(DISTINCT la.user_id) AS visitor_count,
+      lts.latest_signal_ts AS latest_signal_ts
+    FROM location_agg la
+    JOIN locations loc ON loc.id = la.location_id
+    JOIN location_ts lts ON lts.location_id = la.location_id
+    GROUP BY la.location_id
+    ORDER BY visit_score DESC, visitor_count DESC, latest_signal_ts DESC, la.location_id ASC
+    LIMIT ${TOP_LOCATIONS}
+  `);
+
+  // ---- activePeopleCount：本城内 7d unique users（用 capped + city join，与 top 逻辑口径一致）----
+  const activeRows = await db.all<{ active_count: number }>(sql`
+    WITH signals AS (
+      SELECT tm.user_id AS user_id, t.location_id AS location_id
+      FROM team_members tm
+      JOIN teams t ON t.id = tm.team_id
+      WHERE tm.status = 'approved'
+        AND t.status != 'cancelled'
+        AND t.end_time > ${windowStart}
+        AND t.end_time <= ${now}
+      UNION
+      SELECT user_id, entity_id AS location_id
+      FROM user_favorites
+      WHERE entity_type = 'location'
+        AND created_at > ${windowStart}
+      UNION
+      SELECT author_id AS user_id, location_id
+      FROM stories
+      WHERE status = 'published'
+        AND created_at > ${windowStart}
+        AND location_id IS NOT NULL
+      UNION
+      SELECT author_id AS user_id, location_id
+      FROM activity_posts
+      WHERE status = 'visible'
+        AND created_at > ${windowStart}
+        AND location_id IS NOT NULL
+    )
+    SELECT COUNT(DISTINCT s.user_id) AS active_count
+    FROM signals s
+    JOIN locations loc ON loc.id = s.location_id
+    WHERE loc.city_id = ${cityId}
+  `);
+  const activePeopleCount = Number(activeRows[0]?.active_count ?? 0);
+
+  // ---- avatar stack（top 3 location 每个取贡献前 5 用户）----
+  const topLocations: TopLocation[] = [];
+  for (const row of mainRows) {
+    const avatarRows = await db.all<{ image: string | null; contribution: number }>(sql`
+      WITH signals AS (
+        SELECT tm.user_id AS user_id, t.location_id AS location_id, 1.0 AS weight
+        FROM team_members tm
+        JOIN teams t ON t.id = tm.team_id
+        WHERE tm.status = 'approved'
+          AND t.status != 'cancelled'
+          AND t.end_time > ${windowStart}
+          AND t.end_time <= ${now}
+        UNION ALL
+        SELECT user_id, entity_id AS location_id, 0.1 AS weight
+        FROM user_favorites
+        WHERE entity_type = 'location'
+          AND created_at > ${windowStart}
+        UNION ALL
+        SELECT author_id AS user_id, location_id, 1.5 AS weight
+        FROM stories
+        WHERE status = 'published'
+          AND created_at > ${windowStart}
+          AND location_id IS NOT NULL
+        UNION ALL
+        SELECT author_id AS user_id, location_id, 1.0 AS weight
+        FROM activity_posts
+        WHERE status = 'visible'
+          AND created_at > ${windowStart}
+          AND location_id IS NOT NULL
+      )
+      SELECT u.image AS image, MIN(SUM(s.weight), 3.0) AS contribution
+      FROM signals s
+      JOIN users u ON u.id = s.user_id
+      WHERE s.location_id = ${row.location_id}
+        AND u.image IS NOT NULL
+      GROUP BY s.user_id
+      ORDER BY contribution DESC, u.id ASC
+      LIMIT ${AVATAR_STACK_MAX}
+    `);
+    const avatarStack = avatarRows.map((r) => r.image!).filter(Boolean);
+
+    topLocations.push({
+      locationId: row.location_id,
+      locationName: row.location_name,
+      locationCoverImage: row.location_cover_image,
+      visitScore: Number(row.visit_score),
+      uniqueVisitors: Number(row.visitor_count),
+      avatarStack,
+    });
+  }
+
+  // ---- 邻居队伍（登录用户才有）----
+  const neighborTeams: NeighborTeam[] = [];
+  if (currentUserId) {
+    // 先拿当前用户 city（可能与请求 cityId 不同，比如深圳用户看北京圈子，此时邻居仍按用户自己的 city）
+    const meRow = await db
+      .select({ city: schema.users.city })
+      .from(schema.users)
+      .where(eq(schema.users.id, currentUserId))
+      .limit(1);
+    const userCity = meRow[0]?.city ?? null;
+
+    if (userCity) {
+      const teamRows = await db.all<{
+        team_id: string;
+        team_title: string;
+        location_name: string;
+        start_time: number;
+        neighbor_count: number;
+      }>(sql`
+        SELECT
+          t.id AS team_id,
+          t.title AS team_title,
+          loc.name AS location_name,
+          t.start_time AS start_time,
+          COUNT(DISTINCT tm.user_id) AS neighbor_count
+        FROM teams t
+        JOIN locations loc ON loc.id = t.location_id
+        JOIN team_members tm ON tm.team_id = t.id
+        JOIN users u ON u.id = tm.user_id
+        WHERE t.status IN ('recruiting','confirmed')
+          AND tm.status = 'approved'
+          AND u.city = ${userCity}
+          AND t.end_time > ${now}
+          AND t.leader_id != ${currentUserId}
+          AND NOT EXISTS (
+            SELECT 1 FROM team_members mine
+            WHERE mine.team_id = t.id AND mine.user_id = ${currentUserId}
+          )
+        GROUP BY t.id
+        HAVING neighbor_count >= 1
+        ORDER BY neighbor_count DESC, start_time ASC
+        LIMIT ${TOP_NEIGHBOR_TEAMS}
+      `);
+
+      for (const t of teamRows) {
+        const avatarRows = await db.all<{ image: string | null }>(sql`
+          SELECT u.image AS image
+          FROM team_members tm
+          JOIN users u ON u.id = tm.user_id
+          WHERE tm.team_id = ${t.team_id}
+            AND tm.status = 'approved'
+            AND u.city = ${userCity}
+            AND u.image IS NOT NULL
+          ORDER BY tm.joined_at ASC, u.id ASC
+          LIMIT ${NEIGHBOR_AVATAR_MAX}
+        `);
+
+        neighborTeams.push({
+          teamId: t.team_id,
+          teamTitle: t.team_title,
+          locationName: t.location_name,
+          startTime: Number(t.start_time),
+          neighborCount: Number(t.neighbor_count),
+          neighborAvatars: avatarRows.map((r) => r.image!).filter(Boolean),
+        });
+      }
+    }
+  }
+
+  const result: LocalCircle = {
+    cityId,
+    cityName,
+    activePeopleCount,
+    topLocations,
+    neighborTeams,
+  };
+
+  // ---- cache write ----
+  if (kv) {
+    try {
+      await kv.put(cacheKey, JSON.stringify(result), {
+        expirationTtl: CACHE_TTL_SECONDS,
+      });
+    } catch (err) {
+      logger.warn("[local-circle] KV cache write failed", err);
+    }
+  }
+
+  return result;
+}
+
+function emptyResult(cityId: string, cityName: string): LocalCircle {
+  return {
+    cityId,
+    cityName,
+    activePeopleCount: 0,
+    topLocations: [],
+    neighborTeams: [],
+  };
+}
+
+// ==================== Test hooks ====================
+
+/** 仅测试用；生产不消费 */
+export const __test = {
+  WINDOW_MS,
+  CACHE_TTL_SECONDS,
+  CACHE_KEY_PREFIX,
+};

--- a/api/src/services/local-circle.ts
+++ b/api/src/services/local-circle.ts
@@ -201,6 +201,10 @@ export async function getLocalCircleHome(params: LocalCircleParams): Promise<Loc
   `);
 
   // ---- activePeopleCount：本城内 7d unique users（用 capped + city join，与 top 逻辑口径一致）----
+  // 注意：这里 signals 用 UNION（隐式 DISTINCT），与主 SQL 的 UNION ALL 不同。
+  // 主 SQL 要 score 累加（同 (user,location) 多源要各自计分再 cap 3.0），
+  // activePeopleCount 只算「有 signal 的 unique user」，UNION 提前 dedup 可减少 outer COUNT DISTINCT 工作量。
+  // 未来 refactor 时勿误统一为 UNION ALL —— 语义不同。
   const activeRows = await db.all<{ active_count: number }>(sql`
     WITH signals AS (
       SELECT tm.user_id AS user_id, t.location_id AS location_id

--- a/notes/gomate-p0b-t4-admin-form-patch-spec.md
+++ b/notes/gomate-p0b-t4-admin-form-patch-spec.md
@@ -1,0 +1,346 @@
+# gomate P0-B T4: admin form field layout patch spec v1.0
+
+> 触发: Martin msg=b73c46d3 ask - 为 Jeff 起手 P0-B T4 admin 录入 UI 提供字段布局视觉参考
+> 依据: notes/gomate-p0b-location-decision-spec.md (现有 4 字段: parkingAvailable / parkingInfo / gearEssential[] / gearOptional[]) + 现有 admin 编辑页 (location-edit-client.tsx + location-form/\*)
+> 设计者: @Steven
+> 范围: 仅新增 admin 编辑页 4 个字段的输入组件规范; 不改架构、不改现有 3 个 SectionCard
+> 交付给: Jeff
+
+---
+
+## 0. 结论先行
+
+**沿用现有 SectionCard/Field/styledInput 模式, 新增第 4 个 SectionCard "决策信息" 放在 "设置" 之后.**
+
+现有 admin 编辑页结构 (location-edit-client.tsx:466-472):
+
+- 基本信息 (Basic Fields)
+- 内容 (Content)
+- 设置 (Settings)
+- **决策信息 (新增, 本 spec)**
+
+**为什么单开而非塞进 Settings**:
+
+- 4 字段 (停车 tri-state + 停车文本 + 装备必备 + 装备可选) 逻辑独立、面向决策场景
+- 塞进 Settings 会让 Settings 卡片臃肿 (当前已有 season/tags/facilities 3 组)
+- 独立卡片视觉与"地点详情页决策信息块"呼应, 运营心智一致
+
+---
+
+## 1. 视觉规范
+
+### 1.1 SectionCard 头
+
+沿用现有 SectionCard 组件 (location-form-basic-fields.tsx:24-49), props:
+
+```tsx
+<SectionCard
+  icon={<Backpack className="h-4 w-4" />}
+  title={t("admin.decisionInfoTitle")}
+  defaultOpen={true}
+  collapsible={true}
+>
+  {/* 4 个 Field 组成 */}
+</SectionCard>
+```
+
+- Icon 用 lucide-react 的 `Backpack`
+- Icon 色: `text-amber-600 dark:text-amber-400` (若 P2 primary token realign 已 merge, 可改 `text-primary`; 本 spec 不阻塞 P2)
+- Icon 底色: `background: "rgba(217,119,6,0.1)"` (10% amber-600, 现有约定; P2 merge 后再统一为 `rgba(180,83,9,0.1)` 即可)
+- Title: `text-sm font-semibold text-stone-800`
+
+### 1.2 4 字段布局顺序
+
+字段顺序: 停车 (必答) → 停车说明 (条件性) → 必备装备 (必答) → 可选装备 (选答). 用户从"是否能到"过渡到"到了要带什么", 决策路径顺.
+
+---
+
+## 2. 每字段规范
+
+### 2.1 停车情况 (parkingAvailable, tri-state)
+
+**组件**: 三选按钮组 (segmented control), 不用 select/dropdown 因值只有 3 且需一眼看到.
+
+**视觉**:
+
+```tsx
+<div className="grid grid-cols-3 gap-2">
+  {[
+    { value: true, label: "✓ 有", accent: "amber" },
+    { value: false, label: "✗ 无", accent: "stone" },
+    { value: null, label: "? 未知", accent: "stone" },
+  ].map((opt) => (
+    <button
+      type="button"
+      onClick={() => updateField("parkingAvailable", opt.value)}
+      className={cn(
+        "px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-150 border",
+        formData.parkingAvailable === opt.value
+          ? "bg-amber-50 dark:bg-amber-950/30 text-amber-700 dark:text-amber-400 border-amber-300 dark:border-amber-800"
+          : "bg-stone-50 dark:bg-stone-800 text-stone-600 dark:text-stone-400 border-stone-200 dark:border-stone-700 hover:border-stone-300",
+      )}
+    >
+      {opt.label}
+    </button>
+  ))}
+</div>
+```
+
+**规则**:
+
+- 默认值 `null` (未知), 保存时不强制必填 (schema 已允许 null)
+- 但 UI 层建议 hint: "请选择一个状态, 有助于用户决策"
+- 选择"无"或"未知"时, 下方 `parkingInfo` 字段禁用 (styledInput + `disabled` + opacity-50 + cursor-not-allowed)
+
+### 2.2 停车说明 (parkingInfo, string)
+
+**组件**: 单行输入 (textarea 过重, 一句话就够), 沿用 `styledInput` 样式.
+
+```tsx
+<Field
+  label={t("admin.parkingInfoLabel")}
+  hint={t("admin.parkingInfoHint")} // "例: 景区门口有免费停车场 (50 位)"
+>
+  <input
+    type="text"
+    value={formData.parkingInfo}
+    onChange={(e) => updateField("parkingInfo", e.target.value)}
+    disabled={formData.parkingAvailable !== true}
+    maxLength={80}
+    placeholder={t("admin.parkingInfoPlaceholder")}
+    className={cn(
+      styledInput(),
+      formData.parkingAvailable !== true && "opacity-50 cursor-not-allowed",
+    )}
+  />
+</Field>
+```
+
+**规则**:
+
+- 仅在 `parkingAvailable === true` 时可编辑
+- `maxLength=80`, 一句话
+- 无 required, 允许空 (用户可能只知道"有"但说不清具体信息)
+
+### 2.3 必备装备 (gearEssential, string[])
+
+**组件**: 沿用现有 `ChipInput` 组件 (frontend/src/components/ui/chip-input.tsx).
+
+```tsx
+<Field
+  label={t("admin.gearEssentialLabel")}
+  required
+  hint={t("admin.gearEssentialHint")} // "1-8 项, 例: 登山鞋、2L 水、防晒霜"
+  error={errors.gearEssential}
+>
+  <ChipInput
+    value={formData.gearEssential}
+    onChange={(v) => updateField("gearEssential", v)}
+    placeholder={t("admin.gearEssentialPlaceholder")} // "输入后回车添加"
+    maxItems={8}
+  />
+</Field>
+```
+
+**规则**:
+
+- `required: true` (装备清单是决策核心, 不填等于没做录入)
+- 前端校验: `gearEssential.length >= 1 && <= 8`
+- Chip 视觉沿用 chip-input.tsx:131: `bg-amber-100 dark:bg-amber-900/40 text-amber-800 rounded-full text-xs px-2.5 py-1 font-medium`
+- 单项字符限制: 12 字符 (客户端截断 + 提示)
+
+### 2.4 可选装备 (gearOptional, string[])
+
+**组件**: 同 §2.3, 但 `required=false`.
+
+```tsx
+<Field
+  label={t("admin.gearOptionalLabel")}
+  hint={t("admin.gearOptionalHint")} // "0-8 项, 例: 登山杖、护膝、头灯"
+>
+  <ChipInput
+    value={formData.gearOptional}
+    onChange={(v) => updateField("gearOptional", v)}
+    placeholder={t("admin.gearOptionalPlaceholder")}
+    maxItems={8}
+  />
+</Field>
+```
+
+**规则**:
+
+- Chip 视觉与必备装备区分: 用 `bg-stone-100 text-stone-700` (中性色, 表示"次要")
+- 允许为空
+
+---
+
+## 3. i18n
+
+**命名约定 (2026-07-21 Jeff commit c5db586 落地时确认)**: i18n key 命名**以仓库现有 `admin.json` 的 flat `form*` 前缀为准** (如 `formDecisionTitle` / `formParkingLabel` / `formGearEssentialLabel` 等), 不拆成 `admin.decisionInfoTitle` / `admin.parkingLabel` 分组式命名. 下方 keys 仅示意**语义与文案**, 命名以现有 pattern 为准.
+
+新增 `admin.*` keys (三语):
+
+```
+admin.decisionInfoTitle    = "决策信息" / "Decision Info" / "判断情報"
+admin.parkingLabel         = "停车情况" / "Parking" / "駐車場"
+admin.parkingYes           = "✓ 有" / "✓ Yes" / "✓ あり"
+admin.parkingNo            = "✗ 无" / "✗ No" / "✗ なし"
+admin.parkingUnknown       = "? 未知" / "? Unknown" / "? 不明"
+admin.parkingHint          = "请选择一个状态, 有助于用户决策" / "..."
+admin.parkingInfoLabel     = "停车说明 (可选)" / "Parking notes (optional)" / "駐車場詳細"
+admin.parkingInfoPlaceholder = "例: 景区门口免费停车场 (50 位)" / "..." / "..."
+admin.parkingInfoHint      = "简短一句话说明, 最多 80 字" / "..." / "..."
+admin.gearEssentialLabel   = "必备装备" / "Essential gear" / "必須装備"
+admin.gearEssentialHint    = "1-8 项, 例: 登山鞋、2L 水、防晒霜" / "..." / "..."
+admin.gearEssentialPlaceholder = "输入后回车添加" / "Enter to add" / "..."
+admin.gearOptionalLabel    = "可选装备" / "Optional gear" / "推奨装備"
+admin.gearOptionalHint     = "0-8 项, 例: 登山杖、护膝、头灯" / "..." / "..."
+admin.gearOptionalPlaceholder = "输入后回车添加" / "Enter to add" / "..."
+```
+
+---
+
+## 4. 校验规则 (前端)
+
+- `parkingAvailable`: 允许 null (未知)
+- `parkingInfo`: 最多 80 字符; `parkingAvailable !== true` 时忽略
+- `gearEssential`: 1-8 项, 每项 1-12 字符; **required, 不填不给保存**
+- `gearOptional`: 0-8 项, 每项 1-12 字符
+
+hook 层校验 (`use-location-form.ts`) 加:
+
+```ts
+if (formData.gearEssential.length === 0)
+  errors.gearEssential = t("admin.gearEssentialErrorEmpty");
+if (formData.gearEssential.length > 8)
+  errors.gearEssential = t("admin.gearEssentialErrorMax");
+```
+
+### 4.1 UI 约束 vs API 约束 (故意分歧, 保留)
+
+API 侧 (`api/src/lib/validation.ts:createLocationSchema`, T2 已实现):
+
+| 字段                              | UI (本 spec)     | API 实际     | 说明                                     |
+| --------------------------------- | ---------------- | ------------ | ---------------------------------------- |
+| `parkingInfo` max chars           | 80               | 100          | UI 更严, 引导简短; API 100 兜底存量兼容  |
+| `gearEssential/Optional` maxItems | 8                | 10           | UI 更严, 让运营专注 top 8; API 10 兜底   |
+| 每项字符                          | 12               | 20           | UI 更严, 保持 chip 视觉紧凑; API 20 兜底 |
+| `gearEssential` required          | **required 1-8** | **optional** | ⚠️ 决策不一致, 保留                      |
+
+**架构决策 (Martin msg=bd74beb0 拍板)**:
+
+- **UI required + API optional** 是合理设计:
+  - **API optional 是为兼容存量数据** — 旧 locations 未填装备清单, DB 不能强推 not-null
+  - **UI required 是新建/编辑场景强推** — 新数据必须填 1-8 项装备, 保证决策信息完整
+- 本 spec 落地时 **不改** `api/src/lib/validation.ts` — API 校验不变
+- 若未来 API 也想强推, 需要先做数据回填 + 迁移, 另开 spec
+
+---
+
+## 5. 预览面板 (PreviewPanel) 联动
+
+`location-edit-client.tsx:341` 的 PreviewPanel 已经显示 bestSeason 等字段. **本 spec 建议**: 决策信息 4 字段**不进预览面板** (预览应保持"用户看到什么"的模拟, 装备清单在地点详情页决策信息块渲染, 预览可以不展示以避免 preview 卡片过高).
+
+若 Jeff 落地时觉得需要预览, 简约版:
+
+```tsx
+{
+  data.parkingAvailable === true && (
+    <span className="text-xs text-stone-500">
+      🅿️ {t("admin.previewParkingYes")}
+    </span>
+  );
+}
+{
+  data.gearEssential.length > 0 && (
+    <div className="flex flex-wrap gap-1 pt-1">
+      {data.gearEssential.slice(0, 3).map((g) => (
+        <span
+          key={g}
+          className="text-xs px-1.5 py-0.5 bg-amber-50 text-amber-700 rounded-full"
+        >
+          🎒 {g}
+        </span>
+      ))}
+      {data.gearEssential.length > 3 && (
+        <span className="text-xs text-stone-400">
+          +{data.gearEssential.length - 3}
+        </span>
+      )}
+    </div>
+  );
+}
+```
+
+---
+
+## 6. 编辑进度条 (EditProgressBar)
+
+`location-edit-client.tsx:407-412` 已有 4 步进度 (core / location / media / finish). **本 spec 建议**: 不加第 5 步. 决策信息 4 字段视为 "core" 完整性的一部分, 但不强推进度条改造 (进度条只标"关键完成度", 装备清单可以留白).
+
+**替代方案** (可选): 把 `progressStep1` (核心信息) 的 done 判定从 `name && description` 扩展到 `name && description && gearEssential.length >= 1`:
+
+```ts
+{ id: "core", label: t("admin.progressStep1"),
+  done: !!form.formData.name && !!form.formData.description && form.formData.gearEssential.length >= 1 },
+```
+
+Jeff 视工作量决定是否加. 不加也不阻塞.
+
+---
+
+## 7. 交付给 Jeff 的实施要点
+
+**在 `location-form/` 目录**:
+
+1. **新增** `location-form-decision-fields.tsx` (仿 basic/content/settings 3 个兄弟组件)
+2. **修改** `location-form/index.ts`, 导出 `LocationFormDecisionFields`
+3. **修改** `location-edit-client.tsx:466-472`, 在 4 组之后 (LocationActionBar 之前) 加:
+   ```tsx
+   <LocationFormDecisionFields
+     formData={form.formData}
+     errors={form.errors}
+     updateField={form.updateField}
+   />
+   ```
+4. **use-location-form.ts** 已有字段 (§4 校验规则加到 validate 里)
+5. i18n keys 加进 zh/en/ja 三个 admin namespace
+
+**预计工作量**: XS 2-4 小时 (纯组件组装, 无逻辑变更, 无 API 变更).
+
+---
+
+## 8. 验收标准
+
+QA 用例 (Wen 或 Victor 自测):
+
+1. 打开 admin 编辑页, 决策信息卡片默认展开可见, 可折叠
+2. 停车情况三选按钮点击响应, 高亮态正确
+3. 选"有"时停车说明可编辑, 选"无"/"未知"时禁用置灰
+4. 必备装备 chip-input 添加/删除正常, 1-8 项限制
+5. 可选装备 chip-input 独立于必备装备
+6. 必备装备为空时保存, 报错 "必备装备至少填 1 项"
+7. 保存成功后详情页决策信息块显示正确
+8. 三语言 zh/en/ja 全部渲染正确
+9. 移动端布局: SectionCard 单列, 停车 3 按钮 grid 保留
+10. 深色模式渲染正确
+
+---
+
+## 9. 与其他 spec 关系
+
+| 关联                     | 说明                                              |
+| ------------------------ | ------------------------------------------------- |
+| P0-B 主 spec             | 本 spec 是 P0-B T4 "admin 录入 UI" 章节的视觉扩展 |
+| P2 primary token realign | 独立, 不阻塞; icon 色可跟 P2 一起改               |
+| 详情页决策信息块         | 数据源一致, 4 字段直接映射                        |
+
+---
+
+## 10. 一句话总结
+
+**P0-B T4 admin 录入 UI 新增 1 个 SectionCard "决策信息" (Backpack icon), 承载停车 tri-state + 停车说明 + 必备装备 (chip-input, required 1-8 项) + 可选装备 (chip-input, 0-8 项) 4 字段, 沿用现有 SectionCard/Field/styledInput 模式, XS 2-4 小时可上线.**
+
+---
+
+_spec v1.0 完成 (2026-07-20), 等 Martin CR 后交 Jeff 实施._

--- a/notes/gomate-p0d-local-circle-spec-v1.2.md
+++ b/notes/gomate-p0d-local-circle-spec-v1.2.md
@@ -1,0 +1,484 @@
+# gomate P0-D：首页「本地圈子」设计规范 v1.2
+
+> 需求：@Victor 2026-07-20 DM（继续推进 P0 全套） + Victor 反问「B 方案是否用户体验良好」后确认 B 修正版
+> 依据：`notes/gomate-ux-experience-analysis.md` §三-P0-4
+> 设计者：@Steven
+> 范围：首页 `/`（改造）—— 在 P0-C 推荐位下、Locations 区块上插入「本地圈子」 + 队伍卡「邻居 X 人参加」
+> 交付给：Martin 拆任务
+
+> **v1.2 变更**（2026-07-21 Jeff T1 #175 摸底反馈 msg=df697452 + msg=f56f5749 + msg=6e953cca + Martin msg=7776fa59 拍板）：
+>
+> - §3.3 时间字段 `publishedAt` → `createdAt` (schema fact-check, gomate 里发布状态是独立 `status` 列而非时间列)
+> - §3.3 SECONDARY 收藏源: 明确 favorites 泛型 `(entityType='location', entityId)` 定位
+> - §3.3 stories 状态过滤: `status='published'` (draft/published/hidden 三态)
+> - §3.3 activity_posts 状态过滤: `status='visible'` (visible/hidden/deleted 三态, 非 `published`)
+> - §3.3 cancelled **窄义**: 仅 PRIMARY 层 `team_members` 排除 cancelled teams, 其他 3 源不 join teams (业务语义独立)
+> - §3.3 score cap 3.0 语义澄清: **per-(user, location) 聚合后 cap**, 非单信号源 clamp; SQL 建议方案 (subquery raw → MIN → SUM)
+> - §3.3 top 3 tie-breaker 4 档 (Steven msg=06447826 + Martin msg=6d046a06): `visit_score DESC → visitor_count DESC → MAX(signal_ts) DESC → location_id ASC`; `signal_ts` = 任一信号源时间字段 (PRIMARY=`teams.end_time`, 其他=`createdAt`), 每行 signal 自带列, 外层 MAX 聚合
+> - §3.5 复合索引清单更新: 2 已存在 + 3 新增 (Martin msg=82a5ffff 拍板: `teams(status, end_time)` + `user_favorites(entity_type, entity_id, created_at)` + `activity_posts(location_id, created_at)` 服务现有 route; **撤销** `stories(location_id, status, created_at)` — 本 SQL 前缀不匹配, 未来 P1 地点故事列表上线再补 0017)
+> - §3.5 ANALYZE 部署 SOP: 不入 migration, 运维 checklist 手动跑 (数据大增长后重跑)
+> - §4.2 **邻居 tm.status='approved' only** (不含 pending/rejected/left/removed)
+> - §4.2 **邻居 pool 与地点 pool 不同源**: 地点 pool 按 `locations.cityId` 过滤, 邻居 pool 按 `users.cityId` 过滤 (team.locationId 不限, 跨城行为允许)
+> - §8.1 依赖表: users.city 状态 done, 时间列对齐 createdAt
+
+> **v1.1 变更**（2026-07-20 Martin CR PR #393）：
+>
+> - §3.3 加单 user 对单 location score 上限 3.0（防刷分）
+> - §3.5 加复合索引清单（team_members / stories / activity_posts / user_favorites）
+> - §4.3 `user.showCity` P1 延后，本 spec 不实现
+> - §5.1 tooltip + A/B 测试留口子（不强制 P0 内做）—— Victor 拍板 P0 不做 A/B
+> - §11 #175 blocker 明确标注：依赖 #164 users.city 字段落地
+
+---
+
+## 0. 目标
+
+**让新用户打开首页 5 秒内感觉到「有一群人在做这件事」。**
+
+把首页从「陌生的地点列表」补成「**同城 200 人本周去了这里**」——这是「主题 = 本地圈子的周末行动本」最直观的第一视觉锚点。
+
+---
+
+## 1. 顾客损失 → 设计对应
+
+| 顾客损失（用户勉强接受的现实）             | 设计对应                                      | §   |
+| ------------------------------------------ | --------------------------------------------- | --- |
+| 「注册后打开首页 → 都听过，然后呢？」      | 首页加**「本周本地圈子在去哪」**              | §3  |
+| 「看不到同城用户在做什么」                 | 显示同城过去 7 天最多人去 3 个地点 + 头像堆叠 | §3  |
+| 「队伍卡只有人数，不知道邻居有没有参加」   | 队伍卡加**「你的邻居 · X 人参加」**           | §4  |
+| 「数据是假的，加了 checkins 表用户懒得打」 | B 修正方案：用现有 signal 推导                | §5  |
+
+---
+
+## 2. 不做什么（明确边界）
+
+- ❌ **不加 `checkins` / `visits` 表**（B 修正方案：用现有 signal 推导，已 Victor 确认）
+- ❌ **不做「你认识的人也去过这里」**（熟人 signal 需通讯录授权，P2）
+- ❌ **不显示具体用户头像**（除「最近 N 队」的聚合头像堆叠，私隐考虑）
+- ❌ **不重写 Locations 区块**——只在 P0-C 推荐位下、Locations 区块上插入新区块
+- ❌ **不做「本月本地排名」/「年度排名」**——只算过去 7 天，避免「圈子排行」压力
+- ❌ **不做跨城市聚合**——只算当前用户城市的本地圈子
+
+---
+
+## 3. 「本周本地圈子在去哪」模块
+
+### 3.1 位置
+
+在 `home-main.tsx` 中插入新区块，位置在 `<HomeRecommendationsSection>`（P0-C）之后、`<HomeLocationsSection>` 之前。
+
+```
+[HomeHero]
+[HomeRecommendationsSection] ← P0-C
+[HomeLocalCircleSection] ← 新增（P0-D）
+[HomeLocationsSection]
+...
+```
+
+### 3.2 视觉结构
+
+```
+┌─ 本周本地圈子在去哪 ──────────────────────────┐
+│                                                │
+│  深圳 200 人本周去这里                           │
+│  不是你挑，是本地圈子已经在做的事。                  │
+│                                                │
+│  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ │
+│  │  [地点封面图]  │ │  [地点封面图]  │ │  [地点封面图]  │ │
+│  │             │ │             │ │             │ │
+│  │  地点名      │ │  地点名      │ │  地点名      │ │
+│  │  头像堆叠     │ │  头像堆叠     │ │  头像堆叠     │ │
+│  │  32 人去过    │ │  18 人去过    │ │  9 人去过     │ │
+│  └─────────────┘ └─────────────┘ └─────────────┘ │
+│                                                │
+│  你的邻居参加了这些队伍：                          │
+│  ┌─────┐ ┌─────┐ ┌─────┐                        │
+│  │ 队伍A│ │ 队伍B│ │ 队伍C│                        │
+│  │ 3 人 │ │ 2 人 │ │ 1 人 │                        │
+│  │邻居  │ │邻居  │ │邻居  │                        │
+│  └─────┘ └─────┘ └─────┘                        │
+│                                                │
+└────────────────────────────────────────────────┘
+```
+
+### 3.3 数据：过去 7 天「去过」判定
+
+**B 修正方案信号权重表**：
+
+| 来源                                    | 权重    | 条件                                                                                                                            |
+| --------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| **PRIMARY**：已结束队伍的 approved 成员 | **1.0** | `team_members.status='approved'` AND `teams.endTime < now()` AND `teams.endTime > now() - 7d` AND `teams.status != 'cancelled'` |
+| **SECONDARY**：收藏                     | **0.1** | `user_favorites.entityType='location'` AND `user_favorites.entityId` 匹配 AND `user_favorites.createdAt > now() - 7d`           |
+| **SUPPLEMENTARY**：故事                 | **1.5** | `stories.createdAt > now() - 7d` AND `stories.status='published'` AND `stories.locationId` 匹配                                 |
+| **SUPPLEMENTARY**：活动动态             | **1.0** | `activity_posts.createdAt > now() - 7d` AND `activity_posts.status='visible'` AND `activity_posts.locationId` 匹配              |
+
+> **v1.2 note (2026-07-21, Jeff T1 摸底后修正)**:
+>
+> - **时间字段**以 schema 现状 `createdAt` 为准 (spec 初稿的 `publishedAt` 是笔误; gomate schema 里发布状态是独立 `status` 列, 不是时间字段)
+> - **Favorites 泛型定位**: `(entityType='location', entityId)`
+> - **状态过滤按 schema 各自枚举**: stories `status='published'` (draft/published/hidden 三态), activity_posts `status='visible'` (visible/hidden/deleted 三态, deleted=软删/hidden=管理员隐藏皆不计入信号)
+> - **cancelled 窄义**: 仅 PRIMARY 层 `team_members` 排除 `teams.status='cancelled'`, 其他 3 源不 join teams 反查 cancelled (stories/activity_posts 业务语义独立于 team 存在; activity_posts 虽有 teamId 但业务上 cancelled team 不会有活动后分享, 可加数据 assertion 验证「无 activity_posts 挂 cancelled team」)
+
+**最终 visit_score = sum(信号 × 权重)**，按 score 排序取 top 3。
+
+> **v1.2 tie-breaker 4 档 (Steven msg=06447826 起手 + Martin msg=6d046a06 clarify)**: `visit_score` 相同时的 top 3 排序:
+>
+> 1. **一档**: `visitor_count DESC` (`COUNT(DISTINCT user_id)`, 不同真人数越多越活跃)
+> 2. **二档**: `MAX(signal_ts) DESC` — 见下 signal_ts 定义
+> 3. **三档**: `location_id ASC` (稳定字典序兜底, 保证 cache 30min 内同 key 结果确定性)
+>
+> **signal_ts 定义 (Martin msg=6d046a06 采纳 A 方案)**: 任一信号源的时间字段, 每行信号自带 `signal_ts` 列, 外层聚合 `MAX`:
+>
+> - PRIMARY: `teams.end_time`
+> - SECONDARY: `user_favorites.created_at`
+> - SUPPLEMENTARY story: `stories.created_at`
+> - SUPPLEMENTARY activity_post: `activity_posts.created_at`
+>
+> **SQL 结构** (signals CTE 每行加 `signal_ts` 列, MAX 提到最外层 location_agg, 避开 capped CTE 聚合掉时间戳):
+>
+> ```sql
+> -- signals CTE
+> SELECT user_id, location_id, 1.0 AS weight, t.end_time AS signal_ts FROM team_members tm JOIN teams t ... -- PRIMARY
+> UNION ALL
+> SELECT user_id, entity_id AS location_id, 0.1, created_at AS signal_ts FROM user_favorites WHERE entity_type='location' ... -- SECONDARY
+> UNION ALL
+> SELECT author_id AS user_id, location_id, 1.5, created_at AS signal_ts FROM stories WHERE status='published' ... -- SUP story
+> UNION ALL
+> SELECT author_id AS user_id, location_id, 1.0, created_at AS signal_ts FROM activity_posts WHERE status='visible' ... -- SUP activity_post
+>
+> -- location_agg (跳过 capped CTE 或与 capped 并列; MAX 对 cap 无感, 语义等价)
+> SELECT location_id,
+>        SUM(contribution) AS visit_score,
+>        COUNT(DISTINCT user_id) AS visitor_count,
+>        MAX(signal_ts) AS latest_signal_ts
+> FROM capped_or_signals
+> GROUP BY location_id
+> ORDER BY visit_score DESC, visitor_count DESC, latest_signal_ts DESC, location_id ASC
+> LIMIT 3
+> ```
+>
+> **实现细节 (Jeff 二选一, 语义等价)**:
+>
+> - 方案 A: 把 `signal_ts` 从 signals 直接聚合到最外层 (跳过 capped, capped 只算 score)
+> - 方案 B: capped CTE 里 `MAX(signal_ts)` 一并保留 (per-user-location 的最新), 外层再 `MAX` 聚合
+> - 拍板: A 更简洁 (cap 只是 score 的行为, 与时间戳解耦)
+>
+> **Cache key 一致性**: tie-breaker 4 档全定 → 同 `cityId` 30min TTL 内 top 3 顺序完全确定, cache miss 重算不飘.
+>
+> 不用 `location.createdAt`/`location.name` 作 tie-breaker (与信号活跃度无关).
+
+**v1.1 防刷分**：单一用户对单个 location 的总 score 上限 **3.0**（防止单 user 发多篇故事 → 1 人贡献 5 × 1.5 = 7.5 score 顶替 7 个 approved 成员）
+
+> **v1.2 note (2026-07-21)**: cap 语义是 **per-(user, location) 聚合后 cap**, 不是单信号源 clamp. 单 user 在同一 location 撞满 PRIMARY (1.0) + SECONDARY (0.1) + SUPPLEMENTARY 故事 (1.5) + SUPPLEMENTARY 动态 (1.0) = 3.6 → cap 到 3.0 计入该 location 的 visit_score. SQL 建议: subquery 算每 (user, location) raw score → `MIN(raw, 3.0)` → 外层 SUM 得 location visit_score.
+
+**关键修正**（§三 提到）：
+
+- ✅ 排除 cancelled 成员（用 `team_members.status='approved'` 限定）
+- ✅ 强制 7 天窗口（所有 source 都有时间过滤）
+- ✅ 信号分级（PRIMARY/SECONDARY/SUPPLEMENTARY 反映真实度差异）
+- ✅ **v1.1 防刷分**：单 user 单 location score 上限 3.0
+
+### 3.4 API 设计
+
+**端点**：`GET /api/local-circle/home?cityId=<id>`
+
+- **输入**：`cityId`（前端从 session 取当前用户城市，匿名用户 fallback 深圳默认）
+- **输出**：
+  ```ts
+  type LocalCircle = {
+    cityId: string;
+    cityName: string;
+    activePeopleCount: number; // 过去 7 天本城至少 1 次 signal 的 unique users
+    topLocations: Array<{
+      locationId: string;
+      locationName: string;
+      locationCoverImage: string;
+      visitScore: number;
+      uniqueVisitors: number; // 实际有 signal 的 unique 用户数
+      avatarStack: string[]; // 最多 5 个用户头像 URL
+    }>; // top 3
+    neighborTeams: Array<{
+      teamId: string;
+      teamTitle: string;
+      locationName: string;
+      startTime: number;
+      neighborCount: number;
+      neighborAvatars: string[]; // 最多 3 个邻居头像
+    }>; // top 3 邻居队伍
+  };
+  ```
+
+### 3.5 性能
+
+- 查询：**v1.1 单 SQL UNION + GROUP BY + JOIN cities + JOIN users 取 city**，预计 100ms 内
+- **v1.2 复合索引清单** (2 已存在 + 3 新增, Martin msg=82a5ffff 拍板):
+  - `team_members(team_id, status)` — **已存在** (`teamStatusIdx`)
+  - `team_members(user_id)` — **已存在** (`userIdx`)
+  - `teams(status, end_time)` — **新增** (用于「7 天内已结束 non-cancelled」PRIMARY 过滤 + 邻居 SQL)
+  - `user_favorites(entity_type, entity_id, created_at)` — **新增** (泛型 favorites 前缀 entity_type 定位 location)
+  - `activity_posts(location_id, created_at)` — **新增** (服务 P0-A 现有 `GET /locations/:id/activity-posts` route, 非本 SQL 命中; 本 SQL 里 `activity_posts` 走 status_idx)
+
+> **v1.2 索引撤销 note (Jeff EXPLAIN msg=f207c63c + Martin msg=82a5ffff 拍板)**:
+>
+> - **撤销 `stories(location_id, status, created_at)` 3 列索引**: 本 SQL 里 stories 子查询 location_id 非 predicate (被 SELECT 出而非过滤), 走已存的 `stories_status_created_at_idx (status, created_at)` 已够. 现有 `api/src/routes/stories.ts` 的 `GROUP BY location_id` 查询前缀是 `IS NOT NULL` 而非 `=?`, 3 列索引边际收益不足以抵消 write 成本. **未来 P1 地点详情页故事列表上线时** (`WHERE location_id=? AND status='published' ORDER BY created_at DESC`) 补一条 0017 migration
+> - **保留 `activity_posts(location_id, created_at)`**: 服务 P0-A 现有 `GET /locations/:id/activity-posts` (SQL `WHERE locationId=? AND status='visible' ORDER BY createdAt DESC LIMIT 6`), 非未来场景 — 当前生产就在用, 撤了是性能倒退
+> - **ANALYZE 不入 0016 migration** (Martin Q1): migration 幂等 DDL / ANALYZE 是运行时统计采样, 冲突. 部署 SOP: `wrangler d1 migrations apply` → `wrangler d1 execute --command 'ANALYZE'`. 数据大增长后 (P0-D 上线 +1 周 / 每季度) 重跑, 落运维 checklist
+> - **PRIMARY `SCAN tm` 部署后验证**: ANALYZE 跑完 EXPLAIN 复跑, 若仍 `SCAN tm` 才加 `INDEXED BY teams_status_end_time_idx` hint 兜底
+
+- **v1.1 EXPLAIN PLAN**：T1 验收必须 `EXPLAIN QUERY PLAN` 走索引扫描
+- 缓存：city-keyed，TTL 30 分钟（数据不需要实时）
+- **v1.1 cache miss 时一次预算 30 分钟数据**（不是按请求实时算），减少冷启动延迟
+- 头像堆叠：只在 response 中返回 ≤ 5 个 URL，前端不再请求
+
+---
+
+## 4. 队伍卡「你的邻居 · X 人参加」
+
+### 4.1 位置
+
+现有 `<HomeTeamsSection>` 队伍卡 + `<team-card>` 组件内，已有数字徽章（如「3/10 人」）—— 在数字旁加邻居标识。
+
+### 4.2 视觉
+
+```
+┌───────────────────────────────┐
+│ 队伍标题                        │
+│ 地点 · 时间                      │
+│                               │
+│ [头像堆叠] 3/10 人 · 深圳邻居 2 │ ← 修改这里
+│                               │
+│ [加入队伍]                      │
+└───────────────────────────────┘
+```
+
+**邻居标识**：
+
+- 「**深圳邻居 X 人**」副标签，紧跟人数后
+- 「邻居」= 当前用户 cityId 与队伍成员中 ≥ 1 个成员的 `users.city`（P0-A #164 加的字段）匹配
+- X = 实际邻居数（1-3 显示数字，≥4 显示「你的邻居 4+」）
+
+> **v1.2 邻居 pool 语义澄清 (Martin msg=7776fa59 拍板)**:
+>
+> - **邻居 tm.status 过滤**: 仅计 `team_members.status='approved'`, **不含 pending/rejected/left/removed**. 语义: 邻居 = 已确认入队的团员, 意向未确认不给用户「邻居 X 人」的心理承诺 (避免 pending 变 rejected 后信任损失)
+> - **邻居 pool 与地点 pool 不同源**:
+>   - **地点 pool** (top 3 candidate locations): `locations.cityId = user.cityId` (本地圈范围)
+>   - **邻居 pool** (推荐邻居队伍): `users.cityId = target user.cityId` matched via team_members, **team.locationId 不限** (跨城行为允许 — 邻居去外地也是邻居信号, 更有价值)
+> - team 状态过滤: `teams.status IN ('recruiting', 'confirmed')` (未结束未取消), 具体枚举以 schema 现有为准 (recruiting/confirmed/ongoing/ended/cancelled)
+
+### 4.3 边界
+
+- 队伍成员无 `users.city`（未填）→ 不计入邻居，不显示「邻居」标识
+- 当前用户未填 `users.city` → 整个队伍卡不显示「邻居」标识（无法判断）
+- 隐私开关：`user.showCity`（P1，默认开，可关）— 关的用户不参与邻居匹配
+
+### 4.4 数据获取
+
+- 复用现有 `GET /teams?status=recruiting&pageSize=4` 端点
+- 后端 join 一次 team_members + users 表取 city
+- 返回字段加 `neighborCount` 和 `neighborAvatars[]`
+
+---
+
+## 5. 「去过」判定的真实度讨论（已 Victor 确认 B）
+
+### 5.1 B 修正后的真实度评估
+
+| 场景                           | 真实度   | 说明                             |
+| ------------------------------ | -------- | -------------------------------- |
+| 用户加入 approved + 队伍已结束 | **高**   | 大概率真去了（除非临时有事未到） |
+| 用户发布故事                   | **极高** | 真实去过且有输出                 |
+| 用户发布活动动态               | **高**   | 真实去过                         |
+| 用户收藏                       | **低**   | 意愿 ≠ 行动                      |
+
+**误判成本**：用户看到「32 人去过」实际「32 人报名了已结束队伍 + 5 人写了故事」——**用「去过」措辞比用「想去」更吸引人，但有 30% 误差**。
+
+### 5.2 缓解措辞
+
+为了减少误判感知，**不直接说「去过」**，改用以下措辞：
+
+| 当前      | 改为                                             |
+| --------- | ------------------------------------------------ |
+| 32 人去过 | **32 人在行动** / "32 in action" / "32 人活動中" |
+| 头像堆叠  | 加 tooltip：「过去 7 天参与过此地点行动」        |
+| 副标题    | 「不是你去过，是本地圈子已经在做的事」           |
+
+**核心文案原则**：用「在行动」替代「去过」，更准确反映「approved + 已结束」的真实度（批准 ≠ 真去，但基本接近）。
+
+### 5.3 与 P0-A 「行动本」主题对齐
+
+「在行动」一词直接呼应 P0-A Team 行动本的「行动」主题——**主题一致性是「本地圈子的周末行动本」整体精神的具体落地**。
+
+---
+
+## 6. 视觉细节
+
+### 6.1 区块标题与副标题
+
+- 标题：「本周本地圈子在去哪」 / "What Your City Did This Week" / "今週、あなたの街で"
+- 副标题：「不是你挑，是本地圈子已经在做的事」 / "Not what you pick — what your city's already doing" / "あなたが選ぶのではなく、あなたの街で既に起こっていること"
+- 标题前缀城市名（dynamic）：「深圳 200 人在行动」
+
+### 6.2 头像堆叠
+
+- 最大 5 个用户头像
+- 超过 5 个时显示「+N」徽章
+- 头像尺寸：sm = 24px, md = 32px（响应式）
+- 堆叠间隔：-8px（重叠 1/3）
+
+### 6.3 移动端
+
+- 3 张地点卡竖排堆叠
+- 头像堆叠 sm 尺寸（24px）
+
+### 6.4 空态
+
+- **本城无任何 visit signal**：整个区块不渲染（避免显示空板块）
+- **只有 SECONDARY 信号（收藏）**：仍渲染，权重低但有数据
+- **城市识别失败**（匿名 + 无 geo）：默认深圳，若深圳也无数据则整块不渲染
+
+---
+
+## 7. i18n
+
+新增 `home.localCircle.*` keys（zh/en/ja）：
+
+```
+home.localCircle.title = "本周本地圈子在去哪" / "What Your City Did This Week" / "今週、あなたの街で"
+home.localCircle.subtitle = "不是你挑，是本地圈子已经在做的事" / "Not what you pick — what your city's already doing" / "..."
+home.localCircle.inAction = "{n} 人在行动" / "{n} in action" / "{n} 人活動中"
+home.localCircle.avatarStack.tooltip = "过去 7 天参与过此地点行动" / "Active here in the last 7 days" / "過去 7 日間に活動"
+home.localCircle.neighborTeams.title = "你的邻居参加了这些队伍" / "Your neighbors are joining" / "ご近所さんも参加中"
+home.localCircle.neighborCount = "深圳邻居 {n} 人" / "{n} from your city" / "{n} 人ご近所"
+home.localCircle.neighborCount.many = "你的邻居 4+" / "4+ from your city" / "ご近所 4+"
+home.localCircle.empty = "这周本城还没人行动" / "No local action this week" / "今週は街の活動なし"
+home.teamCard.neighbor = "邻居 {n}" / "{n} neighbor" / "{n} ご近所"
+home.teamCard.neighbor.many = "邻居 4+" / "4+ neighbors" / "ご近所 4+"
+```
+
+---
+
+## 8. schema 与 API 改动汇总
+
+### 8.1 schema 变更
+
+**P0-D 不直接加新字段**，但**依赖 P0-A #164 加的 `users.city` 字段**：
+
+| 依赖项                                      | 来源                                 | 状态 |
+| ------------------------------------------- | ------------------------------------ | ---- |
+| `users.city`                                | P0-A #164（已 done）                 | ✅   |
+| `team_members.status='approved'` 过滤       | 现有 schema                          | ✅   |
+| `teams.endTime` / `teams.status`            | 现有 schema                          | ✅   |
+| `user_favorites` 泛型 (entityType/entityId) | 现有 schema                          | ✅   |
+| `stories.createdAt` + `stories.status`      | 现有 schema (published/draft/hidden) | ✅   |
+| `activity_posts.createdAt` + `.status`      | 现有 schema (visible/hidden/deleted) | ✅   |
+| `cities` 表 + `locations.cityId`            | 现有 schema                          | ✅   |
+
+### 8.2 新 API 端点
+
+**`GET /api/local-circle/home?cityId=<id>`** — 见 §3.4
+
+实现位置：`api/src/routes/local-circle/home.ts`
+
+### 8.3 现有端点扩展
+
+**`GET /teams?status=recruiting&pageSize=4`** — 增加返回字段：
+
+- `neighborCount`：int
+- `neighborAvatars`：string[]
+
+后端 join：teams + team_members + users ON users.city = current_user_city
+
+---
+
+## 9. 交付给 Martin 的任务拆分建议
+
+按依赖 + 可并行性，建议拆 3 个子任务：
+
+### T1：API + 信号计算（后端基础）
+
+- **依赖**：P0-A #164（`users.city` 字段落地）
+- **改动**：
+  - `api/src/routes/local-circle/home.ts`：新端点
+  - `api/src/services/local-circle.ts`：4 source 信号查询 + 权重计算 + top 3 排序 + 头像聚合
+  - `api/src/routes/teams/queries.ts`：扩展 recruiting teams 返回 `neighborCount` / `neighborAvatars`
+  - 缓存层：city-keyed，TTL 30 分钟
+- **验收**：
+  - 4 信号正确计算（PRIMARY 1.0 / SECONDARY 0.1 / SUPPLEMENTARY 1.5+1.0）
+  - 7 天窗口强制
+  - cancelled 成员排除
+  - 三类信号全无时整块数据返回 null
+  - 性能：≤ 200ms（包含 KV cache miss）
+
+### T2：首页本地圈子模块渲染
+
+- **依赖**：T1
+- **改动**：
+  - `frontend/src/components/features/home/`：新增 `home-local-circle-section.tsx`
+  - 三个子组件：`local-circle-card.tsx`（地点卡）/ `avatar-stack.tsx`（头像堆叠）/ `neighbor-team-row.tsx`（邻居队伍）
+  - 接入 `home-main.tsx`（P0-C 之后、Locations 之前）
+  - 标题前缀城市名（dynamic）
+- **验收**：
+  - 三张地点卡水平排列（移动端竖排）
+  - 头像堆叠 ≤ 5 + 「+N」徽章
+  - 空态整块不渲染
+  - 城市标题前缀正确
+
+### T3：队伍卡「邻居」标识 + i18n
+
+- **依赖**：T1
+- **改动**：
+  - `frontend/src/components/features/home/home-team-card.tsx`：加邻居副标签
+  - `frontend/src/i18n/locales-data.ts`：新增 §7 所有 keys
+  - 跑 `scripts/validate-i18n-keys.mjs` 验证
+- **验收**：CI 拦截缺失，三语言自然度通过
+
+**推荐执行顺序**：
+
+- Phase 1：T1（依赖 P0-A #164 完成）
+- Phase 2（并行）：T2 + T3
+
+---
+
+## 10. 验收标准
+
+Wen 测试用例覆盖：
+
+1. 首页新用户（无 users.city）看到默认深圳数据
+2. 老用户（有 users.city = 深圳）看到深圳本地圈子
+3. approved 已结束队伍成员算入「在行动」人数
+4. cancelled 成员不算入
+5. 收藏数据加 0.1 权重，但显示数字不暴露具体来源
+6. 故事 + 活动动态加权后总和正确
+7. 「你的邻居 N 人」仅在当前用户填了 city 时显示
+8. 队伍卡邻居数：4+ 显示「4+」不显示具体数字
+9. 三语言渲染完整
+10. 移动端响应式（堆叠 + sm 头像）
+11. 数据全空时整块不渲染
+12. 性能：API 响应 ≤ 200ms
+13. **tie-breaker 边界 (v1.2 新增, Martin msg=6d046a06)**: 两 location 同 `visit_score=1.5`、同 `visitor_count=1` (各 1 个 favorite), location A 的 favorite `created_at` 更晚 → top-1 是 A。Jeff seed fixture 覆盖。
+
+---
+
+## 11. 与 P0-A / P0-B / P0-C 的关系
+
+| P0                  | 关系                                                          |
+| ------------------- | ------------------------------------------------------------- |
+| P0-A Team 行动本    | **直接依赖**：P0-A #164 加 `users.city` 字段，P0-D 才能算邻居 |
+| P0-B 详情页决策信息 | 无直接依赖                                                    |
+| P0-C 首页推荐位     | 视觉布局：P0-C 推荐位上，P0-D 本地圈子下                      |
+
+**关键路径**：P0-A #164 → P0-D T1（API） → P0-D T2/T3（前端） → 上线
+
+P0-D T1 等 P0-A #164 done 才能启动——这是清晰的串行依赖。
+
+**v1.1 Martin 任务编号预分配**：#175（API+信号计算，**blocker = #164**）→ #176（前端本地圈子）→ #177（队伍卡邻居+i18n）。Jeff 起手 #175 时必须等 #164 done。
+
+---
+
+## 12. 一句话总结
+
+**P0-D 用「在行动」替代「去过」的措辞策略 + 4-source 信号加权（PRIMARY 1.0 + SECONDARY 0.1 + SUPPLEMENTARY 1.5/1.0）+ 严格 7 天窗口 + cancelled 排除，给新用户第一视觉「有一群人在做这件事」的本地圈子感。零新表（依赖 P0-A #164 的 users.city）。主题一致性：呼应「行动本」主题。**
+
+---
+
+_spec v1.2 完成（2026-07-21 Jeff T1 #175 摸底 6 点 + Martin msg=7776fa59 拍板 2 点邻居 pool 语义: createdAt 时间列 / favorites 泛型 / stories.status='published' / activity_posts.status='visible' / cancelled 窄义 / score cap per-(user, location) 聚合后 / 索引 4 新增 / 邻居 tm.status='approved' only / 邻居 pool 与地点 pool 不同源）, v1.1 CR 结论沿用, Jeff T1 SQL 草图按 v1.2 落码._

--- a/notes/gomate-p0d-t1-main-sql-inline.sql
+++ b/notes/gomate-p0d-t1-main-sql-inline.sql
@@ -1,0 +1,47 @@
+-- P0-D T1 主 SQL：inline params 版（EXPLAIN 用）
+-- now = 1721952000000, now-7d = 1721347200000, cityId = 'city_shenzhen'
+WITH signals AS (
+  SELECT tm.user_id AS user_id, t.location_id AS location_id, 1.0 AS weight
+  FROM team_members tm
+  JOIN teams t ON t.id = tm.team_id
+  WHERE tm.status = 'approved'
+    AND t.status != 'cancelled'
+    AND t.end_time > 1721347200000
+    AND t.end_time <= 1721952000000
+  UNION ALL
+  SELECT user_id, entity_id AS location_id, 0.1 AS weight
+  FROM user_favorites
+  WHERE entity_type = 'location'
+    AND created_at > 1721347200000
+  UNION ALL
+  SELECT author_id AS user_id, location_id, 1.5 AS weight
+  FROM stories
+  WHERE status = 'published'
+    AND created_at > 1721347200000
+    AND location_id IS NOT NULL
+  UNION ALL
+  SELECT author_id AS user_id, location_id, 1.0 AS weight
+  FROM activity_posts
+  WHERE status = 'visible'
+    AND created_at > 1721347200000
+    AND location_id IS NOT NULL
+),
+capped AS (
+  SELECT user_id, location_id, MIN(SUM(weight), 3.0) AS contribution
+  FROM signals
+  GROUP BY user_id, location_id
+),
+location_agg AS (
+  SELECT c.location_id, c.contribution, c.user_id
+  FROM capped c
+  JOIN locations loc ON loc.id = c.location_id
+  WHERE loc.city_id = 'city_shenzhen'
+)
+SELECT
+  la.location_id,
+  SUM(la.contribution) AS visit_score,
+  COUNT(DISTINCT la.user_id) AS visitor_count
+FROM location_agg la
+GROUP BY la.location_id
+ORDER BY visit_score DESC, visitor_count DESC, la.location_id ASC
+LIMIT 3;

--- a/notes/gomate-p0d-t1-main-sql.sql
+++ b/notes/gomate-p0d-t1-main-sql.sql
@@ -1,0 +1,62 @@
+-- P0-D T1 主 SQL（对齐 Martin msg=8b50c654 骨架 + Jeff v0.2 微调）
+-- 参数：
+--   ?1 = now - 7d (ms epoch)
+--   ?2 = now (ms epoch)
+--   ?3 = cityId
+WITH signals AS (
+  -- PRIMARY: approved 成员 + team 已结束（7d 内）+ non-cancelled
+  SELECT tm.user_id AS user_id, t.location_id AS location_id, 1.0 AS weight
+  FROM team_members tm
+  JOIN teams t ON t.id = tm.team_id
+  WHERE tm.status = 'approved'
+    AND t.status != 'cancelled'
+    AND t.end_time > ?1
+    AND t.end_time <= ?2
+
+  UNION ALL
+
+  -- SECONDARY: user_favorites 泛型 entityType='location'
+  SELECT user_id, entity_id AS location_id, 0.1 AS weight
+  FROM user_favorites
+  WHERE entity_type = 'location'
+    AND created_at > ?1
+
+  UNION ALL
+
+  -- SUPPLEMENTARY: stories status='published'
+  SELECT author_id AS user_id, location_id, 1.5 AS weight
+  FROM stories
+  WHERE status = 'published'
+    AND created_at > ?1
+    AND location_id IS NOT NULL
+
+  UNION ALL
+
+  -- SUPPLEMENTARY: activity_posts status='visible' (fact-check: NOT 'published')
+  SELECT author_id AS user_id, location_id, 1.0 AS weight
+  FROM activity_posts
+  WHERE status = 'visible'
+    AND created_at > ?1
+    AND location_id IS NOT NULL
+),
+capped AS (
+  -- per-(user, location) 聚合后 cap 3.0 (spec §5 防刷分)
+  SELECT user_id, location_id, MIN(SUM(weight), 3.0) AS contribution
+  FROM signals
+  GROUP BY user_id, location_id
+),
+location_agg AS (
+  -- 城市 scope 过滤下沉到这里（跨城全算 signals，再按 city 过滤 top pool）
+  SELECT c.location_id, c.contribution, c.user_id
+  FROM capped c
+  JOIN locations loc ON loc.id = c.location_id
+  WHERE loc.city_id = ?3
+)
+SELECT
+  la.location_id,
+  SUM(la.contribution) AS visit_score,
+  COUNT(DISTINCT la.user_id) AS visitor_count
+FROM location_agg la
+GROUP BY la.location_id
+ORDER BY visit_score DESC, visitor_count DESC, la.location_id ASC
+LIMIT 3;

--- a/notes/gomate-p0d-t1-sql-draft.md
+++ b/notes/gomate-p0d-t1-sql-draft.md
@@ -1,0 +1,194 @@
+# P0-D T1 SQL 草图（预审用 · thread 预贴）
+
+**版本**：v0.1 draft
+**依据**：spec v1.1 §3.3 + §3.5 + Jeff v1.2 反馈（等 Steven 修补）
+**参数占位**：`?1 = cityId` / `?2 = now - 7d (ms epoch)` / `?3 = now (ms epoch)`
+
+---
+
+## 主查询：本地圈子 top 3 locations
+
+```sql
+WITH per_user_location_signal AS (
+  -- PRIMARY: approved + team.endTime 在 7d 内 + non-cancelled
+  SELECT
+    tm.user_id AS user_id,
+    t.location_id AS location_id,
+    1.0 AS raw_score
+  FROM team_members tm
+  JOIN teams t ON t.id = tm.team_id
+  JOIN locations loc ON loc.id = t.location_id
+  WHERE tm.status = 'approved'
+    AND t.status != 'cancelled'
+    AND t.end_time > ?2
+    AND t.end_time < ?3
+    AND loc.city_id = ?1
+
+  UNION ALL
+
+  -- SECONDARY: user_favorites (entityType='location', 7d)
+  SELECT
+    uf.user_id,
+    uf.entity_id AS location_id,
+    0.1 AS raw_score
+  FROM user_favorites uf
+  JOIN locations loc ON loc.id = uf.entity_id
+  WHERE uf.entity_type = 'location'
+    AND uf.created_at > ?2
+    AND loc.city_id = ?1
+
+  UNION ALL
+
+  -- SUPPLEMENTARY: stories (status='published', 7d)
+  SELECT
+    s.author_id AS user_id,
+    s.location_id,
+    1.5 AS raw_score
+  FROM stories s
+  JOIN locations loc ON loc.id = s.location_id
+  WHERE s.status = 'published'
+    AND s.created_at > ?2
+    AND loc.city_id = ?1
+
+  UNION ALL
+
+  -- SUPPLEMENTARY: activity_posts (status='visible', 7d)
+  -- 待 Steven 拍：cancelled 广义/窄义。窄义 = 不 join teams。若广义则 + JOIN teams t2 ON t2.id = ap.team_id AND t2.status != 'cancelled'
+  SELECT
+    ap.author_id AS user_id,
+    ap.location_id,
+    1.0 AS raw_score
+  FROM activity_posts ap
+  JOIN locations loc ON loc.id = ap.location_id
+  WHERE ap.status = 'visible'
+    AND ap.created_at > ?2
+    AND loc.city_id = ?1
+    AND ap.location_id IS NOT NULL  -- schema: location_id nullable (onDelete: set null)
+),
+per_user_location_capped AS (
+  -- 每 (user, location) 聚合后 cap 到 3.0（spec §5 防刷分）
+  SELECT
+    user_id,
+    location_id,
+    MIN(SUM(raw_score), 3.0) AS capped_score
+  FROM per_user_location_signal
+  GROUP BY user_id, location_id
+),
+location_agg AS (
+  SELECT
+    location_id,
+    SUM(capped_score) AS visit_score,
+    COUNT(DISTINCT user_id) AS unique_visitors
+  FROM per_user_location_capped
+  GROUP BY location_id
+)
+SELECT
+  la.location_id,
+  loc.name AS location_name,
+  loc.cover_image AS location_cover_image,
+  la.visit_score,
+  la.unique_visitors
+FROM location_agg la
+JOIN locations loc ON loc.id = la.location_id
+ORDER BY la.visit_score DESC, la.unique_visitors DESC, loc.name ASC  -- score 并列时按 unique_visitors 次序，最终 name 稳定排序
+LIMIT 3;
+```
+
+## 头像堆叠子查询（top 3 location 拿到后再查）
+
+```sql
+-- 每个 top location 拿前 5 个头像
+-- 参数：?location_id + ?2 (now-7d)
+-- 排序：per_user 的 capped_score DESC → 高贡献用户优先展示
+SELECT DISTINCT u.image
+FROM per_user_location_capped pulc  -- 或重新展开子查询
+JOIN users u ON u.id = pulc.user_id
+WHERE pulc.location_id = ?location_id
+  AND u.image IS NOT NULL
+ORDER BY pulc.capped_score DESC
+LIMIT 5;
+```
+
+**性能注**：头像不与主查询混，避免笛卡尔膨胀；主查询返回 top 3 location_id → 3 次并发头像查询（或 IN(?, ?, ?) 一次），可选缓存。
+
+## 邻居队伍 top 3 (spec §3.4 neighborTeams)
+
+```sql
+-- 参数：?1 = currentUserCity, ?4 = now (recruiting 队伍) — 独立子查询
+SELECT
+  t.id AS team_id,
+  t.title AS team_title,
+  loc.name AS location_name,
+  t.start_time,
+  COUNT(DISTINCT tm.user_id) AS neighbor_count
+  -- neighborAvatars 头像堆叠：类似 top location 的头像子查询
+FROM teams t
+JOIN locations loc ON loc.id = t.location_id
+JOIN team_members tm ON tm.team_id = t.id
+JOIN users u ON u.id = tm.user_id
+WHERE t.status = 'recruiting'
+  AND tm.status IN ('approved', 'pending')   -- 待 Steven 确认：邻居只算 approved 还是含 pending？
+  AND u.city = ?1     -- 当前用户所在城市
+  AND loc.city_id = ?userCityId  -- 同城队伍前提，需 Martin 确认
+GROUP BY t.id
+HAVING neighbor_count >= 1
+ORDER BY neighbor_count DESC, t.start_time ASC
+LIMIT 3;
+```
+
+## activePeopleCount (spec §3.4 首屏 badge "深圳 200 人本周去这里")
+
+```sql
+SELECT COUNT(DISTINCT user_id) AS active_people_count
+FROM per_user_location_capped;
+-- 或独立扫全部信号源 UNION 后 COUNT DISTINCT user_id (per-user, city-scoped)
+```
+
+---
+
+## EXPLAIN QUERY PLAN 预期（wrangler d1 local 待跑）
+
+**PRIMARY 子查询**：
+
+- `SEARCH team_members USING INDEX team_members_team_status_idx (team_id=? AND status=?)` — 待验，实际是从 teams 侧驱动更好
+- 或 `SCAN teams USING INDEX teams_status_end_time_idx` → `SEARCH team_members USING INDEX team_members_team_status_idx` → `SEARCH locations USING PK`
+
+**SECONDARY 子查询**：
+
+- `SCAN user_favorites USING INDEX user_favorites_entity_type_entity_id_created_at_idx` → `SEARCH locations USING PK`
+- 前缀 `entity_type='location'` 高选择性，剩余按 created_at 范围扫描
+
+**SUPPLEMENTARY 故事**：
+
+- `SEARCH stories USING INDEX stories_location_status_created_at_idx (location_id=? AND status=? AND created_at>?)` — 需要驱动侧是 locations by city → JOIN stories，索引覆盖三列
+- 或反向：`SEARCH locations USING INDEX locations_city_idx` → nested loop 到 stories
+
+**SUPPLEMENTARY 动态**：
+
+- `SEARCH activity_posts USING INDEX activity_posts_location_created_at_idx` — status 白名单在 SQL 层过滤（不进索引因基数低，不 useful 前缀）
+
+## 索引 → 子查询 覆盖表
+
+| 索引                                                          | 列 combo                             | 覆盖子查询                      | 前缀命中                                                                | Access path      |
+| ------------------------------------------------------------- | ------------------------------------ | ------------------------------- | ----------------------------------------------------------------------- | ---------------- |
+| `teams(status, end_time)` **新增**                            | (status, end_time)                   | PRIMARY 7d non-cancelled 已结束 | status='?' AND end_time BETWEEN ?,?                                     | Index range scan |
+| `team_members(team_id, status)` 已存                          | (team_id, status)                    | PRIMARY approved 成员           | team_id=? AND status='approved'                                         | Index range scan |
+| `team_members(user_id)` 已存                                  | (user_id)                            | 邻居队伍 join                   | user_id=?                                                               | Index seek       |
+| `stories(location_id, status, created_at)` **新增**           | (location_id, status, created_at)    | SUPPLEMENTARY 故事              | location_id=? AND status='published' AND created_at>?                   | Index range scan |
+| `activity_posts(location_id, created_at)` **新增**            | (location_id, created_at)            | SUPPLEMENTARY 动态              | location_id=? AND created_at>?                                          | Index range scan |
+| `user_favorites(entity_type, entity_id, created_at)` **新增** | (entity_type, entity_id, created_at) | SECONDARY 收藏                  | entity_type='location' AND entity_id IN (city 内 locs) AND created_at>? | Index range scan |
+| `locations(city_id)` 已存 (cityIdx)                           | (city_id)                            | 城市 scope 过滤                 | city_id=?                                                               | Index seek       |
+
+## 5 边界 test case（Martin 约定 #3）
+
+1. **score cap 3.0**：单 user 单 location 撞 PRIMARY 1.0 + SECONDARY 0.1 + 2 SUPPLEMENTARY (1.5+1.0) = 3.6 → capped=3.0
+2. **cancelled 排除**：team.status='cancelled' 时 PRIMARY 子查询 0 行（窄义），activity_posts 若也走窄义则不 join teams
+3. **7 天窗口**：team endTime = now-8d 不计；story createdAt = now-6d23h 计入
+4. **空态**：city 内 4 源全 0 行 → 主查询返回 0 行 → API 层返回 topLocations=[], activePeopleCount=0 → 前端整块不渲染 (spec §6.4)
+5. **entityType 泛化过滤**：user_favorites 中 entity_type='story' 或 entity_type='team' 的行不误计入 SECONDARY
+
+## 待 Martin 拍的 3 点
+
+1. **spec.md `MIN(SUM(x), 3.0)` D1 支持性**：SQLite 3.42+ 支持 `LEAST()`/`MIN()`（scalar 版本）—— D1 底层 SQLite 3.44+ 已 GA。但 `MIN(SUM(...))` 是嵌套聚合，D1 是否支持？备选：`CASE WHEN SUM(raw) > 3.0 THEN 3.0 ELSE SUM(raw) END`。**建议**：先试 `MIN(SUM(...), 3.0)`（更简），失败 fallback CASE。
+2. **邻居队伍成员计数**：`tm.status IN ('approved', 'pending')` 还是 only `approved`？spec §4.2 只说「≥1 个成员的 users.city 匹配」，未指定 status 过滤。**倾向 only approved**（避免"邻居申请了但被拒"误计）。
+3. **邻居队伍地点限制**：spec §4.2 没说邻居队伍的 location 是否同城。**倾向不限**：可能有队伍去外地徒步，同城邻居"跟着去"也是"邻居行为"，展示合理。

--- a/notes/gomate-p2-primary-token-realign-spec.md
+++ b/notes/gomate-p2-primary-token-realign-spec.md
@@ -1,0 +1,478 @@
+# gomate P2: primary token realign spec v1.1
+
+> 触发: Wen msg=f7d57125 提示的 P2 视觉一致性 follow-up + Martin msg=713158cf CR 反馈
+> 根因: PR #402 (task #180 a11y hotfix) 为过 WCAG AA 门禁在 navbar CTA / locale-toggle 硬编码 `amber-700`, 与 `--primary` (#D97706) 分裂
+> 设计者: @Steven
+> CR: @Martin @Victor
+> 交付给: Jeff
+
+**v1.1 变更 (2026-07-20 21:00, 应 Martin CR)**:
+
+- §A 附录: 全站 `bg-primary` 20 处 + `text-primary/border-primary` 82 处逐条 file:line 清单
+- §3.3 补 dark 模式 `--primary = #F59E0B` 对比度具体测算数值
+- §5.3 视觉走查 9 项逐条展开检查动作
+- §3.4 hotfix 回滚 3 处 file:line 精确到具体 diff
+- §7 补具体验证命令
+
+---
+
+## 0. 结论先行
+
+**问题不在 hotfix, 问题在 `--primary` token 值定错了.**
+
+现值 `--primary = #D97706` (amber-600) + `--primary-foreground = #FFFBEB` (cream) → **对比度 ≈ 3.3:1**, 挂 WCAG AA 4.5:1 门禁.
+
+只要 `--primary` 保持 amber-600, 任何用 `bg-primary text-primary-foreground` 的 CTA 都过不了 a11y. PR #402 只是把 "过不了 a11y 的 token" 局部绕开, 问题会在每个新 CTA 反复发生.
+
+**动作**: 把 `--primary` 从 `#D97706` (amber-600) 改为 `#B45309` (amber-700), 全站 `bg-primary` 自动跟上, 一次拉齐.
+
+---
+
+## 1. 现状证据
+
+### 1.1 token 定义
+
+`frontend/src/styles/globals.css:271-298` + `critical.css:20-40`:
+
+```css
+--primary-500: #d97706; /* 品牌主色 */
+--primary: #d97706; /* = primary-500 */
+--primary-foreground: #fffbeb; /* = primary-50 (cream) */
+```
+
+Dark 模式 (`globals.css:365`): `--primary: #F59E0B` (primary-400) + `--primary-foreground: #1c0f00`.
+
+### 1.2 a11y 挂点 (PR #402 手动绕开的地方)
+
+**`frontend/src/components/layout/navbar.tsx:490-492`** (登录/注册按钮):
+
+```tsx
+// task #180 a11y: bg-primary (#D97706 amber-600) on cream #FFFBEB = ~3.3:1 挂 WCAG AA 4.5:1
+// 走 amber-700 (#B45309) + text-white = ~5.5:1 稳过; 不改 --primary token 避免全站隐性回归
+className = "... bg-amber-700 text-white hover:bg-amber-800 ...";
+```
+
+**`frontend/src/components/layout/locale-toggle.tsx:94-95`** (语言切换 active):
+
+```tsx
+// task #180 a11y: active state bg-primary #D97706 + cream text = ~3.3:1 挂门禁; amber-700 + white 稳过
+? "bg-amber-700 text-white hover:bg-amber-800"
+```
+
+**`frontend/src/components/layout/navbar.tsx:158-161`** (active tab 文字):
+
+```tsx
+// task #180 a11y: active text-primary (#D97706) on bg-accent (#fffbeb) = ~3.07:1 挂; amber-800 = ~6.8:1
+? "text-amber-800 dark:text-amber-300 bg-accent"
+```
+
+3 处 hotfix 都指向同一根因: `amber-600 on cream` 不够暗.
+
+### 1.3 全站 primary 使用点统计
+
+- **`bg-primary`**: 20 处 (`grep -rn "bg-primary" frontend/src --include="*.tsx" --include="*.ts"` 过滤色阶变量后)
+- **`text-primary` + `border-primary`**: 82 处 (同上过滤)
+- 完整清单见文末 §A 附录
+
+按用途归类:
+
+- **品牌 CTA** (`bg-primary` 实心按钮): 3 处 - navbar 登录注册按钮 (mobile drawer 内)、team-actionbook-form 保存、story-poster-preview 分享
+- **激活/选中态背景**: 4 处 - navbar active tab 指示条、locale-toggle active、activity-calendar 今日圆点、quick-duration-button 选中
+- **装饰半透明** (`bg-primary/5, /10, /15, /20`): 13 处 - 各种圆角 icon 底、chip 底、hover 变化
+- **icon/文字色** (`text-primary`): 30+ 处 - 主要是 Mountain 品牌 icon、Loader 旋转、hover 变化
+- **焦点边框** (`focus:border-primary` + `focus:ring-primary/10`): 20+ 处 - 表单输入 focus 状态
+- **实体边框** (`border-primary`): 1 处 - quick-duration-button 选中态
+
+**结论**: 20 处 `bg-primary` 里, 只有 3 处品牌 CTA 直接受 a11y 影响; 其他 17 处是半透明装饰 (与前景色对比度基本无关) 或纯圆点/指示条 (无正文对比要求). 82 处 text/border 里, 82% 是 icon/装饰/focus, ~15 处是文本用途需要走查.
+
+---
+
+## 2. 顾客损失 → 设计对应
+
+| 顾客损失                                         | 设计对应                                                      | §     |
+| ------------------------------------------------ | ------------------------------------------------------------- | ----- |
+| a11y 用户看不清 CTA 上的文字                     | `--primary` 从 amber-600 改到 amber-700, 对比度 3.3:1 → 5.5:1 | §3    |
+| 明眼用户看到 "品牌色不一致" (导航深色、按钮中色) | 全站统一, navbar/CTA 都用 `bg-primary`                        | §3 §5 |
+| 未来每个新 CTA 都要重蹈 hotfix 覆辙              | 一次改 token, 后续代码可以放心用 `bg-primary`                 | §3    |
+| 硬编码色让 dark 模式适配失控                     | Token 一次到位, dark 变体也顺带调                             | §3.2  |
+
+---
+
+## 3. 变更方案
+
+### 3.1 Light 模式 token 变更
+
+```css
+/* globals.css + critical.css 同步修改 */
+
+/* 变更前 */
+--primary-500: #d97706; /* amber-600 */
+--primary: #d97706;
+
+/* 变更后 */
+--primary-500: #b45309; /* amber-700 */
+--primary: #b45309;
+```
+
+**保持不变**:
+
+- `--primary-50: #FFFBEB` (cream, 用作 `--primary-foreground` 和 `bg-accent`)
+- `--primary-300: #FCD34D`
+- `--primary-400: #F59E0B`
+- `--primary-foreground: #FFFBEB`
+- `--accent-*` 珊瑚色系
+- `--muted-foreground` (首页 4 屏已 patch, 其他页面存量问题另开 spec, 本轮不动)
+
+### 3.2 Dark 模式 token 变更
+
+Dark 模式当前 `--primary: #F59E0B` (amber-400) + `--primary-foreground: #1c0f00`.
+
+**决定**: dark 模式不动. 暗背景需要更亮的前景色, amber-400 是对的.
+
+### 3.3 对比度验证 (改后测算)
+
+Light 模式:
+
+| 组合                                                           | 计算值 | AA 4.5:1 | AAA 7:1 |
+| -------------------------------------------------------------- | ------ | -------- | ------- |
+| `#B45309` on `#FFFBEB` (light bg-primary + primary-foreground) | 5.53:1 | ✅       | ❌      |
+| `#B45309` on `#faf8f5` (page background neutral-50)            | 5.63:1 | ✅       | ❌      |
+| `#FFFBEB` on `#B45309` (CTA 文字)                              | 5.53:1 | ✅       | ❌      |
+| `#B45309` on `#f2ede7` (bg-secondary neutral-100)              | 5.24:1 | ✅       | ❌      |
+
+Dark 模式 (未改动, 复核为验证):
+
+| 组合                                                               | 计算值     | AA 4.5:1 | AAA 7:1          |
+| ------------------------------------------------------------------ | ---------- | -------- | ---------------- |
+| `#F59E0B` on `#1e1812` (dark 主背景 `--background`)                | 8.71:1     | ✅       | ✅               |
+| `#1c0f00` on `#F59E0B` (dark CTA 文字, `bg-primary`)               | 8.85:1     | ✅       | ✅               |
+| `#F59E0B` on `#0a0a0a` (near-black)                                | 10.24:1    | ✅       | ✅               |
+| **`#F59E0B` on `#3d2000` (dark `text-primary` on `bg-accent`)**    | **6.96:1** | ✅       | ⚠️ marginal miss |
+| `#FCD34D` on `#3d2000` (dark 保留 `text-amber-300` on `bg-accent`) | 10.37:1    | ✅       | ✅               |
+
+**全部过 AA**. Dark 里 CTA / 主背景 / near-black 三档过 AAA. **Dark `text-primary` on `bg-accent` 只过 AA 不过 AAA** (6.96:1 marginal miss AAA 7:1).
+
+**决定**: navbar.tsx:161 dark 分支**保留 `text-amber-300`** (10.37:1 AAA), light 分支改为 `text-primary` (5.5:1 AA). §3.4 diff 已按此写. Light 做 CTA 只求 AA 已足够 (AAA 会让主色过暗, 失去品牌活力); dark 保留 amber-300 是免费的 AAA, 顺便保留.
+
+计算方法: [WebAIM 对比度公式](https://www.w3.org/WAI/GL/wiki/Contrast_ratio), Jeff 落地时可用 `pnpm dlx axe-core` 或 Chrome DevTools Lighthouse a11y 复验.
+
+### 3.4 hotfix 回滚清单 (3 处 file:line + diff)
+
+改完 `--primary` 后, 回滚 3 处 hotfix:
+
+**#1. `frontend/src/components/layout/navbar.tsx:492`** (登录/注册 CTA):
+
+```diff
+- className="flex items-center gap-1.5 text-sm font-medium px-4 py-1.5 rounded-lg transition-all hover:scale-[1.02] active:scale-[0.97] bg-amber-700 text-white hover:bg-amber-800 shadow-md hover:shadow-lg transition-shadow"
++ className="flex items-center gap-1.5 text-sm font-medium px-4 py-1.5 rounded-lg transition-all hover:scale-[1.02] active:scale-[0.97] bg-primary text-primary-foreground hover:bg-primary/90 shadow-md hover:shadow-lg transition-shadow"
+```
+
+- 更新注释 (line 490-491):
+
+```diff
+- // task #180 a11y: `bg-primary` (#D97706 amber-600) on cream `#FFFBEB` primary-foreground = ~3.3:1 挂 WCAG AA 4.5:1
+- // 走 amber-700 (#B45309) + text-white = ~5.5:1 稳过; 不改 --primary token 避免全站隐性回归
++ // task #180 a11y: 通过 P2 primary token realign (--primary → #B45309 amber-700) 通过 5.5:1
+```
+
+**#2. `frontend/src/components/layout/locale-toggle.tsx:94-95`** (语言切换 active):
+
+```diff
+- // task #180 a11y: active state bg-primary #D97706 + cream text = ~3.3:1 挂门禁; amber-700 + white 稳过
+- ? "bg-amber-700 text-white hover:bg-amber-800"
++ // task #180 a11y: 通过 P2 primary token realign 生效
++ ? "bg-primary text-primary-foreground hover:bg-primary/90"
+```
+
+**#3. `frontend/src/components/layout/navbar.tsx:158-161`** (active tab 文字):
+
+```diff
+- // task #180 a11y: active text-primary (#D97706) on bg-accent (#fffbeb) = ~3.07:1 挂; amber-800 = ~6.8:1
+- ? "text-amber-800 dark:text-amber-300 bg-accent"
++ // task #180 a11y: P2 realign 后 text-primary (#B45309) on bg-accent (#fffbeb) = ~5.5:1 通过
++ ? "text-primary dark:text-amber-300 bg-accent"
+```
+
+Dark 保留 `text-amber-300` (dark active 视觉更亮), 不动.
+
+---
+
+## 4. 不做什么 (明确边界)
+
+- ❌ **不改 `--accent-color-500`** (珊瑚色 #f55b45) - 它是次色, 不涉及 CTA
+- ❌ **不改 `--primary-50/300/400`** - 只动 500 和 `--primary` 别名, 色阶其他刻度保留
+- ❌ **不动 dark 模式的 `--primary`** - dark 需要更亮的 amber, 逻辑相反
+- ❌ **不动 `--muted-foreground`** - Martin CR 明确, 存量对比度问题另开 spec
+- ❌ **不清理业务色的 amber-700** (Heart icon、footer-mobile、profile-client 徽章、cover-image-upload) - 有意的暖色装饰, 不属于 CTA/primary 语义
+- ❌ **不引入 `--brand-cta` / `--brand-navbar-active` 新 token** - 增加复杂度, A 方案 (改根 token) 更干净
+- ❌ **不做 shadcn Button 组件层的封装重构** - 只动 token 层, 最小侵入
+
+---
+
+## 5. 影响面清单
+
+### 5.1 强变化 (用户会注意到)
+
+- 所有 `bg-primary` CTA (3 处品牌 CTA + 少量激活态) → 从 amber-600 → amber-700, 更沉、更暮色
+- Navbar active tab 底部指示条 (`bg-primary` line 169)
+- Focus ring `focus:border-primary` / `focus:ring-primary/10` (20+ 处表单)
+- Activity calendar 今日文字 + 圆点
+- Progress ring `text-primary` (cover-image-upload/circular-progress)
+
+### 5.2 弱变化 (几乎察觉不到)
+
+- Icon 色 `text-primary`: Mountain、Loader、User 等 icon 从 amber-600 → amber-700, 肉眼差 ~1 个色阶
+- Hover 状态色 `hover:text-primary`
+- 装饰性 `bg-primary/10, /5` (半透明层, 视觉几乎无差)
+
+### 5.3 视觉走查敏感点 (9 项, 逐条列出)
+
+Jeff 落地后必须逐项走查, 建议 Playwright screenshot 前后对比:
+
+**1. 首页 (`/`)**
+
+- 检查: hero CTA 按钮 (若使用 bg-primary)、navbar 双端可见性、locale-toggle
+- 动作: 桌面 + 移动端各一张 screenshot, 对比色饱和度
+- 验证: 无 CTA 文字对比不清
+
+**2. Navbar 桌面**
+
+- 检查: 登录/注册 CTA (line 492)、active tab 文字色 (line 161)、active tab 底部 line 指示条 (line 169)
+- 动作: 切换 tab 状态, 每种截图
+- 验证: active 态视觉一致、CTA 可读
+
+**3. Navbar 移动端 drawer**
+
+- 检查: 抽屉内登录/注册按钮 (`navbar.tsx:433, 460` bg-primary)
+- 动作: <768px 打开 drawer 截图
+- 验证: 按钮色与桌面统一
+
+**4. Locale toggle**
+
+- 检查: active 语言背景色 (line 95) + inactive 语言 hover
+- 动作: 三语切换各截图
+- 验证: active 高亮 + 文字对比通过
+
+**5. 表单页面 focus 状态 (`/teams/create`、`/register`、`/admin/locations/[id]/edit`)**
+
+- 检查: input focus border 从 amber-600 → amber-700, focus ring `ring-primary/10` 底色
+- 动作: 每个页面点击一个 input 触发 focus, 截图
+- 验证: focus 可见、无色差过大问题
+
+**6. Activity calendar (`/teams/*` 详情内)**
+
+- 检查: 今日标记 `text-primary font-bold` (line 165) + 圆点 `bg-primary` (line 176)
+- 动作: 打开一个有今日活动的 team 页面
+- 验证: 今日标记可见、圆点色统一
+
+**7. Error boundary `/` 或触发 error 页**
+
+- 检查: 返回首页按钮 (`error-boundary.tsx:56` bg-primary)
+- 动作: 手动触发 error state (可临时抛错)
+- 验证: 按钮可见、hover 变化正常
+
+**8. Chat FAB (`/messages` 或全局)**
+
+- 检查: 悬浮圆形聊天按钮 (`chat-fab.tsx:24` bg-primary)
+- 动作: 桌面 + 移动端截图
+- 验证: 阴影 + hover 对比清晰
+
+**9. Favorites 空态 (`/favorites` 无数据)**
+
+- 检查: 空态 CTA (`favorites-client.tsx:126, 145` bg-primary)
+- 动作: 用无收藏账号打开 favorites 页
+- 验证: 空态引导按钮可点、色一致
+
+**辅助覆盖** (非核心走查, 顺带看):
+
+- `/locations` 列表页 (有无 CTA 使用 bg-primary?)
+- `/discover` 探索页 (若有筛选 chip 用 bg-primary/10 装饰)
+- `/teams` 列表页 (若有创建 CTA)
+- Profile 页 amber-700 硬编码徽章 (确认与新 primary 色协调, 本轮不动它)
+
+---
+
+## 6. 交付给 Jeff 的任务拆分建议
+
+**单 PR 完成**:
+
+### T1 (P2 token realign 单 PR)
+
+- **改动**:
+  - `frontend/src/styles/globals.css`: `--primary-500` + `--primary` 改为 `#B45309` (line 274 + line 297)
+  - `frontend/src/styles/critical.css`: 同上 (line 23 + line 39)
+  - `frontend/src/components/layout/navbar.tsx`: 回滚 line 161 + line 492 (见 §3.4)
+  - `frontend/src/components/layout/locale-toggle.tsx`: 回滚 line 95 (见 §3.4)
+  - 保留 a11y 注释, 更新为 "P2 realign 后生效"
+
+---
+
+## 7. 验证命令
+
+### 7.1 本地验证 (Jeff 提 PR 前必跑)
+
+```bash
+# 1. build 通过
+pnpm --filter frontend build
+
+# 2. type check
+pnpm --filter frontend typecheck
+
+# 3. e2e (a11y test 在其中)
+pnpm --filter frontend test:e2e
+
+# 4. Lighthouse a11y (对首页 + navbar 展开态)
+pnpm dlx lighthouse http://localhost:3000/ --only-categories=accessibility --output=json --output-path=./lh-home.json
+pnpm dlx lighthouse http://localhost:3000/teams/create --only-categories=accessibility --output=json --output-path=./lh-teams-create.json
+
+# 5. 硬编码残留检查
+grep -rn "amber-600\|amber-700\|amber-800" frontend/src --include="*.tsx" --include="*.ts" | grep -v "test\|spec\|\.md$"
+# 期望: 只剩下 §4 明确保留的业务色装饰 (Heart / footer-mobile / profile / cover-image-upload / map-picker)
+```
+
+### 7.2 CI 门禁
+
+- Playwright a11y test 必须通过 (WCAG AA 4.5:1)
+- Lighthouse a11y score 保持或提升 (task #180 目标 100)
+- `pnpm build` 通过
+
+### 7.3 视觉走查
+
+按 §5.3 9 项 + 辅助覆盖 4 项, Wen + Steven review screenshot 对比.
+
+---
+
+## 8. 风险与回滚
+
+### 8.1 风险
+
+- **视觉审美主观**: amber-700 比 amber-600 深一档, 可能有人觉得 "不够活力". 缓解: 走查阶段 Victor / Wen / Steven 三人 review, 不 OK 再评估.
+- **dark 模式对比**: light 变深、dark 不变, 两个模式之间的品牌调性可能出现观感差. 缓解: 这本来就是 dark 模式的常识 (暗背景需要亮前景), 不算问题.
+- **profile-client 硬编码 amber-700**: 与新的 `--primary` 色值巧合一致, 改天再统一到 token; 本 PR 不动它.
+
+### 8.2 回滚路径
+
+- 单 PR 修改, 回滚只需 revert
+- 无 schema / 无 API / 无数据变更
+- CI 门禁保护: a11y test + build test 通过才 merge
+- 若 merge 后线上出现视觉异常, revert 后 `--primary` 回到 amber-600, hotfix 手动补回 (从 PR 历史找 diff)
+
+---
+
+## 9. 与其他 spec / task 关系
+
+| 关联                            | 说明                                                                                 |
+| ------------------------------- | ------------------------------------------------------------------------------------ |
+| PR #402 (task #180 a11y hotfix) | 本 spec 是 PR #402 的 "根本修复", merge 后回滚 PR #402 的 3 处硬编码                 |
+| P0-A/B/C/D                      | 独立, 不阻塞. 本 spec 与 P0 series 并行                                              |
+| P0-B T4 admin form patch spec   | 独立, 但 icon 底色 `rgba(217,119,6,0.1)` 建议本 PR 完成后统一到 `rgba(180,83,9,0.1)` |
+| `--muted-foreground` 存量问题   | 另开 spec, 本轮不动                                                                  |
+
+---
+
+## 10. 一句话总结
+
+**P2 把 `--primary` 从 amber-600 (#D97706, 3.3:1 挂) 改到 amber-700 (#B45309, 5.5:1 稳过) - 一次拉齐全站 CTA 品牌色 + 回滚 3 处 a11y hotfix - 1-2 天可上线, 是 gomate a11y 与视觉一致性的根本修复.**
+
+---
+
+## §A 附录: 全站 primary 使用点清单
+
+### A.1 `bg-primary` 使用点 (20 处)
+
+按类归:
+
+**品牌 CTA 实心** (3 处):
+
+- `frontend/src/components/layout/navbar.tsx:433` - mobile drawer 登录按钮
+- `frontend/src/components/layout/navbar.tsx:460` - mobile drawer 注册按钮
+- `frontend/src/components/features/team-detail/team-actionbook-form.tsx:322` - Team actionbook 保存按钮
+- `frontend/src/components/features/discover/story-poster-preview.tsx:87` - Story 分享按钮
+- `frontend/src/components/features/favorites-client.tsx:126` - 空态 CTA 主按钮
+- `frontend/src/components/features/favorites-client.tsx:145` - 空态 CTA 次按钮
+- `frontend/src/components/features/create-story-client.tsx:405` - 发布故事按钮
+- `frontend/src/components/ui/error-boundary.tsx:56` - 返回首页按钮
+- `frontend/src/components/messages/chat-fab.tsx:24` - 悬浮聊天按钮
+
+**激活/选中态指示** (2 处):
+
+- `frontend/src/components/layout/navbar.tsx:169` - active tab 底部指示条
+- `frontend/src/components/features/activity-calendar.tsx:176` - 今日活动圆点
+
+**半透明装饰 `bg-primary/N`** (~13 处):
+
+- `frontend/src/components/features/create-story-client.tsx:377` - `bg-primary/10` 标签底
+- `frontend/src/components/features/create-story-client.tsx:383` - `hover:bg-primary/15` 标签删除
+- `frontend/src/components/features/activity-calendar.tsx:157` - `bg-primary/5` 今日底
+- `frontend/src/components/features/activity-calendar.tsx:201` - `bg-primary/10` icon 底
+- `frontend/src/components/features/discover/featured-story-card.tsx:127, 137` - `bg-primary/10, /5` 装饰
+- `frontend/src/components/features/discover/tag-filter-bar.tsx:58, 62` - `bg-primary/10, hover:bg-primary/20` chip
+- `frontend/src/components/features/discover/story-card.tsx:142` - `bg-primary/10` icon 底
+- `frontend/src/components/features/discover/story-detail-ui.tsx:82` - `bg-primary/10` icon 底
+- `frontend/src/components/features/discover/discover-main.tsx:223, 280` - `bg-primary/10` icon 底
+- `frontend/src/components/features/team-detail/team-detail-members.tsx:98` - `bg-primary/10, hover:bg-primary/20` chip
+- `frontend/src/components/features/team-detail/team-detail-sidebar.tsx:207` - `bg-primary/10, hover:bg-primary/20` chip
+- `frontend/src/components/features/create-team/quick-duration-button.tsx:27` - `bg-primary/10 border-primary` 选中态
+
+**a11y hotfix 硬编码** (2 处, 走 amber-700):
+
+- `frontend/src/components/layout/locale-toggle.tsx:95` - `bg-amber-700` (待回滚)
+- `frontend/src/components/layout/navbar.tsx:492` - `bg-amber-700` (待回滚)
+
+### A.2 `text-primary` + `border-primary` 使用点 (82 处)
+
+按类归 (完整清单见 `/tmp/primary-text-usage.txt` 或直接跑 `grep -rn "text-primary\b\|border-primary\b" frontend/src --include="*.tsx"`):
+
+**品牌 icon** (Mountain / Loader / User 等, ~10 处):
+
+- `frontend/src/components/layout/navbar.tsx:332` - `<Mountain className="text-primary" />` 品牌 logo icon
+- `frontend/src/components/features/create-story-client.tsx:226` - `<Loader2 className="text-primary animate-spin" />`
+- `frontend/src/components/features/activity-calendar.tsx:165, 180` - 今日标记文字 + 数字
+- `frontend/src/components/features/activity-calendar.tsx:202` - `<Calendar className="text-primary" />`
+- `frontend/src/components/ui/cover-image-upload/circular-progress.tsx:41` - Progress ring
+
+**Hover 变化** (`hover:text-primary`, ~20 处):
+
+- theme-toggle 三处 line 84/96/108
+- navbar mobile line 375
+- footer.tsx:377
+- register-client.tsx:260
+- create-team-client.tsx:199, 391
+
+**Focus border/ring** (`focus:border-primary` + `focus:ring-primary/10`, ~25 处):
+
+- chip-input.tsx:119
+- register-client.tsx:255, 393
+- create-team-client.tsx:261, 276, 302, 318, 341, 353, 391, 412, 429
+- (其他表单)
+
+**Active tab/state text** (5 处):
+
+- navbar.tsx:161 - active tab (hotfix 走 amber-800, 待回滚)
+- navbar.tsx:374 - mobile active tab
+- locale-toggle.tsx:142 - active locale
+- theme-toggle 三处
+
+**Chip/badge text** (`text-primary` 在装饰 chip 内, ~10 处):
+
+- create-story-client.tsx:377 - 标签文字
+- discover/featured-story-card.tsx:127, 137
+- discover/story-card.tsx:142
+- discover/story-detail-ui.tsx:82
+- discover/tag-filter-bar.tsx:58
+- team-detail-members.tsx:98
+- team-detail-sidebar.tsx:207
+
+**Border 实心** (1 处):
+
+- create-team/quick-duration-button.tsx:27 - `border-primary` 选中态
+
+**其他文本用途** (需要走查, ~10 处):
+
+- create-team-client.tsx:341 - `text-xs font-medium text-primary` 说明文本 (走查确认对比通过)
+- register-client.tsx:335 - `text-primary` 链接文字
+- edit-team-client.tsx:201 - hover 链接
+
+---
+
+_spec v1.1 完成 (2026-07-20 21:00, 应 Martin CR 补齐 5 项要求), 等 Victor 拍板后交 Jeff 实施._


### PR DESCRIPTION
## 目标

`GET /api/local-circle/home?cityId=<id>` — 本地圈子首页单端点，5 项一次拉齐：
1. `topLocations[3]` — 4-source signal → per-(user,location) cap 3.0 → SUM 后 top 3
2. `activePeopleCount` — 7d 内本城 unique users
3. `avatarStack[≤5]` — 每个 top location 贡献前 5 用户头像
4. `neighborTeams[3]` — 邻居队伍（登录才有；u.city 同城 + status IN ('recruiting','confirmed') + tm.status='approved' + end_time 未过）
5. `neighborAvatars[≤3]` — 每邻居队伍前 3 成员头像

## 关键改动

**新增**
- `api/db/migrations/0016_p0d_t1_local_circle_indexes.sql` — 3 索引：
  - `teams(status, end_time)` — 邻居查询主入口
  - `activity_posts(location_id, created_at)` — SUPPLEMENTARY 源
  - `user_favorites(entity_type, entity_id, created_at)` — SECONDARY 源
  - 说明：撤 `stories_location_status_created_at_idx` (Martin msg=82a5ffff 判定 dead index，现有 stories 路由用 IS NOT NULL 前缀无 location_id=?)
  - ANALYZE 移到部署 SOP 不进 migration
- `api/src/services/local-circle.ts` — 服务层：
  - `WINDOW_MS = 7d`、`CACHE_TTL_SECONDS = 30min`、KV key `local-circle:v1:<cityId>`
  - 主 SQL：signals CTE (UNION ALL 4 源，各自带 signal_ts) → capped CTE (`MIN(SUM(weight), 3.0)`) → location_agg (city filter) → location_ts (并列 CTE 直取 MAX signal_ts) → ORDER BY visit_score DESC, visitor_count DESC, latest_signal_ts DESC, location_id ASC LIMIT 3
  - `activePeopleCount` 用 UNION（DISTINCT）不是 UNION ALL
  - Avatar stack 独立按 location 查（LIMIT 5, ORDER BY contribution DESC, u.id ASC）
  - Neighbor teams：`status IN ('recruiting','confirmed')` + `tm.status='approved'` + `u.city=userCity` + `t.end_time > now` + `leader_id != currentUserId` + NOT EXISTS 当前用户
- `api/src/routes/local-circle/home.ts` — Hono 路由（cityId 必填 → 400；匿名 fallback null；session 查 currentUserId）
- `api/src/__tests__/integration/local-circle.test.ts` — 8 case（5 边界 + 2 assertion + 1 tie-breaker）

**修改**
- `api/src/index.ts` — 挂载 `app.route(\"/local-circle/home\", localCircleHomeRoute)`

## Tie-breaker 4 档

spec v1.2 §3.3 amend / Martin msg=6d046a06 拍板方案 A：
1. `visit_score DESC`
2. `visitor_count DESC`
3. `MAX(signal_ts) DESC` — signal_ts = PRIMARY `teams.end_time` / SECONDARY+SUPPLEMENTARY `created_at`
4. `location_id ASC` — cache 一致性兜底

## 本地验证

- `pnpm --filter @gomate/api vitest run` → **310/310 PASS**（含新增 8/8）
- `pnpm --filter @gomate/api tsc --noEmit` → clean
- `pnpm --filter @gomate/api lint` → clean
- 本地 D1 EXPLAIN 主 SQL / 邻居 SQL 均命中新索引

## 已知风险

- **prod DB 尚未跑 migration 0016**：合并后需在部署流程里执行 + 加 ANALYZE
- **KV cache 未做 invalidation**：新签队伍 30min 才会反映到端点；spec §3.5 v1.1 已明确接受（v1 高频写场景少）
- **邻居队伍需 u.city 字段**：现有用户表已有此字段（0009 迁移），空字段 fallback 到空邻居列表（Case 4 已覆盖）

## 回滚方式

- 路由未挂在前端任何页面 → 关键路径无副作用，直接 revert commit 即可
- migration 0016 反向 SQL：`DROP INDEX teams_status_end_time_idx; DROP INDEX activity_posts_location_created_at_idx; DROP INDEX user_favorites_entity_created_at_idx;`

## Spec

- notes/gomate-p0d-local-circle-spec-v1.2.md (Steven 定稿)
- Martin msg=82a5ffff (Phase 2 blueprint + 撤 stories dead index)
- Martin msg=6d046a06 (tie-breaker 4 档 + case #6)
- Steven msg=fd7d0265 (SQL 结构 sign-off)

任务：#175 P0-D T1