### PR TITLE
feat(#183+#184): fetchCurrentUser memo + /local-circle/home KV SWR

### DIFF
--- a/api/src/__tests__/integration/local-circle.test.ts
+++ b/api/src/__tests__/integration/local-circle.test.ts
@@ -330,3 +330,93 @@ describe("local-circle route — GET /local-circle/home（cityId 缺省 fallback
     expect(res.status).toBe(400);
   });
 });
+
+// ==================== #184：KV cache SWR 复评 ====================
+describe("local-circle cache — #184 SWR（fresh 5min / stale 60min）", () => {
+  const NOW = 1_700_000_000_000;
+  const MIN = 60 * 1000;
+
+  /** Map 版 fake KV（仅实现本测试用到的 get/put） */
+  function fakeKv() {
+    const store = new Map<string, string>();
+    return {
+      store,
+      get: async (key: string) => store.get(key) ?? null,
+      put: async (key: string, value: string) => void store.set(key, value),
+    } as unknown as KVNamespace & { store: Map<string, string> };
+  }
+
+  function cachedEntry(cityId: string, storedAt: number, cityName = "缓存城") {
+    return JSON.stringify({
+      data: { cityId, cityName, activePeopleCount: 99, topLocations: [], neighborTeams: [] },
+      storedAt,
+    });
+  }
+
+  beforeEach(async () => {
+    const fresh = createTestDb();
+    testDb = fresh.db;
+  });
+
+  it("fresh 窗口内（<5min）→ 直接返回缓存，不重算", async () => {
+    const svc = await loadService();
+    const kv = fakeKv();
+    const city = await seedCity(testDb, { name: "深圳", adcode: "440300" });
+    kv.store.set(`local-circle:v2:${city.id}`, cachedEntry(city.id, NOW - 1 * MIN));
+
+    const result = await svc.getLocalCircleHome({ db: testDb as never, kv, cityId: city.id, now: NOW });
+
+    expect(result.cityName).toBe("缓存城"); // 缓存值而非 DB 值
+    expect(result.activePeopleCount).toBe(99);
+  });
+
+  it("stale 窗口（5~60min）+ waitUntil → 先返回 stale，后台重算回写新数据", async () => {
+    const svc = await loadService();
+    const kv = fakeKv();
+    const city = await seedCity(testDb, { name: "深圳", adcode: "440300" });
+    const key = `local-circle:v2:${city.id}`;
+    kv.store.set(key, cachedEntry(city.id, NOW - 10 * MIN));
+
+    const background: Promise<unknown>[] = [];
+    const result = await svc.getLocalCircleHome({
+      db: testDb as never, kv, cityId: city.id, now: NOW,
+      waitUntil: (p) => background.push(p),
+    });
+
+    // 先返回 stale 数据
+    expect(result.cityName).toBe("缓存城");
+    expect(background.length).toBe(1);
+
+    // 后台重算完成 → 缓存被刷新为 DB 实算值 + 新 storedAt
+    await Promise.all(background);
+    const refreshed = JSON.parse(kv.store.get(key)!) as { data: { cityName: string }; storedAt: number };
+    expect(refreshed.data.cityName).toBe("深圳");
+    expect(refreshed.storedAt).toBe(NOW);
+  });
+
+  it("stale 窗口但无 waitUntil → 同步重算返回新数据", async () => {
+    const svc = await loadService();
+    const kv = fakeKv();
+    const city = await seedCity(testDb, { name: "深圳", adcode: "440300" });
+    kv.store.set(`local-circle:v2:${city.id}`, cachedEntry(city.id, NOW - 10 * MIN));
+
+    const result = await svc.getLocalCircleHome({ db: testDb as never, kv, cityId: city.id, now: NOW });
+
+    expect(result.cityName).toBe("深圳"); // 实算而非 stale
+  });
+
+  it("cache miss → 同步实算 + 写入 SWR entry 格式 {data, storedAt}", async () => {
+    const svc = await loadService();
+    const kv = fakeKv();
+    const city = await seedCity(testDb, { name: "深圳", adcode: "440300" });
+
+    const result = await svc.getLocalCircleHome({ db: testDb as never, kv, cityId: city.id, now: NOW });
+
+    expect(result.cityName).toBe("深圳");
+    const written = JSON.parse(kv.store.get(`local-circle:v2:${city.id}`)!) as {
+      data: { cityName: string }; storedAt: number;
+    };
+    expect(written.data.cityName).toBe("深圳");
+    expect(written.storedAt).toBe(NOW);
+  });
+});

