### PR TITLE
T3: 首页极简 - 移动端（横滑snap+紧凑卡）

### DIFF
--- a/frontend/src/components/features/home/home-location-card.tsx
+++ b/frontend/src/components/features/home/home-location-card.tsx
@@ -10,6 +10,8 @@ interface LocationCardProps {
   location: Location;
   /** 卡片索引，前3张为首屏图片，优先加载 */
   index?: number;
+  /** 紧凑模式：左图右文，适合移动端列表 */
+  compact?: boolean;
 }
 
 /**
@@ -17,7 +19,7 @@ interface LocationCardProps {
  * 使用 React.memo 避免不必要重渲染
  * 仅当 location.id 变化时重新渲染
  */
-export const LocationCard = memo(function LocationCard({ location, index = 0 }: LocationCardProps) {
+export const LocationCard = memo(function LocationCard({ location, index = 0, compact = false }: LocationCardProps) {
   const { t } = useI18n(["locations", "locationDetail", "enums"]);
   // task #152 切源：徒步参数读 location 自身字段（0010 回填），不再读 routes[0]
   const difficulty = location.difficulty;
@@ -37,6 +39,51 @@ export const LocationCard = memo(function LocationCard({ location, index = 0 }: 
       elevation: hiking.elevation?.value,
     };
   }, [location, t]);
+
+  // Compact mode: horizontal card, left image ~80px square, right side name+params, ~95px height
+  if (compact) {
+    return (
+      <a href={`/locations/${location.id}`} className="block group">
+        <article className="flex items-center gap-3 px-3 py-2.5 bg-card rounded-xl shadow-[var(--shadow-card)] transition-all duration-200 hover:shadow-[var(--shadow-card-hover)] will-change-transform">
+          {/* Left: square thumbnail ~80px */}
+          <div className="flex-shrink-0 w-[72px] h-[72px] rounded-lg overflow-hidden bg-muted">
+            {location.coverImage ? (
+              <img src={location.coverImage} alt={location.name} className="w-full h-full object-cover" loading="lazy" />
+            ) : (
+              <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-amber-100 dark:from-amber-950/40 to-teal-100 dark:to-teal-950/40">
+                <Mountain className="h-7 w-7 text-primary/30" />
+              </div>
+            )}
+          </div>
+          {/* Right: name + params */}
+          <div className="flex-1 min-w-0 flex flex-col justify-center gap-1">
+            <h3 className="font-semibold text-foreground text-sm leading-snug line-clamp-1 group-hover:text-amber-700 dark:group-hover:text-amber-400 transition-colors">
+              {location.name}
+            </h3>
+            <p className="text-xs text-stone-700 dark:text-stone-300 flex items-center gap-1">
+              <MapPin className="h-3 w-3 flex-shrink-0" />
+              {location.address || t("locations.defaultCity")}
+            </p>
+            {routeInfo && (
+              <p className="text-xs text-stone-500 dark:text-stone-400 flex items-center gap-2">
+                {routeInfo.duration && (
+                  <span className="inline-flex items-center gap-1"><Clock className="h-3 w-3" />{routeInfo.duration}</span>
+                )}
+                {routeInfo.distance && (
+                  <span className="inline-flex items-center gap-1"><Route className="h-3 w-3" />{routeInfo.distance}</span>
+                )}
+              </p>
+            )}
+          </div>
+          {/* Arrow */}
+          <div className="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center transition-all duration-150 group-hover:bg-brand group-hover:text-white flex-shrink-0"
+            style={{ background: "var(--brand-subtle)", color: "var(--brand)" }}>
+            <ArrowRight className="h-3 w-3" />
+          </div>
+        </article>
+      </a>
+    );
+  }
 
   return (
     <a href={`/locations/${location.id}`} className="block group">
@@ -116,5 +163,6 @@ export const LocationCard = memo(function LocationCard({ location, index = 0 }: 
 }, (prevProps, nextProps) => {
   // 比较 id 和 index，确保首屏加载状态变化时重新渲染
   return prevProps.location.id === nextProps.location.id &&
-         prevProps.index === nextProps.index;
+         prevProps.index === nextProps.index &&
+         prevProps.compact === nextProps.compact;
 });

--- a/frontend/src/components/features/home/home-location-card.tsx
+++ b/frontend/src/components/features/home/home-location-card.tsx
@@ -76,7 +76,7 @@ export const LocationCard = memo(function LocationCard({ location, index = 0, co
             )}
           </div>
           {/* Arrow */}
-          <div className="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center transition-all duration-150 group-hover:bg-brand group-hover:text-white flex-shrink-0"
+          <div className="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center transition-all duration-150 group-hover:bg-brand group-hover:text-white"
             style={{ background: "var(--brand-subtle)", color: "var(--brand)" }}>
             <ArrowRight className="h-3 w-3" />
           </div>

--- a/frontend/src/components/features/home/home-locations-section.tsx
+++ b/frontend/src/components/features/home/home-locations-section.tsx
@@ -21,15 +21,31 @@ export function HomeLocationsSection({ data }: { data: HomeData }) {
         </div>
 
         {isLoading ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <div key={i} className="h-72 rounded-2xl bg-muted animate-pulse" />
-            ))}
-          </div>
+          <>
+            {/* Mobile skeleton */}
+            <div className="lg:hidden flex flex-col gap-2">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div key={i} className="h-[88px] rounded-xl bg-muted animate-pulse" />
+              ))}
+            </div>
+            {/* Desktop skeleton */}
+            <div className="hidden lg:grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div key={i} className="h-72 rounded-2xl bg-muted animate-pulse" />
+              ))}
+            </div>
+          </>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {locations.map((location, index) => <LocationCard key={location.id} location={location} index={index} />)}
-          </div>
+          <>
+            {/* Mobile: compact list */}
+            <div className="lg:hidden flex flex-col gap-2">
+              {locations.map((location, index) => <LocationCard key={location.id} location={location} index={index} compact />)}
+            </div>
+            {/* Desktop: 3-col grid */}
+            <div className="hidden lg:grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {locations.map((location, index) => <LocationCard key={location.id} location={location} index={index} />)}
+            </div>
+          </>
         )}
 
       </div>

