### PR TITLE
P3: delete orphan recentTeams from ja/home.json

### DIFF
--- a/frontend/public/locales/ja/home.json
+++ b/frontend/public/locales/ja/home.json
@@ -1,5 +1,4 @@
 {
-  "recentTeams": "最近のチーム",
   "teamCard": {
     "departingToday": "今日出発",
     "departingTomorrow": "明日出発",


### PR DESCRIPTION
## P3 Hygiene — ja/home.json 孤 key 清理

**来源**：Jeff #418 CR 时遗留，zh-CN/en 已删，ja 遗留孤  key。

**改动**：删除  的  key（无任何组件消费）。

**无需移动端验收**。