--- a/api/src/routes/local-circle/home.ts
+++ b/api/src/routes/local-circle/home.ts
@@ -62,6 +62,8 @@ home.get("/", async (c) => {
       kv: c.env.GOMATE_KV,
       cityId,
       currentUserId,
+      // #184：SWR 后台重算（stale 命中时返回旧数据 + 后台刷新）
+      waitUntil: (promise) => c.executionCtx.waitUntil(promise),
     });
 
     return c.json(result);

--- a/api/src/services/local-circle.ts
+++ b/api/src/services/local-circle.ts
@@ -17,7 +17,10 @@
  *   - SUPPLEMENTARY: activity_posts status='visible' 7d 内 location_id NOT NULL = 1.0
  *   - per-(user, location) cap 3.0 防刷分（spec §5.1 / SQL `MIN(SUM(w), 3.0)`）
  *
- * KV cache：key = `local-circle:v1:<cityId>` TTL 30min（spec §3.5 v1.1）
+ * KV cache（task #184 SWR 复评）：key = `local-circle:v2:<cityId>`
+ *   - fresh 窗口 5min 内直接命中；5min~60min 返回 stale + waitUntil 后台重算（SWR）
+ *   - 30min 无 invalidation 的 ghost card / 缓存自污染窗口从 30min 降到 5min
+ *   - 写路径失效被否：数据源 7 处分散写路径（teams CRUD / team_members / favorites / stories / activity_posts / PATCH city）≥6，部分失效的过期不对称比短 TTL 更难排查（Martin msg=b111422e 决策准则）
  *
  * 假设：D1 3.44+，`MIN(SUM(x), 3.0)` scalar 版本可用（已本地 EXPLAIN 验证）。
  */
@@ -33,11 +36,14 @@ import { logger } from "../lib/logger";
 /** 7 天窗口（毫秒） */
 const WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
-/** KV cache TTL（秒），30min */
-const CACHE_TTL_SECONDS = 30 * 60;
+/** #184：fresh 窗口（秒）—— 5min 内直接返回缓存 */
+const CACHE_FRESH_SECONDS = 5 * 60;
 
-/** KV key 前缀，含 v1 版本号方便未来无痛升级 */
-const CACHE_KEY_PREFIX = "local-circle:v1:";
+/** #184：KV 物理 TTL（秒）—— stale 服务窗口上限 60min，过期则同步重算 */
+const CACHE_STALE_SECONDS = 60 * 60;
+
+/** KV key 前缀（v2 = #184 SWR entry 格式 {data, storedAt}，v1 旧 key 30min 自然过期） */
+const CACHE_KEY_PREFIX = "local-circle:v2:";
 
 /** top locations 上限 */
 const TOP_LOCATIONS = 3;
