### PR TITLE
fix(e2e): staging 登录依赖用例全红修复 — 账号切换新种子体系 + team-applications 自构造 fixture

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { fillLoginForm } from "./helpers";
+import { fillLoginForm, STAGING_ACCOUNTS } from "./helpers";
 
 test.describe("Auth", () => {
   test("login page loads and form is interactive", async ({ page }) => {
@@ -8,14 +8,14 @@ test.describe("Auth", () => {
     await expect(page.locator("form")).toBeVisible();
     await expect(page.locator("[data-testid='login-email']")).toBeVisible();
     await expect(page.locator("[data-testid='login-password']")).toBeVisible();
-    await fillLoginForm(page, "leader_a@test.com", "test1234");
+    await fillLoginForm(page, STAGING_ACCOUNTS.leader.email, STAGING_ACCOUNTS.leader.password);
     await page.locator("[data-testid='login-submit']").click();
     await expect(page.locator("body")).toBeVisible();
   });
 
   test("successful login redirects to home", async ({ page }) => {
     await page.goto("/login");
-    await fillLoginForm(page, "admin@test.com", "test1234");
+    await fillLoginForm(page, STAGING_ACCOUNTS.admin.email, STAGING_ACCOUNTS.admin.password);
     await page.locator("[data-testid='login-submit']").click();
     // Deterministic assertion: wait for navigation to home
     await page.waitForURL(/\/$/, { timeout: 30000 });

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,20 +1,22 @@
 /**
- * E2E fixture 自构造工具（staging 用）
+ * E2E fixture 自构造工具
  *
  * 背景：team-applications 等用例历史上依赖 seed 脚本预置的账号 + 队伍 + pending 申请，
- * 但 seed 体系 07-06 更换后旧账号（admin@test.com 等）在 staging D1 已不存在，
- * 且「申请 → 审批」是消耗性状态（approve/reject 一次即消失），预置种子天然不幂等。
+ * 但「申请 → 审批」是消耗性状态（approve/reject 一次即消失），预置种子天然不幂等；
+ * staging 侧旧种子账号（admin@test.com 等）在 staging D1 也已不存在。
  *
  * 本模块让每个用例自行构造隔离 fixture：
  *   signUpUser → patchWechat（建队/申请的前置条件）→ createTeamAs / applyToTeamAs
  * 用户名/队名带 RUN_ID 时间戳，多次运行互不干扰，无需清理。
  *
+ * 环境自适应：staging 打 api-staging.gomate.live，本地打 localhost:8799（可用 env 覆盖）。
  * HTTP 模式与 scripts/seed-staging.mjs 一致（Origin 头 + set-cookie 会话），
  * 已在 staging 实证可用。
  */
 
-const API_BASE = process.env.E2E_API_URL || "https://api-staging.gomate.live";
-const STAGING_ORIGIN = process.env.E2E_ORIGIN || "https://staging.gomate.live";
+const IS_STAGING = (process.env.E2E_BASE_URL || "").includes("staging.gomate.live");
+const API_BASE = process.env.E2E_API_URL || (IS_STAGING ? "https://api-staging.gomate.live" : "http://localhost:8799");
+const FRONTEND_ORIGIN = process.env.E2E_ORIGIN || (IS_STAGING ? "https://staging.gomate.live" : "http://localhost:5432");
 
 export interface FixtureUser {
   email: string;
@@ -41,7 +43,7 @@ async function apiFetch(
   const headers: Record<string, string> = {
     Accept: "application/json",
     "Content-Type": "application/json",
-    Origin: STAGING_ORIGIN,
+    Origin: FRONTEND_ORIGIN,
   };
   if (cookie) headers.Cookie = cookie;
 

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,113 @@
+/**
+ * E2E fixture 自构造工具（staging 用）
+ *
+ * 背景：team-applications 等用例历史上依赖 seed 脚本预置的账号 + 队伍 + pending 申请，
+ * 但 seed 体系 07-06 更换后旧账号（admin@test.com 等）在 staging D1 已不存在，
+ * 且「申请 → 审批」是消耗性状态（approve/reject 一次即消失），预置种子天然不幂等。
+ *
+ * 本模块让每个用例自行构造隔离 fixture：
+ *   signUpUser → patchWechat（建队/申请的前置条件）→ createTeamAs / applyToTeamAs
+ * 用户名/队名带 RUN_ID 时间戳，多次运行互不干扰，无需清理。
+ *
+ * HTTP 模式与 scripts/seed-staging.mjs 一致（Origin 头 + set-cookie 会话），
+ * 已在 staging 实证可用。
+ */
+
+const API_BASE = process.env.E2E_API_URL || "https://api-staging.gomate.live";
+const STAGING_ORIGIN = process.env.E2E_ORIGIN || "https://staging.gomate.live";
+
+export interface FixtureUser {
+  email: string;
+  password: string;
+  name: string;
+  userId: string;
+  cookie: string;
+}
+
+interface ApiResult {
+  status: number;
+  ok: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data: any;
+  setCookie: string | null;
+}
+
+async function apiFetch(
+  method: string,
+  path: string,
+  body?: Record<string, unknown>,
+  cookie?: string,
+): Promise<ApiResult> {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+    Origin: STAGING_ORIGIN,
+  };
+  if (cookie) headers.Cookie = cookie;
+
+  const res = await fetch(`${API_BASE}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const text = await res.text();
+  let data: unknown = null;
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = text;
+    }
+  }
+  return { status: res.status, ok: res.ok, data, setCookie: res.headers.get("set-cookie") };
+}
+
+/** 注册新用户（better-auth sign-up 自动登录，会话在 set-cookie 里） */
+export async function signUpUser(email: string, password: string, name: string): Promise<FixtureUser> {
+  const res = await apiFetch("POST", "/auth/sign-up/email", { email, password, name });
+  const userId = res.data?.user?.id as string | undefined;
+  if (!res.ok || !res.setCookie || !userId) {
+    throw new Error(`sign-up failed for ${email}: ${res.status} ${JSON.stringify(res.data)}`);
+  }
+  return { email, password, name, userId, cookie: res.setCookie };
+}
+
+/** 补微信号（建队 / 申请加入的前置条件，API 强制校验） */
+export async function patchWechat(user: FixtureUser, wechat: string): Promise<void> {
+  const res = await apiFetch("PATCH", "/users/update", { userId: user.userId, wechat }, user.cookie);
+  if (!res.ok) {
+    throw new Error(`patch wechat failed for ${user.email}: ${res.status} ${JSON.stringify(res.data)}`);
+  }
+}
+
+/** 以某个用户身份建队，返回 teamId */
+export async function createTeamAs(
+  user: FixtureUser,
+  team: { locationId: string; title: string; date: string; time: string; maxMembers: number; description?: string },
+): Promise<string> {
+  const res = await apiFetch("POST", "/teams", team as unknown as Record<string, unknown>, user.cookie);
+  const teamId = res.data?.team?.id as string | undefined;
+  if (!res.ok || !teamId) {
+    throw new Error(`create team failed for ${user.email}: ${res.status} ${JSON.stringify(res.data)}`);
+  }
+  return teamId;
+}
+
+/** 以某个用户身份申请加入队伍（构造 pending 状态用） */
+export async function applyToTeamAs(user: FixtureUser, teamId: string, message = "E2E 申请"): Promise<void> {
+  const res = await apiFetch("POST", `/teams/${teamId}/join`, { message }, user.cookie);
+  if (!res.ok) {
+    throw new Error(`apply to team failed for ${user.email}: ${res.status} ${JSON.stringify(res.data)}`);
+  }
+}
+
+/** 取 staging 第一个 location id（种子保证至少一个） */
+export async function getFirstLocationId(): Promise<string> {
+  const res = await apiFetch("GET", "/locations?pageSize=1");
+  const id = res.data?.locations?.[0]?.id as string | undefined;
+  if (!res.ok || !id) {
+    throw new Error(`list locations failed: ${res.status} ${JSON.stringify(res.data)}`);
+  }
+  return id;
+}

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,21 +1,25 @@
 import type { Page } from "@playwright/test";
 
 /**
- * staging 种子账号（scripts/seed-staging.mjs 07-06 起创建，密码均为 test1234）。
- * 旧账号体系（admin@test.com / leader_a@test.com 等）在 staging D1 已不存在，勿再引用。
- * 可用环境变量覆盖以指向其他环境。
+ * 测试账号按环境切换：
+ * - staging（E2E_BASE_URL 指向 staging.gomate.live）：seed-staging.mjs 07-06 起创建的
+ *   *-staging@gomate.test 账号（密码 test1234）
+ * - 本地（默认）：api/db/seed-mobile-test.ts 创建的 admin/leader_a/member_a@test.com
+ * 均可用环境变量覆盖。
  */
+const IS_STAGING = (process.env.E2E_BASE_URL || "").includes("staging.gomate.live");
+
 export const STAGING_ACCOUNTS = {
   admin: {
-    email: process.env.E2E_ADMIN_EMAIL || "admin-staging@gomate.test",
+    email: process.env.E2E_ADMIN_EMAIL || (IS_STAGING ? "admin-staging@gomate.test" : "admin@test.com"),
     password: process.env.E2E_ADMIN_PASSWORD || "test1234",
   },
   leader: {
-    email: process.env.E2E_LEADER_EMAIL || "leader-staging@gomate.test",
+    email: process.env.E2E_LEADER_EMAIL || (IS_STAGING ? "leader-staging@gomate.test" : "leader_a@test.com"),
     password: process.env.E2E_LEADER_PASSWORD || "test1234",
   },
   member: {
-    email: process.env.E2E_MEMBER_EMAIL || "member-staging@gomate.test",
+    email: process.env.E2E_MEMBER_EMAIL || (IS_STAGING ? "member-staging@gomate.test" : "member_a@test.com"),
     password: process.env.E2E_MEMBER_PASSWORD || "test1234",
   },
 } as const;

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,6 +1,26 @@
 import type { Page } from "@playwright/test";
 
 /**
+ * staging 种子账号（scripts/seed-staging.mjs 07-06 起创建，密码均为 test1234）。
+ * 旧账号体系（admin@test.com / leader_a@test.com 等）在 staging D1 已不存在，勿再引用。
+ * 可用环境变量覆盖以指向其他环境。
+ */
+export const STAGING_ACCOUNTS = {
+  admin: {
+    email: process.env.E2E_ADMIN_EMAIL || "admin-staging@gomate.test",
+    password: process.env.E2E_ADMIN_PASSWORD || "test1234",
+  },
+  leader: {
+    email: process.env.E2E_LEADER_EMAIL || "leader-staging@gomate.test",
+    password: process.env.E2E_LEADER_PASSWORD || "test1234",
+  },
+  member: {
+    email: process.env.E2E_MEMBER_EMAIL || "member-staging@gomate.test",
+    password: process.env.E2E_MEMBER_PASSWORD || "test1234",
+  },
+} as const;
+
+/**
  * 等待登录页 React island hydration 完成，然后填写邮箱/密码。
  *
  * 登录表单的 input 是 React controlled component；如果在 hydration 完成前 fill，
@@ -29,7 +49,7 @@ export async function loginAs(page: Page, email: string, password: string) {
 
 /** 使用 admin 测试账号登录 */
 export async function loginAsAdmin(page: Page) {
-  await loginAs(page, "admin@test.com", "test1234");
+  await loginAs(page, STAGING_ACCOUNTS.admin.email, STAGING_ACCOUNTS.admin.password);
 }
 
 /** 在队伍列表页通过标题找到队伍，点击进入详情页，返回队伍 ID */

--- a/e2e/team-applications.spec.ts
+++ b/e2e/team-applications.spec.ts
@@ -1,21 +1,55 @@
 import { test, expect } from "@playwright/test";
-import { loginAs, gotoTeamByTitle } from "./helpers";
+import { loginAs } from "./helpers";
+import {
+  signUpUser,
+  patchWechat,
+  createTeamAs,
+  applyToTeamAs,
+  getFirstLocationId,
+  type FixtureUser,
+} from "./fixtures";
 
-const EXPERT = { email: "expert@test.com", password: "test1234" };
-const ADMIN = { email: "admin@test.com", password: "test1234" };
-const LEADER_A = { email: "leader_a@test.com", password: "test1234" };
-const LEADER_B = { email: "leader_b@test.com", password: "test1234" };
+/**
+ * 队伍申请流 E2E —— 每次运行自构造隔离 fixture。
+ *
+ * 历史版本依赖 seed 预置的 expert/admin/leader_a/leader_b@test.com + 特定队伍的
+ * 特定 pending 申请：旧种子账号在 staging D1 已不存在（E2E 因此全红 18+ 次），
+ * 且 approve/reject 消耗 pending 状态，预置种子天然不幂等。
+ * 现改为每个用例自建 leader/member/team/application，UI 只走被测主路径。
+ */
 
-const TEAM_1_TITLE = "周末清水湾海岸线徒步";
-const TEAM_2_TITLE = "梧桐山轻松线体验";
-const EXPERT_NICKNAME = "Expert Hiker";
-const ADMIN_NICKNAME = "Admin";
+const RUN_ID = Date.now().toString(36);
+const PASSWORD = "test1234";
+
+async function makeUser(role: string): Promise<FixtureUser> {
+  const user = await signUpUser(`e2e-app-${RUN_ID}-${role}@e2e.gomate.test`, PASSWORD, `E2E ${RUN_ID} ${role}`);
+  // 建队 / 申请加入都强制要求已填微信号
+  await patchWechat(user, `e2e${RUN_ID}${role}`);
+  return user;
+}
+
+/** leader 建一支未来 7 天出发的招募中队，返回 teamId */
+async function makeTeam(leader: FixtureUser, suffix: string): Promise<string> {
+  const locationId = await getFirstLocationId();
+  const start = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  return createTeamAs(leader, {
+    locationId,
+    title: `E2E 申请流 ${RUN_ID} ${suffix}`,
+    date: start.toISOString().split("T")[0]!,
+    time: "10:00",
+    maxMembers: 5,
+    description: "E2E 自构造 fixture 队伍，可安全忽略",
+  });
+}
 
 test.describe("Team Application Flow", () => {
   test("member can apply to join a recruiting team", async ({ page }) => {
-    // expert 不是队伍 1 的成员，可以提交加入申请
-    await loginAs(page, EXPERT.email, EXPERT.password);
-    await gotoTeamByTitle(page, TEAM_1_TITLE);
+    const leader = await makeUser("leader-apply");
+    const teamId = await makeTeam(leader, "申请");
+    const member = await makeUser("applicant-apply");
+
+    await loginAs(page, member.email, member.password);
+    await page.goto(`/teams/${teamId}`);
 
     await page.locator("[data-testid='team-join-button']").click();
     await expect(page.locator("[data-testid='team-join-message']")).toBeVisible();
@@ -27,16 +61,22 @@ test.describe("Team Application Flow", () => {
   });
 
   test("leader can approve a pending application", async ({ page }) => {
-    await loginAs(page, LEADER_A.email, LEADER_A.password);
-    await gotoTeamByTitle(page, TEAM_1_TITLE);
+    const leader = await makeUser("leader-approve");
+    const teamId = await makeTeam(leader, "审批");
+    const member = await makeUser("applicant-approve");
+    // pending 申请由 API 构造，UI 只走审批主路径
+    await applyToTeamAs(member, teamId);
+
+    await loginAs(page, leader.email, leader.password);
+    await page.goto(`/teams/${teamId}`);
 
     const applicationsSection = page.locator("[data-testid='team-applications-section']");
     await expect(applicationsSection).toBeVisible();
 
-    // 找到 expert 的申请卡片并点击通过
+    // 找到该成员的申请卡片并点击通过
     const appCard = applicationsSection
       .locator("[data-testid='team-application-card']")
-      .filter({ hasText: EXPERT_NICKNAME });
+      .filter({ hasText: member.name });
     await appCard.locator("[data-testid='team-application-approve']").click();
 
     // 审批后该申请卡片应消失
@@ -44,16 +84,20 @@ test.describe("Team Application Flow", () => {
   });
 
   test("leader can reject a pending application", async ({ page }) => {
-    await loginAs(page, LEADER_B.email, LEADER_B.password);
-    await gotoTeamByTitle(page, TEAM_2_TITLE);
+    const leader = await makeUser("leader-reject");
+    const teamId = await makeTeam(leader, "拒绝");
+    const member = await makeUser("applicant-reject");
+    await applyToTeamAs(member, teamId);
+
+    await loginAs(page, leader.email, leader.password);
+    await page.goto(`/teams/${teamId}`);
 
     const applicationsSection = page.locator("[data-testid='team-applications-section']");
     await expect(applicationsSection).toBeVisible();
 
-    // 种子数据中 admin 在队伍 2 有一条待审核申请，找到后点击拒绝
     const appCard = applicationsSection
       .locator("[data-testid='team-application-card']")
-      .filter({ hasText: ADMIN_NICKNAME });
+      .filter({ hasText: member.name });
     await appCard.locator("[data-testid='team-application-reject']").click();
 
     // 拒绝后该申请卡片应消失


### PR DESCRIPTION
## 背景

E2E Staging 定时任务可见历史 **18 连红**（07-06 起从未绿过）。所有失败集中在 6 个登录依赖用例，统一挂在登录后 `waitForURL(/\/$/)` 30s 超时。

## 根因（一手 D1 实证）

spec 硬编码旧种子账号 `admin@test.com` / `leader_a/b@test.com` / `expert@test.com`，但 07-06 `seed-staging.mjs` 更换种子体系后这些账号在 staging D1 **已不存在**（SELECT 0 行）。staging 现存账号是 `admin/leader/member-staging@gomate.test`（密码 test1234）。登录永远失败 → 永不跳转 → 超时。

## 改动范围（4 文件，+201/-24）

| 文件 | 改动 |
|---|---|
| `e2e/helpers.ts` | 新增 `STAGING_ACCOUNTS` 常量（新种子账号，env 可覆盖），`loginAsAdmin` 切换 |
| `e2e/auth.spec.ts` | 两个登录用例账号切换 |
| `e2e/team-applications.spec.ts` | **重写**：每用例自构造隔离 fixture（API 注册 + PATCH wechat + API 建队/申请），UI 只走被测主路径 |
| `e2e/fixtures.ts` | 新增：`signUpUser` / `patchWechat` / `createTeamAs` / `applyToTeamAs` / `getFirstLocationId`（HTTP 模式与 `scripts/seed-staging.mjs` 一致：Origin 头 + set-cookie 会话） |

team-applications 重写的额外理由：旧版不仅账号不存在，还依赖「特定队伍的特定 pending 申请」**消耗性状态**——approve/reject 一次即消失，种子重灌也不幂等。自构造 fixture 每次 run 全新用户/队伍（RUN_ID 时间戳命名），天然幂等、无需清理。

## 本地验证

```
E2E_BASE_URL=https://staging.gomate.live CI=true pnpm exec playwright test --project=chromium-staging e2e/auth.spec.ts e2e/profile.spec.ts e2e/teams.spec.ts e2e/team-applications.spec.ts
→ 14/14 PASS（含此前全红的 6 个登录依赖用例）
```
- `tsc --noEmit` 0 错（根 tsconfig 覆盖 e2e）
- `pnpm lint` 0 error（1 个 pre-existing warning，与本 PR 无关）

## 已知事项

- **staging 数据增长**：fixture 每次 run 在 staging 新建 6 用户 + 3 队伍 + teams.spec 的「E2E Test Team」。命名均带 `e2e-*` / RUN_ID 可识别，量小（每日 1 次定时），定期清理即可；如需自动清理可后续立项。
- **本地 30s 默认 timeout 偶紧**：staging 冷启动时 fixture API 往返慢，本地默认 30s 偶尔不够（CI 60s + retries=2 从容）。实跑验证 CI 语义下 14/14。
- 本 PR 只动 e2e/，零业务代码、零 schema、零部署配置变更。

## 回滚

revert 本 PR 即恢复（回到 18 连红状态，无生产影响面）。