--- a/frontend/src/components/features/home/home-locations-section.tsx
+++ b/frontend/src/components/features/home/home-locations-section.tsx
@@ -22,14 +22,14 @@ export function HomeLocationsSection({ data }: { data: HomeData }) {
 
         {isLoading ? (
           <>
-            {/* Mobile skeleton */}
-            <div className="lg:hidden flex flex-col gap-2">
+            {/* Mobile/tablet skeleton */}
+            <div className="md:hidden flex flex-col gap-2">
               {Array.from({ length: 6 }).map((_, i) => (
                 <div key={i} className="h-[88px] rounded-xl bg-muted animate-pulse" />
               ))}
             </div>
             {/* Desktop skeleton */}
-            <div className="hidden lg:grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            <div className="hidden md:grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {Array.from({ length: 6 }).map((_, i) => (
                 <div key={i} className="h-72 rounded-2xl bg-muted animate-pulse" />
               ))}
@@ -37,12 +37,12 @@ export function HomeLocationsSection({ data }: { data: HomeData }) {
           </>
         ) : (
           <>
-            {/* Mobile: compact list */}
-            <div className="lg:hidden flex flex-col gap-2">
+            {/* Mobile/tablet: compact list */}
+            <div className="md:hidden flex flex-col gap-2">
               {locations.map((location, index) => <LocationCard key={location.id} location={location} index={index} compact />)}
             </div>
             {/* Desktop: 3-col grid */}
-            <div className="hidden lg:grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            <div className="hidden md:grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {locations.map((location, index) => <LocationCard key={location.id} location={location} index={index} />)}
             </div>
           </>

--- a/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
+++ b/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
@@ -133,29 +133,53 @@ export function HomeRecommendationsSection() {
           </p>
         </div>
 
-        {/* Cards grid */}
+        {/* Cards grid — mobile: horizontal snap; desktop: 3-col grid */}
         {state.status === "loading" ? (
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 sm:gap-5">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <div
-                key={i}
-                className="h-48 rounded-lg border bg-muted animate-pulse"
-                data-testid="recommendation-card-skeleton"
-              />
-            ))}
+          <div className="md:grid md:grid-cols-3 md:gap-4 sm:gap-5">
+            {/* Mobile skeleton: single card visible at a time */}
+            <div className="md:hidden flex overflow-x-auto snap-x snap-mandatory gap-3 pb-2 -mx-4 px-4 scrollbar-hide">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="flex-shrink-0 w-[68%] snap-center h-48 rounded-lg border bg-muted animate-pulse"
+                  data-testid="recommendation-card-skeleton"
+                />
+              ))}
+            </div>
+            {/* Desktop skeleton */}
+            <div className="hidden md:grid grid-cols-3 gap-4 sm:gap-5">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="h-48 rounded-lg border bg-muted animate-pulse"
+                  data-testid="recommendation-card-skeleton"
+                />
+              ))}
+            </div>
           </div>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 sm:gap-5">
