### PR TITLE
feat(#186): approve 通过通知申请人 — applicationApproved 邮件链路

### DIFF
--- a/api/src/__tests__/integration/teams.test.ts
+++ b/api/src/__tests__/integration/teams.test.ts
@@ -24,6 +24,15 @@ vi.mock("../../db", () => ({
   createDb: (_d1: unknown) => testDb,
 }));
 
+// task #186：邮件发送器 mock（断言 approve 通知接线，避免依赖 Resend）
+const mockSendJoinApplication = vi.fn(async (..._args: unknown[]) => ({ success: true }));
+const mockSendApplicationApproved = vi.fn(async (..._args: unknown[]) => ({ success: true }));
+
+vi.mock("../../lib/email", () => ({
+  sendTeamJoinApplicationEmail: (...args: unknown[]) => mockSendJoinApplication(...args),
+  sendApplicationApprovedEmail: (...args: unknown[]) => mockSendApplicationApproved(...args),
+}));
+
 // 在 mock 之后导入路由
 const { teamsRoute } = await import("../../routes/teams");
 
@@ -61,6 +70,8 @@ describe("Teams API 集成测试", () => {
     testDb = fresh.db;
     app = createApp();
     currentSession = null;
+    mockSendJoinApplication.mockClear();
+    mockSendApplicationApproved.mockClear();
 
     leader = await seedUser(testDb, { name: "队长", wechat: "leader_wechat" });
     member = await seedUser(testDb, { name: "成员", wechat: "member_wechat" });
@@ -377,6 +388,46 @@ describe("Teams API 集成测试", () => {
   // ===== POST /teams/:id/members/:userId/approve - 批准申请 =====
   describe("POST /teams/:id/members/:userId/approve - 批准申请", () => {
     it("队长批准申请成功", async () => {
+      const team = await seedTeam(testDb, leader.id, location.id, { maxMembers: 5 });
+      await seedTeamMember(testDb, team.id, leader.id, "approved");
+      await seedTeamMember(testDb, team.id, member.id, "pending");
+      setSession({ id: leader.id, email: leader.email, name: leader.name });
+
+      const res = await req(app, `/teams/${team.id}/members/${member.id}/approve`, {
+        method: "POST",
+      });
+      expect(res.status).toBe(200);
+
+      const [membership] = await testDb.select().from(schema.teamMembers)
+        .where(and(eq(schema.teamMembers.teamId, team.id), eq(schema.teamMembers.userId, member.id)));
+      expect(membership.status).toBe("approved");
+    });
+
+    it("task #186：批准申请后异步通知申请人（sendApplicationApprovedEmail 被调用，payload 正确）", async () => {
+      const team = await seedTeam(testDb, leader.id, location.id, { maxMembers: 5 });
+      await seedTeamMember(testDb, team.id, leader.id, "approved");
+      await seedTeamMember(testDb, team.id, member.id, "pending");
+      setSession({ id: leader.id, email: leader.email, name: leader.name });
+
+      const res = await req(app, `/teams/${team.id}/members/${member.id}/approve`, {
+        method: "POST",
+      });
+      expect(res.status).toBe(200);
+
+      // 通知走 waitUntil 异步触发，waitFor 等 floating promise 落地
+      await vi.waitFor(() => expect(mockSendApplicationApproved).toHaveBeenCalledTimes(1));
+      const payload = mockSendApplicationApproved.mock.calls[0]![0] as Record<string, unknown>;
+      expect(payload).toMatchObject({
+        applicantEmail: member.email,
+        applicantName: member.name,
+        teamTitle: team.title,
+        locationName: location.name,
+        teamUrl: expect.stringContaining(`/teams/${team.id}`),
+      });
+    });
+
+    it("task #186：邮件发送失败不影响审批结果（通知 .catch 兜底）", async () => {
+      mockSendApplicationApproved.mockRejectedValueOnce(new Error("Resend down"));
       const team = await seedTeam(testDb, leader.id, location.id, { maxMembers: 5 });
       await seedTeamMember(testDb, team.id, leader.id, "approved");
       await seedTeamMember(testDb, team.id, member.id, "pending");

--- a/api/src/lib/email-i18n.ts
+++ b/api/src/lib/email-i18n.ts
@@ -9,7 +9,7 @@ import emailEn from "./locales/email.en.json";
 import emailJa from "./locales/email.ja.json";
 
 export type EmailLocale = "zh-CN" | "en" | "ja";
-export type EmailType = "passwordReset" | "welcome" | "contactForm" | "feedback" | "teamJoinApplication";
+export type EmailType = "passwordReset" | "welcome" | "contactForm" | "feedback" | "teamJoinApplication" | "applicationApproved";
 
 const EMAIL_TEMPLATES: Record<EmailLocale, Record<string, unknown>> = {
   "zh-CN": emailZhCn as unknown as Record<string, unknown>,

--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -199,6 +199,59 @@ export async function sendTeamJoinApplicationEmail(
 }
 
 /**
+ * 发送申请通过通知邮件给申请人（task #186）
+ */
+export async function sendApplicationApprovedEmail(
+  data: {
+    applicantEmail: string;
+    applicantName: string;
+    teamTitle: string;
+    locationName: string;
+    teamUrl: string;
+  },
+  env: { RESEND_API_KEY?: string; RESEND_FROM_EMAIL?: string },
+  locale: EmailLocale = "zh-CN",
+): Promise<{ success: boolean; error?: string }> {
+  const apiKey = env.RESEND_API_KEY;
+  if (!apiKey) return { success: false, error: "Email service not configured" };
+
+  try {
+    const resend = new Resend(apiKey);
+    const fromEmail = env.RESEND_FROM_EMAIL || "GoMate <noreply@gomate.live>";
+    const vars = {
+      applicantName: data.applicantName,
+      teamTitle: data.teamTitle,
+      locationName: data.locationName,
+    };
+
+    await withTimeout(
+      () => resend.emails.send({
+        from: fromEmail,
+        to: data.applicantEmail,
+        subject: getEmailField(locale, "applicationApproved", "subject", vars),
+        html: `
+          <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
+            <h2 style="color: #16a34a;">${getEmailField(locale, "applicationApproved", "title")}</h2>
+            <p>${getEmailField(locale, "applicationApproved", "greeting", vars)}</p>
+            <p>${getEmailField(locale, "applicationApproved", "body", vars)}</p>
+            <p>${getEmailField(locale, "applicationApproved", "prompt")}</p>
+            <a href="${data.teamUrl}" style="display:inline-block;padding:12px 24px;background:#16a34a;color:#fff;text-decoration:none;border-radius:6px;margin:16px 0;">${getEmailField(locale, "applicationApproved", "viewTeamBtn")}</a>
+            <p style="color:#6b7280;font-size:14px;">${getEmailField(locale, "applicationApproved", "signature")}</p>
+          </div>
+        `,
+      }),
+      10000,
+      "Send application approved email timeout"
+    );
+
+    return { success: true };
+  } catch (error) {
+    logger.error("[Email] Failed to send application approved email:", error);
+    return { success: false, error: (error as Error).message };
+  }
+}
+
+/**
  * 发送用户反馈邮件（功能建议 / Bug 反馈）
  */
 export async function sendFeedbackEmail(

--- a/api/src/lib/locales/email.en.json
+++ b/api/src/lib/locales/email.en.json
@@ -37,6 +37,15 @@
     "viewApplicationBtn": "View Application",
     "signature": "The GoMate Team"
   },
+  "applicationApproved": {
+    "subject": "Your application has been approved: {teamTitle}",
+    "title": "Application Approved!",
+    "greeting": "Congratulations {applicantName}!",
+    "body": "You have successfully joined the team \"{teamTitle}\" at {locationName}.",
+    "prompt": "Click the button below to view the team and get in touch with your teammates.",
+    "viewTeamBtn": "View Team",
+    "signature": "The GoMate Team"
+  },
   "feedback": {
     "bugSubject": "[GoMate Bug Report] from {name}",
     "suggestionSubject": "[GoMate Suggestion] from {name}",

--- a/api/src/lib/locales/email.ja.json
+++ b/api/src/lib/locales/email.ja.json
@@ -37,6 +37,15 @@
     "viewApplicationBtn": "申請を確認",
     "signature": "GoMate チーム"
   },
+  "applicationApproved": {
+    "subject": "申請が承認されました：{teamTitle}",
+    "title": "申請が承認されました！",
+    "greeting": "{applicantName}さん、おめでとうございます！",
+    "body": "{locationName}のチーム「{teamTitle}」への参加が完了しました。",
+    "prompt": "下のボタンからチームを確認し、メンバーと連絡を取りましょう。",
+    "viewTeamBtn": "チームを見る",
+    "signature": "GoMate チーム"
+  },
   "feedback": {
     "bugSubject": "[GoMate バグ報告] {name}より",
     "suggestionSubject": "[GoMate 提案] {name}より",

--- a/api/src/lib/locales/email.zh-CN.json
+++ b/api/src/lib/locales/email.zh-CN.json
@@ -37,6 +37,15 @@
     "viewApplicationBtn": "查看申请",
     "signature": "GoMate 团队"
   },
+  "applicationApproved": {
+    "subject": "您的申请已通过：{teamTitle}",
+    "title": "申请已通过！",
+    "greeting": "恭喜 {applicantName}！",
+    "body": "您已成功加入 {locationName} 的队伍「{teamTitle}」。",
+    "prompt": "点击下方按钮查看队伍详情，与队友取得联系。",
+    "viewTeamBtn": "查看队伍",
+    "signature": "GoMate 团队"
+  },
   "feedback": {
     "bugSubject": "[GoMate Bug反馈] 来自 {name}",
     "suggestionSubject": "[GoMate 建议反馈] 来自 {name}",

--- a/api/src/routes/teams/membership.ts
+++ b/api/src/routes/teams/membership.ts
@@ -6,7 +6,7 @@ import { createAuth } from "../../lib/auth";
 import { createDb } from "../../db";
 import * as schema from "../../db/schema";
 import type { Env } from "../../lib/auth";
-import { sendTeamJoinApplicationEmail } from "../../lib/email";
+import { sendTeamJoinApplicationEmail, sendApplicationApprovedEmail } from "../../lib/email";
 import { requireTeamLeader } from "../../lib/team-permissions";
 import { generateId } from "../../lib/id";
 
@@ -142,6 +142,18 @@ membership.post("/members/:userId/approve", requireTeamLeader(), async (c) => {
     await db.update(schema.teams)
       .set({ status: newStatus, updatedAt: now })
       .where(eq(schema.teams.id, teamId));
+
+    // task #186：异步通知申请人审核通过（waitUntil 不阻塞响应，失败不影响审批结果）
+    const notifyPromise = notifyApplicantOfApproval(db, team, targetUserId, c.env).catch((err) => {
+      logger.error("[Email] Application approved notification failed:", err);
+    });
+    try {
+      if (c.executionCtx?.waitUntil) {
+        c.executionCtx.waitUntil(notifyPromise);
+      }
+    } catch {
+      // 非 Cloudflare 环境，直接执行不阻塞
+    }
 
     return c.json({ success: true, message: "已通过申请" });
   } catch (error) {
@@ -314,6 +326,37 @@ async function notifyLeaderOfApplication(
     {
       leaderEmail: leaderRow.email,
       leaderName: leaderRow.nickname || leaderRow.name,
+      applicantName: applicantRow.nickname || applicantRow.name,
+      teamTitle: team.title,
+      locationName: locationRow.name,
+      teamUrl: `${frontendUrl}/teams/${team.id}`,
+    },
+    env,
+  );
+}
+
+/**
+ * task #186：通知申请人审核通过（查申请人邮箱 + 地点名，发 applicationApproved 邮件）
+ */
+async function notifyApplicantOfApproval(
+  db: ReturnType<typeof createDb>,
+  team: typeof schema.teams.$inferSelect,
+  applicantUserId: string,
+  env: Env,
+) {
+  const [applicantRow, locationRow] = await Promise.all([
+    db.select({ email: schema.users.email, name: schema.users.name, nickname: schema.users.nickname })
+      .from(schema.users).where(eq(schema.users.id, applicantUserId)).then((r) => r[0]),
+    db.select({ name: schema.locations.name })
+      .from(schema.locations).where(eq(schema.locations.id, team.locationId)).then((r) => r[0]),
+  ]);
+
+  if (!applicantRow?.email || !locationRow) return;
+
+  const frontendUrl = env.FRONTEND_URL || "https://gomate.live";
+  await sendApplicationApprovedEmail(
+    {
+      applicantEmail: applicantRow.email,
       applicantName: applicantRow.nickname || applicantRow.name,
       teamTitle: team.title,
       locationName: locationRow.name,


### PR DESCRIPTION
## 改动范围

task #186（P2）：队员侧 approve 通过通知 —— approve 端点原本只改状态返回 200，无任何通知；`email.ts` 无 applicationApproved 发送器（前端 email namespace 预置了 4 个 key 但 API 消费不到，半拉子）。本 PR 补齐邮件链路，P1-1 onboarding §6.3 文案可摘掉兜底口径。

### 关键文件

- `api/src/lib/email.ts`：新增 `sendApplicationApprovedEmail`（复用 teamJoinApplication 模板结构：subject/title/greeting/body/prompt/CTA/signature）
- `api/src/lib/locales/email.{zh-CN,en,ja}.json`：补 `applicationApproved` 段，文案对齐前端 email ns 预置（申请已通过！/ 恭喜 {applicantName}/ 您已成功加入 {locationName} 的队伍）+ 补 prompt + 「查看队伍」CTA
- `api/src/lib/email-i18n.ts`：`EmailType` += `applicationApproved`
- `api/src/routes/teams/membership.ts`：approve 端点两次状态更新后 `notifyApplicantOfApproval` 异步通知（与 notifyLeaderOfApplication 同 pattern：`waitUntil` 不阻塞响应，`.catch` 兜底失败不影响审批结果；查申请人 email/nickname + 地点名，无邮箱则静默跳过）
- `api/src/__tests__/integration/teams.test.ts`：邮件模块 mock + 2 新 case

### 设计说明

- **通知失败不阻塞审批**：通知走 floating promise + `.catch` logger.error，审批 200 不受 Resend 可用性影响
- **locale**：与 notifyLeaderOfApplication 同口径默认 zh-CN（用户 locale 偏好未入库，全站邮件现状如此）
- **零 schema 变更、零环境变量变更**（复用现有 RESEND_API_KEY）

## 本地验证

- `pnpm type-check`（api 含 tsconfig.scripts.json）✅
- teams.test.ts **39/39 PASS**（新增 2 case：① approve 后 `sendApplicationApprovedEmail` 被调 1 次且 payload 含 applicantEmail/teamTitle/locationName/teamUrl ② mock reject 时审批仍 200 + membership approved）
- 全量 **323/323 PASS**
- pre-push hook ✅

## 风险与回滚

- 风险低：纯增量通知，审批主流程行为不变；revert 单 commit 即回退
- 不涉及 schema / migration / 环境变量

## 验收建议（@Wen）

staging：队长 approve 一个 pending 申请 → 申请人邮箱收到「您的申请已通过：{teamTitle}」邮件（zh-CN 模板 + 查看队伍 CTA 指向 `/teams/{id}`）；审批接口响应时间不因邮件发送退化（异步）。

关联：task #186；解锁 P1-1 onboarding §6.3 正式文案（task #187/#188）
