### PR TITLE
fix(#181): city 读取链路热修 — get-session + GET /users 双路透 city

### DIFF
--- a/api/src/__tests__/integration/users.test.ts
+++ b/api/src/__tests__/integration/users.test.ts
@@ -102,6 +102,23 @@ describe("用户 API 集成测试", () => {
       const data = await res.json() as { user: Record<string, unknown> };
       expect(data.user.wechat).toBe("my-wechat");
     });
+
+    /**
+     * 测试场景：task #181 热修 — GET /users?id= 透出 city（Wen 锚点 2 FAIL：
+     * 内联响应对象不消费 sanitizeUser，city 缺失致前端 fetchCurrentUser 拿不到）
+     */
+    it("获取用户信息 → 包含 city 字段（cityId）", async () => {
+      // Arrange
+      const user = await seedUser(testDb, { city: "test-city-id-456" });
+
+      // Act
+      const res = await req(app, `/users?id=${user.id}`);
+
+      // Assert
+      expect(res.status).toBe(200);
+      const data = await res.json() as { user: Record<string, unknown> };
+      expect(data.user.city).toBe("test-city-id-456");
+    });
   });
 
   describe("PATCH /users/update - 更新用户信息", () => {

--- a/api/src/lib/auth.ts
+++ b/api/src/lib/auth.ts
@@ -160,6 +160,8 @@ export function createAuth(env: Env) {
         gender: { type: "string", required: false },
         birthday: { type: "date", required: false },
         wechat: { type: "string", required: false },
+        // #181 热修（Wen 锚点 2 FAIL）：get-session 透 city（cityId），否则前端 fetchCurrentUser 合并后仍无 city
+        city: { type: "string", required: false },
         completedHikes: { type: "number", required: false, defaultValue: 0 },
         status: { type: "string", required: false, defaultValue: "active" },
         extra: { type: "string", required: false },

--- a/api/src/routes/users/queries.ts
+++ b/api/src/routes/users/queries.ts
@@ -37,6 +37,7 @@ queries.get("/", async (c) => {
         level: user.level || "beginner",
         completedHikes: user.completedHikes ?? 0,
         wechat: user.wechat, extra: user.extra,
+        city: user.city, // #181: cityId（防休眠 2.0，与 sanitizeUser 对称透出）
         role: user.role || "user", status: user.status,
         createdAt: user.createdAt,
         updatedAt: user.updatedAt,


### PR DESCRIPTION
## 背景

Wen staging 验收锚点 2/4 FAIL（msg=5f794012）：PR #408 只改了 `sanitizeUser`，但前端 `fetchCurrentUser` 实际消费 `/auth/get-session` + `/api/users?id=`（后者是内联响应对象，不消费 sanitizeUser）→ 两路均无 city。后果：profile 保存城市后刷新不回填；首页本地圈子永远 fallback 深圳。

Martin 决策 **A+B 对称补齐**（msg=e92f3f56），非只 A。

## 改动（3 文件，+20 行，无 schema/迁移）

- `api/src/lib/auth.ts`：`user.additionalFields` += `city`（`/auth/get-session` 透 city）
- `api/src/routes/users/queries.ts`：GET `/users?id=` 内联响应对象 += `city: user.city`（API 链路对称，未来任一消费方不再踩）
- `api/src/__tests__/integration/users.test.ts`：补 GET 透 city 用例

`sanitizeUser` 的 city 保留（第三处对称，harmless）。

## 验证

- api `tsc --noEmit` 0 errors；**317/317 tests PASS**（含新增 GET city 用例）

## 验收路径

@Wen 复跑锚点 2/4/R1 完整 UI 路径：保存城市 → 刷新回填 ✓ → 首页本地圈子切自己城市 → X 清空 → fallback 深圳。

关联 task #181。