### PR TITLE
P3 hygiene: 删除 ja/home.json 废弃的 recentTeams 孤 key

### DIFF
--- a/frontend/public/locales/ja/home.json
+++ b/frontend/public/locales/ja/home.json
@@ -1,5 +1,4 @@
 {
-  "recentTeams": "最近のチーム",
   "teamCard": {
     "departingToday": "今日出発",
     "departingTomorrow": "明日出発",


### PR DESCRIPTION
删 zh-CN/en 已移除但 ja 残留的 recentTeams 孤 key（P3 backlog，Martin msg=939e77ed 记录）。i18n validate 无 missing 即通过。