### PR TITLE
ci: workflow job 显示名改 kebab-case 对齐 branch protection required contexts

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   e2e-staging:
-    name: E2E Tests against Staging
+    name: e2e-staging
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   # API Package Validation
   api-checks:
-    name: API Checks
+    name: api-checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
 
   # Frontend Package Validation
   frontend-checks:
-    name: Frontend Checks
+    name: frontend-checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
         run: pnpm --filter @gomate/frontend lint
   # E2E Tests (local dev server)
   e2e-tests:
-    name: E2E Tests (Local)
+    name: e2e-tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 背景

PR #414 暴露的悬案：CI 3/3 全绿、`mergeable: MERGEABLE`、`required_approving_review_count=0`，但非 admin merge 永久 BLOCKED。

## 根因（@Karis 一手定位）

branch protection 的 required contexts 是 kebab-case（`api-checks` / `frontend-checks` / `e2e-tests`），但 job 显示名是 `API Checks` / `Frontend Checks` / `E2E Tests (Local)`。GitHub 按 check run 显示名精确匹配 required check → 永远等不到 → 永久 BLOCKED。历史 PR 能合是因为 owner 合并走 admin bypass（`enforce_admins: false`）。

## 改动（2 文件 4 行，Victor 授权 CI 配置变更）

| 文件 | 改动 |
|---|---|
| `pr-validation.yml` | `API Checks`→`api-checks` / `Frontend Checks`→`frontend-checks` / `E2E Tests (Local)`→`e2e-tests`（与 job id 同名） |
| `e2e-staging.yml` | `E2E Tests against Staging`→`e2e-staging`（不在 required contexts，同风格对齐） |

选改 workflow 显示名而非保护规则的理由：显示名是 UI 文案属性，措辞一改门禁静默失效；kebab slug（= job id）是稳定契约，只动实现不动规则。

## 验证

- 全仓 grep（mjs/ts/yml/md）：无任何脚本/报告引用旧显示名（e2e-health-report.mjs 解析 results.json 不涉 check 名）
- **本 PR 自身即试金石**：check run 将以 kebab 名上报 → `gh pr checks --required` 应正确匹配三个 required → 非 admin 可正常 merge 即证明修复生效

## 风险与回滚

零业务代码、零运行时影响；回滚 = revert（回到非 admin 需 admin bypass 的状态）。