@@ -87,29 +93,83 @@ export interface LocalCircleParams {
   currentUserId?: string | null;
   /** 时间基准（默认 Date.now()，测试注入用） */
   now?: number;
+  /** #184：SWR 后台重算调度（route 层传 c.executionCtx.waitUntil）；不传则 stale 时同步重算 */
+  waitUntil?: (promise: Promise<unknown>) => void;
+}
+
+/** #184：SWR cache entry 包装格式 */
+interface CacheEntry {
+  data: LocalCircle;
+  storedAt: number;
 }
 
 // ==================== 主入口 ====================
 
 export async function getLocalCircleHome(params: LocalCircleParams): Promise<LocalCircle> {
-  const { db, kv, cityId, currentUserId = null, now = Date.now() } = params;
-  const windowStart = now - WINDOW_MS;
+  const { kv, cityId, now = Date.now(), waitUntil } = params;
 
-  // ---- cache read ----
+  // ---- cache read（#184 SWR）----
   const cacheKey = `${CACHE_KEY_PREFIX}${cityId}`;
   if (kv) {
     try {
       const raw = await kv.get(cacheKey);
       if (raw) {
-        const cached = JSON.parse(raw) as LocalCircle;
-        // 邻居队伍是「按当前用户 city 关联」，city 相同的所有登录用户共享同一份邻居集合，
-        // 匿名用户也只 hide neighborTeams（前端根据是否登录决定渲染）—— 因此邻居数据依然可以走 cache。
-        return cached;
+        const entry = JSON.parse(raw) as CacheEntry;
+        const ageSeconds = (now - entry.storedAt) / 1000;
+        if (ageSeconds < CACHE_FRESH_SECONDS) {
+          // fresh 窗口内直接命中
+          return entry.data;
+        }
+        // stale 窗口：先返回旧数据（邻居集合同城共享，匿名 hide 由前端决定，stale 语义同 v1），
+        // 后台重算刷新（waitUntil 缺失时退化为同步重算）
+        if (waitUntil) {
+          waitUntil(
+            refreshLocalCircleCache(params, cacheKey).catch((err) =>
+              logger.warn("[local-circle] SWR refresh failed", err)
+            )
+          );
+          return entry.data;
+        }
+        // 无 waitUntil → 落到下方同步重算
       }
     } catch (err) {
       logger.warn("[local-circle] KV cache read failed", err);
     }
   }
+
+  const result = await computeLocalCircleHome(params);
+  await writeLocalCircleCache(kv, cacheKey, result, now);
+  return result;
+}
+
+/** #184：SWR 后台重算 —— 跳过 cache read 直算并回写（避免递归触发 SWR） */
+async function refreshLocalCircleCache(params: LocalCircleParams, cacheKey: string): Promise<void> {
+  const { kv, now = Date.now() } = params;
+  if (!kv) return;
+  const result = await computeLocalCircleHome(params);
+  await writeLocalCircleCache(kv, cacheKey, result, now);
+}
+
+async function writeLocalCircleCache(
+  kv: KVNamespace | null | undefined,
+  cacheKey: string,
+  result: LocalCircle,
+  now: number
+): Promise<void> {
+  if (!kv) return;
+  try {
+    const entry: CacheEntry = { data: result, storedAt: now };
+    await kv.put(cacheKey, JSON.stringify(entry), {
+      expirationTtl: CACHE_STALE_SECONDS,
+    });
+  } catch (err) {
+    logger.warn("[local-circle] KV cache write failed", err);
+  }
+}
+
+async function computeLocalCircleHome(params: LocalCircleParams): Promise<LocalCircle> {
+  const { db, cityId, currentUserId = null, now = Date.now() } = params;
+  const windowStart = now - WINDOW_MS;
 
   // ---- city name lookup ----
   const cityRow = await db
@@ -369,17 +429,6 @@ export async function getLocalCircleHome(params: LocalCircleParams): Promise<Loc
     neighborTeams,
   };
 
-  // ---- cache write ----
-  if (kv) {
-    try {
-      await kv.put(cacheKey, JSON.stringify(result), {
-        expirationTtl: CACHE_TTL_SECONDS,
-      });
-    } catch (err) {
-      logger.warn("[local-circle] KV cache write failed", err);
-    }
-  }
-
   return result;
 }
 