-            {state.recommendations.map((reco) => (
-              <RecommendationCard key={reco.locationId} reco={reco} />
-            ))}
+          <div className="md:grid md:grid-cols-3 md:gap-4 sm:gap-5">
+            {/* Mobile: horizontal scroll snap, card width ~68% viewport */}
+            <div className="md:hidden flex overflow-x-auto snap-x snap-mandatory gap-3 pb-2 -mx-4 px-4 scrollbar-hide">
+              {state.recommendations.map((reco) => (
+                <div key={reco.locationId} className="flex-shrink-0 w-[68%] snap-center">
+                  <RecommendationCard reco={reco} />
+                </div>
+              ))}
+            </div>
+            {/* Desktop: 3-col grid */}
+            <div className="hidden md:grid grid-cols-3 gap-4 sm:gap-5">
+              {state.recommendations.map((reco) => (
+                <RecommendationCard key={reco.locationId} reco={reco} />
+              ))}
+            </div>
           </div>
         )}
 
-        {/* Refresh CTA — 桌面居右标题行；移动端 sticky 底部
-            Martin CR B1: 用 w-fit + mx-auto 让容器只覆盖按钮宽度，避免 sticky 容器矩形挡住卡片点击 */}
+        {/* Refresh CTA — 桌面居右标题行（弱化为文字按钮）；移动端居中可见
+            Martin CR R2: 换一批保留，spec §3 无移动端隐藏口径 */}
         {state.status === "ready" && (
-          <div className="mt-5 sm:mt-6 text-right md:text-right">
+          <div className="mt-5 sm:mt-6 flex justify-center md:justify-end">
             <button
               type="button"
               onClick={handleRefresh}

--- a/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
+++ b/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
@@ -135,7 +135,7 @@ export function HomeRecommendationsSection() {
 
         {/* Cards grid — mobile: horizontal snap; desktop: 3-col grid */}
         {state.status === "loading" ? (
-          <div className="md:grid md:grid-cols-3 md:gap-4 sm:gap-5">
+          <>
             {/* Mobile skeleton: single card visible at a time */}
             <div className="md:hidden flex overflow-x-auto snap-x snap-mandatory gap-3 pb-2 -mx-4 px-4 scrollbar-hide">
               {Array.from({ length: 3 }).map((_, i) => (
@@ -156,9 +156,9 @@ export function HomeRecommendationsSection() {
                 />
               ))}
             </div>
-          </div>
+          </>
         ) : (
-          <div className="md:grid md:grid-cols-3 md:gap-4 sm:gap-5">
+          <>
             {/* Mobile: horizontal scroll snap, card width ~68% viewport */}
             <div className="md:hidden flex overflow-x-auto snap-x snap-mandatory gap-3 pb-2 -mx-4 px-4 scrollbar-hide">
               {state.recommendations.map((reco) => (
@@ -173,7 +173,7 @@ export function HomeRecommendationsSection() {
                 <RecommendationCard key={reco.locationId} reco={reco} />
               ))}
             </div>
-          </div>
+          </>
         )}
 
         {/* Refresh CTA — 桌面居右标题行（弱化为文字按钮）；移动端居中可见

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -419,6 +419,15 @@
     scrollbar-color: var(--border) transparent;
   }
 
+  /* Hide scrollbar but keep functionality (for horizontal snap scrollers) */
+  .scrollbar-hide {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;
+  }
+
   body {
     @apply bg-background text-foreground font-sans;
     line-height: 1.6;


### PR DESCRIPTION
## T3: 首页极简优化 - 移动端

**任务**: task #191  
**Spec**:  §4.2/§6.4  
**验收**: spec §8 #2/6

### 改动

**本周三卡（recommendations）**:
- 移动端（<md）横向滚动 snap，卡宽 68% 视口，露出次卡半张
- 桌面保持 3 列 grid
- 移动端去掉 sticky refresh button（横滑本身是导航）

**探索地点（locations）**:
- 新增  prop → 左图右文紧凑卡（~95px 高）
- 移动端（<lg）展示紧凑列表，桌面展示大卡片 grid

### 依赖
- #190 先合，rebase main 后合并本 PR

### 测试要点
- [ ] 移动端本周三卡横滑 snap 定位（一次一张半）
- [ ] 移动端探索地点紧凑卡左图右文
- [ ] 桌面两种卡片形态正常
- [ ] i18n 三语门禁