### PR TITLE
ci: align PR check run names with branch protection contexts

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -11,7 +11,6 @@ permissions:
 jobs:
   # API Package Validation
   api-checks:
-    name: API Checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +31,6 @@ jobs:
 
   # Frontend Package Validation
   frontend-checks:
-    name: Frontend Checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -57,7 +55,6 @@ jobs:
         run: pnpm --filter @gomate/frontend lint
   # E2E Tests (local dev server)
   e2e-tests:
-    name: E2E Tests (Local)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 问题

PR #414 全绿（3/3 checks SUCCESS、MERGEABLE、0 behind）但 `mergeStateStatus: BLOCKED`，非 admin 无法合并。

**根因**：main 的 branch protection required status check contexts 是 job ID（`api-checks` / `frontend-checks` / `e2e-tests`），但 workflow 里 job 设置了显示名 `name: API Checks` 等，GitHub 按 check run 显示名精确匹配 required contexts → 永远等不到 → 永久 BLOCKED。#413 能合是因为 owner 合并走 admin bypass（`enforce_admins: false`）。

## 修复（Victor 拍板方案②）

删除 3 个 job 的 `name:` 显示名，check run 名回退为 job ID，与保护规则 contexts 精确对齐。同时消除「显示名是 UI 文案、改措辞就静默失效」的漂移风险。

## 验证

- [x] YAML 语法校验通过
- [x] 全仓搜索无其他地方引用旧显示名
- [ ] 本 PR 的 CI 跑完后，check run 名应为 `api-checks` / `frontend-checks` / `e2e-tests`（本 PR 自身即可验证）
- [ ] 合并后任意非 admin PR 应能正常解锁合并

## 注意

本 PR 自身的 checks 在合并前仍受旧规则影响：跑完后三个 check 名会变成 kebab-case（正好是保护规则要求的名字），所以本 PR 应该能正常解除 BLOCKED —— 这本身就是端到端验证。若仍 BLOCKED 请用 admin 合并。

🤖 Generated with [Claude Code](https://claude.com/claude-code)