@@ -398,6 +447,7 @@ function emptyResult(cityId: string, cityName: string): LocalCircle {
 /** 仅测试用；生产不消费 */
 export const __test = {
   WINDOW_MS,
-  CACHE_TTL_SECONDS,
+  CACHE_FRESH_SECONDS,
+  CACHE_STALE_SECONDS,
   CACHE_KEY_PREFIX,
 };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -135,9 +135,18 @@ export async function apiDelete<T>(path: string): Promise<T> {
  * 1. /auth/get-session → 验证登录状态，取 userId
  * 2. /api/users?id=xxx → 直接读数据库，取最新字段
  *
+ * task #183：模块级 promise memo —— 同页并发 dedupe + 会话内复用。
+ * 首页 navbar + use-local-circle 同时调用时只打一轮 2 RTT（此前各打一轮，且
+ * local-circle 串行等其完成后才发请求，共 3 串行 RTT）。
+ * Astro MPA 整页刷新天然重置 memo，无跨页脏读面；
+ * profile 保存走 PATCH 后 location.replace 整页跳转，memo 同样重置（无同页脏读）。
+ * redirect 副作用在 memo 外层处理，缓存值保持纯净（不含跳转行为）。
+ *
  * @param redirectOnFail 未登录或出错时跳转的 URL，不传则静默返回 null
  */
-export async function fetchCurrentUser(redirectOnFail?: string): Promise<import("./types").SessionUser | null> {
+let currentUserMemo: Promise<import("./types").SessionUser | null> | null = null;
+
+async function loadCurrentUser(): Promise<import("./types").SessionUser | null> {
   try {
     const sessionRes = await fetchAPI("/auth/get-session");
     const sessionData = await sessionRes.json();
@@ -152,9 +161,16 @@ export async function fetchCurrentUser(redirectOnFail?: string): Promise<import(
       image: userData.user?.avatar ?? sessionData.user.image,
     };
   } catch {
-    if (redirectOnFail) window.location.href = redirectOnFail;
     return null;
   }
+}
+
+export function fetchCurrentUser(redirectOnFail?: string): Promise<import("./types").SessionUser | null> {
+  if (!currentUserMemo) currentUserMemo = loadCurrentUser();
+  return currentUserMemo.then((user) => {
+    if (!user && redirectOnFail) window.location.href = redirectOnFail;
+    return user;
+  });
 }
 
 /**


### PR DESCRIPTION
## 改动范围

P2 热修链，一个 PR 两个 commit（Martin 建议打包）：

- **task #183**（commit `8ebb0f1`）：`fetchCurrentUser` 模块级 promise memo —— 消首页串行瀑布
- **task #184**（commit `41a4e9c`）：`/local-circle/home` KV cache 策略复评 —— TTL 30min 直取 → SWR（fresh 5min / stale 60min）

### #183：fetchCurrentUser promise memo（`frontend/src/lib/api.ts`）

首页 navbar / local-circle / 其他 island 各自调 `fetchCurrentUser`，每次调用都是 get-session + /api/users 两步串行，模块间互相等待形成瀑布。

- 模块级 `currentUserMemo` 缓存首个 `loadCurrentUser()` promise，后续调用复用同一 promise
- 原两步请求逻辑原样移入 `loadCurrentUser`（catch → null，**不做跳转**）
- `redirectOnFail` 语义不变：在 memo promise 的 `.then` 侧处理，未登录才跳 —— 跳转决策不被 memo 污染（避免 A 处匿名跳转导致 B 处也跳）
- **安全性依据**：Astro MPA 整页加载即重置 module state，memo 生命周期 = 单页面会话，无跨页脏数据

### #184：/local-circle/home KV cache SWR（`api/src/services/local-circle.ts`）

**背景**：#175 上线时 KV TTL 30min 直取，Wen 验收实证两个事故级症状 —— 幽灵卡片（队伍解散后 30min 内仍展示）+ 缓存自污染（验收造的数据被缓存放大）。

**方案权衡**（Martin 判据：写路径失效 ≤4-5 条集中才可行）：

- 枚举实际写路径 7 条且分散：teams CRUD / team_members join·approve·leave / favorites / stories / activity_posts / PATCH city —— **≥6 条分散 → 放弃写路径失效，走短 TTL + SWR 单点**
- SWR 窗口：fresh 5min 内直接返回缓存；stale 5~60min 先返回 stale + `waitUntil` 后台重算回写；>60min / miss 同步重算
- 缓存 entry 格式升级为 `{ data, storedAt }`，key 前缀 bump 到 `local-circle:v2:`（旧 v1 key 自然过期，无需清理）
- `refreshLocalCircleCache` 跳缓存读取防递归；`computeLocalCircleHome` 抽离纯实算
- 最坏 stale 窗口 60min（TTL 内），但 fresh 窗口仅 5min —— 幽灵卡片可见期从 30min 降到 5min，且 stale 期用户看到的是旧数据但后台已在刷新

### 关键文件

- `frontend/src/lib/api.ts`（+18/-2）
- `api/src/services/local-circle.ts`（SWR 主逻辑）
- `api/src/routes/local-circle/home.ts`（注入 `c.executionCtx.waitUntil`）
- `api/src/__tests__/integration/local-circle.test.ts`（+4 SWR case）

## 本地验证

- `pnpm type-check`（api 含 tsconfig.scripts.json）✅
- `npx vitest run src/__tests__/integration/local-circle.test.ts` **16/16 PASS**（新增 4 case：fresh 直返 / stale+waitUntil 先返旧后台写新 / stale 无 waitUntil 同步重算 / miss 写 SWR 格式）
- 全量 `npx vitest run` **321/321 PASS**
- pre-push hook（type-check + lint）✅

## 风险与回滚

- 风险低：#183 纯前端 memo，行为等价（请求合并，响应一致）；#184 缓存 key bump v2，旧 key 自然过期
- 回滚：revert 两个 commit 即回 30min 直取 + 无 memo
- 不涉及 schema / migration / 环境变量

## 验收建议（@Wen）

staging：

1. 首页 DevTools Network：get-session + /api/users 各 **1 次**（memo 前 navbar + local-circle 各打一组）
2. local-circle 接口：5min 内重复刷新返回 X-Cache 一致数据；staging 造一个新队 → **≤5min** 首页可见（旧策略 30min）
3. 登录未设 city → 引导卡仍在（#185 回归）

关联：task #183、task #184（P2 热修链，随 #181 CR N1 + #175 缓存复评立项）
