### PR TITLE
P1: 首页 city 个性化 T1+T2+T4（推荐软过滤 + 地点不足回退 + i18n）

### DIFF
--- a/api/src/routes/locations/queries.ts
+++ b/api/src/routes/locations/queries.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { logger } from "../../lib/logger";
-import { eq, like, and, sql, inArray } from "drizzle-orm";
+import { eq, like, and, sql, inArray, not } from "drizzle-orm";
 import { createDb } from "../../db";
 import * as schema from "../../db/schema";
 import type { Env } from "../../lib/auth";
@@ -180,7 +180,59 @@ queries.get("/", async (c) => {
         };
       });
 
-      return { success: true, locations: formattedLocations, pagination: { page, pageSize, total, totalPages } };
+      // P1 (city 个性化 #192 T2): city 过滤不足 → 以 hot 补位（仅首页 view=card 走此路径）
+      let cityMatch: 'exact' | 'mixed' | 'fallback' | null = null;
+      if (cityId && view === 'card' && total >= pageSize) {
+        cityMatch = 'exact';
+      } else if (cityId && view === 'card' && formattedLocations.length < pageSize) {
+        const existingIds = new Set(formattedLocations.map(l => l.id));
+        const needed = pageSize - formattedLocations.length;
+        const hotRows = await db
+          .select({
+            id: schema.locations.id,
+            name: schema.locations.name,
+            slug: schema.locations.slug,
+            type: schema.locations.type,
+            subtitle: schema.locations.subtitle,
+            description: schema.locations.description,
+            address: schema.locations.address,
+            cityName: schema.locations.cityName,
+            coverImage: schema.locations.coverImage,
+            difficulty: schema.locations.difficulty,
+            durationMin: schema.locations.durationMin,
+            durationMax: schema.locations.durationMax,
+            distance: schema.locations.distance,
+            elevation: schema.locations.elevation,
+            createdAt: schema.locations.createdAt,
+          })
+          .from(schema.locations)
+          .where(existingIds.size > 0 ? not(inArray(schema.locations.id, Array.from(existingIds))) : undefined)
+          .orderBy(sql`created_at DESC`)
+          .limit(needed);
+        for (const h of hotRows) {
+          formattedLocations.push({
+            id: h.id, name: h.name, slug: h.slug,
+            type: h.type, subtitle: h.subtitle,
+            description: h.description, address: h.address,
+            cityName: h.cityName, coverImage: h.coverImage,
+            difficulty: h.difficulty ?? null,
+            durationMin: h.durationMin ?? null,
+            durationMax: h.durationMax ?? null,
+            distance: h.distance ?? null,
+            elevation: h.elevation ?? null,
+            tags: [],
+            createdAt: h.createdAt,
+          });
+        }
+        cityMatch = total > 0 ? 'mixed' : 'fallback';
+      }
+
+      return {
+        success: true,
+        locations: formattedLocations,
+        pagination: { page, pageSize, total, totalPages },
+        ...(cityMatch ? { _meta: { cityMatch } } : {}),
+      };
     }
 
     // ==================== 完整模式（默认） ====================

--- a/api/src/routes/recommendations/home.ts
+++ b/api/src/routes/recommendations/home.ts
@@ -62,6 +62,7 @@ home.get("/", async (c) => {
       kv: c.env.GOMATE_KV,
       request: c.req.raw,
       sessionCity,
+      cityIdFilter: sessionCity, // P1: 原始 city ID（如 city_sz）传给 SQL filter
       seed,
       salt: c.env.RECOMMEND_CACHE_SALT,
     });
@@ -70,6 +71,7 @@ home.get("/", async (c) => {
       recommendations: result.recommendations,
       candidatePoolSize: result.candidatePoolSize,
       nextSeed: result.nextSeed,
+      _meta: result._meta,
     });
   } catch (err) {
     logger.error("[recommendations/home] failed", err);

--- a/api/src/services/recommendations.ts
+++ b/api/src/services/recommendations.ts
@@ -116,6 +116,9 @@ export interface RecommendationsResult {
     bucket: number;
     key: string;
   };
+  _meta: {
+    cityMatch: 'exact' | 'mixed' | 'fallback';
+  };
 }
 
 export interface RecommendInput {
@@ -123,6 +126,8 @@ export interface RecommendInput {
   kv?: KVNamespace;
   request: Request;
   sessionCity?: string | null;
+  /** P1 city 个性化 #195 T1：SQL 过滤用的原始 city ID（如 city_sz），非归一化名 */
+  cityIdFilter?: string | null;
   seed?: string | null;
   now?: number; // 测试注入
   salt?: string; // env.RECOMMEND_CACHE_SALT
@@ -222,13 +227,13 @@ interface SignalRow {
   new_teams_7d: number;
 }
 
-async function fetchSignals(db: Db, now: number): Promise<SignalRow[]> {
+async function fetchSignals(db: Db, now: number, cityFilter?: string | null): Promise<SignalRow[]> {
   const nowMs = now;
   const sevenDaysAgo = now - 7 * 24 * 60 * 60 * 1000;
   const sevenDaysAhead = now + 7 * 24 * 60 * 60 * 1000;
 
   // Drizzle sql`` — 参数化 timestamps，防止 SQL 注入且让 SQLite planner 用 prepared cache
-  const rows = await db.all<SignalRow>(sql`
+  const query = sql`
     SELECT
       l.id AS id,
       l.name AS name,
@@ -281,9 +286,14 @@ async function fetchSignals(db: Db, now: number): Promise<SignalRow[]> {
         AND status = 'recruiting'
       GROUP BY location_id
     ) nt ON nt.location_id = l.id
-  `);
+  `;
 
-  return rows;
+  // P1 city 个性化 #195 T1: 按 cityId 软过滤
+  const fullQuery = cityFilter
+    ? sql`${query} WHERE l.city_id = ${cityFilter}`
+    : query;
+
+  return await db.all<SignalRow>(fullQuery);
 }
 
 // ==================== 候选评分 ====================
@@ -717,53 +727,100 @@ export async function recommendHome(input: RecommendInput): Promise<Recommendati
   const { city } = getCurrentCity(input.request, input.sessionCity);
   const season = getCurrentSeason(new Date(now), city);
 
-  // cache key
+  // IP + UA（cache key 成分，不存数据库）
   const ip = input.request.headers.get("cf-connecting-ip") || "unknown-ip";
   const ua = input.request.headers.get("user-agent") || "unknown-ua";
-  const cacheKey = await buildCacheKey({ salt, ip, ua, city, bucket });
 
-  // 读 KV
   let pool: Pool | null = null;
   let cacheHit = false;
+  let cityMatch: 'exact' | 'mixed' | 'fallback' = 'fallback';
+  let cacheCity = city; // cache key 中的 city 段（含纯/混后缀）
+
+  // ==================== KV cache 读取（含 pure/mixed 分桶）====================
   if (input.kv) {
-    try {
-      const raw = await input.kv.get(cacheKey);
-      if (raw) {
-        const cached = JSON.parse(raw) as CachedPool;
-        if (
-          cached &&
-          cached.version === 1 &&
-          cached.bucket === bucket &&
-          cached.season === season
-        ) {
-          pool = await rehydratePool(input.db, cached, now, season);
-          cacheHit = true;
+    if (input.cityIdFilter) {
+      // P1 city 个性化 #195 T1：先试 pure 桶，再试 mixed 桶
+      const pureKey = await buildCacheKey({ salt, ip, ua, city: `${city}:pure`, bucket });
+      const mixedKey = await buildCacheKey({ salt, ip, ua, city: `${city}:mixed`, bucket });
+      for (const [key, label] of [[pureKey, 'exact' as const], [mixedKey, 'mixed' as const]]) {
+        try {
+          const raw = await input.kv.get(key);
+          if (raw) {
+            const cached = JSON.parse(raw) as CachedPool;
+            if (cached && cached.version === 1 && cached.bucket === bucket && cached.season === season) {
+              pool = await rehydratePool(input.db, cached, now, season);
+              cacheHit = true;
+              cacheCity = label === 'exact' ? `${city}:pure` : `${city}:mixed`;
+              cityMatch = label as typeof cityMatch;
+              break;
+            }
+          }
+        } catch {
+          continue;
         }
       }
-    } catch {
-      // KV 失败不阻断，静默回退到重算
-      pool = null;
+    } else {
+      // 无 city 过滤 — 老路径（单桶）
+      try {
+        const cacheKey = await buildCacheKey({ salt, ip, ua, city, bucket });
+        const raw = await input.kv.get(cacheKey);
+        if (raw) {
+          const cached = JSON.parse(raw) as CachedPool;
+          if (cached && cached.version === 1 && cached.bucket === bucket && cached.season === season) {
+            pool = await rehydratePool(input.db, cached, now, season);
+            cacheHit = true;
+          }
+        }
+      } catch {
+        pool = null;
+      }
     }
   }
 
-  // 未命中 → 从 DB 全表算
+  // ==================== 计算（cache miss 时）====================
   if (!pool) {
-    const rows = await fetchSignals(input.db, now);
-    const cands = rows.map((r) => buildCandidate(r, now, season));
-    pool = computePool(cands);
+    if (input.cityIdFilter) {
+      // 1. 按 city 过滤取候选
+      const cityRows = await fetchSignals(input.db, now, input.cityIdFilter);
+      const cityCands = cityRows.map((r) => buildCandidate(r, now, season));
+      const cityPool = computePool(cityCands);
+      const cityTotal = cityPool.steady.length + cityPool.worthy.length + cityPool.fresh.length;
+
+      if (cityTotal >= 3) {
+        // 纯 city 池，足够出 3 卡
+        pool = cityPool;
+        cityMatch = 'exact';
+        cacheCity = `${city}:pure`;
+      } else {
+        // 候选不足 → 混搭深圳热门兜底（两池合并去重再跑 computePool）
+        const allRows = await fetchSignals(input.db, now);
+        const cityIdSet = new Set(cityRows.map((r) => r.id));
+        const mergedRows = [...cityRows, ...allRows.filter((r) => !cityIdSet.has(r.id))];
+        const mergedCands = mergedRows.map((r) => buildCandidate(r, now, season));
+        pool = computePool(mergedCands);
+        cityMatch = cityTotal > 0 ? 'mixed' : 'fallback';
+        cacheCity = `${city}:mixed`;
+      }
+    } else {
+      // 无 city 过滤 — 全表
+      const rows = await fetchSignals(input.db, now);
+      const cands = rows.map((r) => buildCandidate(r, now, season));
+      pool = computePool(cands);
+      cityMatch = 'fallback';
+      cacheCity = city;
+    }
 
     // 异步写 KV（不 await；即便失败也不影响响应）
     if (input.kv) {
+      const cacheKey = await buildCacheKey({ salt, ip, ua, city: cacheCity, bucket });
       const cached = poolToCached(pool, bucket, season);
-      // 用 waitUntil 场景在 route 层再处理，这里直接 fire-and-forget
       void input.kv
         .put(cacheKey, JSON.stringify(cached), { expirationTtl: CACHE_TTL_SECONDS })
-        .catch(() => {
-          /* silent */
-        });
+        .catch(() => { /* silent */ });
     }
   }
 
+  const cacheKey = await buildCacheKey({ salt, ip, ua, city: cacheCity, bucket });
   const recommendations = selectThree(pool, seed);
   const poolSize = pool.steady.length + pool.worthy.length + pool.fresh.length;
 
@@ -776,6 +833,7 @@ export async function recommendHome(input: RecommendInput): Promise<Recommendati
       bucket,
       key: cacheKey,
     },
+    _meta: { cityMatch },
   };
 }
 

--- a/frontend/public/locales/en/home.json
+++ b/frontend/public/locales/en/home.json
@@ -45,12 +45,19 @@
       "fresh_new_teams": "{n} new teams heading out — join early",
       "fresh_fallback": "New this week — check it out"
     },
+    "cityHint": {
+      "mixed": "Mixed with {city} popular picks",
+      "fallback": "No picks for {city} yet — see other popular"
+    },
     "empty": {
       "steady": "No steady pick this week",
       "worthy": "No worthy pick this week",
       "fresh": "Nothing new this week"
     },
     "error": "Failed to load recommendations. Try again later."
+  },
+  "locations": {
+    "cityChip": "📍 {city}"
   },
   "localCircle": {
     "title": "What Your City Did This Week",

--- a/frontend/public/locales/ja/home.json
+++ b/frontend/public/locales/ja/home.json
@@ -46,12 +46,19 @@
       "fresh_new_teams": "{n} チーム新設、早めに参加",
       "fresh_fallback": "今週の新顔、まずは覗いてみて"
     },
+    "cityHint": {
+      "mixed": "{city}の人気とミックス",
+      "fallback": "{city}のおすすめはまだありません — 他の人気をチェック"
+    },
     "empty": {
       "steady": "今週は安定なし",
       "worthy": "今週は特選なし",
       "fresh": "今週は新着なし"
     },
     "error": "おすすめの読み込みに失敗しました。後で再試行してください。"
+  },
+  "locations": {
+    "cityChip": "📍 {city}"
   },
   "localCircle": {
     "title": "今週、あなたの街で",

--- a/frontend/public/locales/zh-CN/home.json
+++ b/frontend/public/locales/zh-CN/home.json
@@ -45,12 +45,19 @@
       "fresh_new_teams": "{n} 支新队伍下周走，抢先加入",
       "fresh_fallback": "本周新面孔，先睹为快"
     },
+    "cityHint": {
+      "mixed": "混搭{city}热门",
+      "fallback": "{city}暂无推荐，看看其他热门"
+    },
     "empty": {
       "steady": "这周没特别稳的",
       "worthy": "这周没特别值得的",
       "fresh": "这周没新的"
     },
     "error": "推荐加载失败，稍后重试"
+  },
+  "locations": {
+    "cityChip": "📍 {city}"
   },
   "localCircle": {
     "title": "本周本地圈子在去哪",

--- a/notes/gomate-home-city-personalization-spec.md
+++ b/notes/gomate-home-city-personalization-spec.md
@@ -1,0 +1,142 @@
+# gomate 首页个性化（city 维度）spec v1.1
+
+> 立项：2026-07-26 Victor DM（msg=fa6418e1）「本周去这三个 和 探索地点 都一起改造，你先设计产品方案」+ 前置 DM（msg=cace1ea2）反馈「gomate 用户设置了地点，但是在首页展示的不是该地点的推荐」
+> 作者：@Steven｜CR：@Martin（msg=c034dc4b PASS v1.1 口径）｜实现：@Jeff / @Bob
+> 触发：P0-C spec v1.1 §386 行写明「city 过滤属 P1 待细化」，本次正式立 P1
+> 事实基线（一手核实 origin/main）：`api/src/services/recommendations.ts:225-291` fetchSignals SQL 无 city 过滤；`api/src/routes/locations/queries.ts:65/81` 支持 `?cityId=`；前端 `frontend/src/hooks/use-locations.ts:33` 未传 cityId；`use-local-circle.ts:30-32` 已正确传 cityId（本地圈子模板已就绪，本 spec 复用同模式）；seed 数据：深圳 city_sz 3 个地点 + 广州 city_gz 1 个地点（**真实用户 city 字段全 NULL，本 spec 解决「写入链路已上线但首页无响应」的预见性问题，不是修当前 bug**）
+>
+> **v1.1 变更（2026-07-26 Martin CR + Victor 拍板）**：
+> ① Q2 异地文案定「热门」（隐藏深圳措辞，避免吐槽；Victor msg=abd23a91）
+> ② Q3 城市 chip 不可点击（与 #185 引导卡 CTA 一致；Victor msg=abd23a91）
+> ③ Q1 阈值改动态：候选 ≥ 阈值即纯 city 池，< 阈值即混搭兜底（Martin 拍 A 路径）
+> ④ cache key 加 city 维度，与 SQL filter 同 commit 内原子完成（Martin 防跨城 cache 污染）
+> ⑤ i18n 命名空间与占位规范见 §4.4
+
+---
+
+## 0. 一句话
+
+**让首页的两块内容真正用上用户的城市**：本周三个选择按 city 软过滤候选池 + 探索地点按 city 优先 + 异地用户的「你城市的地点」明示。本质是把 #181 city 写入链路的价值兑现到首页内容。
+
+## 1. 现状问题（Victor 反馈）
+
+1. **本周三个选择**（`/api/recommendations/home`）：候选池 SQL 全表，过滤规则只用 city 算季节 + cache key——非深圳/异地用户设了 city 后，三卡仍是深圳地点（因为 locations 表 95%+ 是深圳）
+2. **探索地点**（`/api/locations?page=1&pageSize=6`）：前端 hook 不传 cityId，等价全表取最近 6 条，与用户 city 无关
+3. 本地圈子（`/local-circle/home`）已正确传 cityId，**作为本 spec 复用模式**
+
+## 2. 设计原则
+
+- **复用 > 重建**：use-local-circle 的 cityId 模式已上线，本 spec 不发明新约定
+- **软过滤 > 硬过滤**：异地用户零候选时**回退热门**，绝不显示空白（graceful degradation）
+- **明示 > 隐式**：用户异地/候选少时显式提示「展示深圳热门」，避免「我设的城市没生效」的隐性事故
+- **不破坏已有验收**：本周三个选择的 cache 复用（spec §5.2 v1.1）继续生效，只是 cache key 增加 city 维度
+
+## 3. 产品行为矩阵
+
+| 用户态 | city 状态 | 本周三个选择 | 探索地点 |
+|---|---|---|---|
+| 匿名 | 无 city | 全表（现状，季节算 fallback 深圳） | 全表热门 6 条（现状） |
+| 登录已设 city | city = 深圳 | city 过滤（≈全表，因为表里几乎都是深圳） | cityId=深圳过滤 6 条 |
+| 登录已设 city | city = 杭州 | 杭州优先；不足 3 张时混搭深圳热门兜底 | cityId=杭州过滤 6 条；不足时回退深圳热门 |
+| 登录已设 city | city = 不存在地点的城市（如拉萨） | 全表热门（spec 软过滤） | 同上，明示「拉萨暂无 → 深圳热门」 |
+| 登录未设 city | city = null | 全表（fallback 深圳季节） | 全表热门 6 条 |
+
+**「不足」阈值（v1.1 动态规则）**：
+- **本周三个选择**：city 过滤后 `pool.length ≥ 3` → 纯 city 池；< 3 → 启动混搭（city 池 + 深圳热门池合并去重，按 score 排序取 top 3）；= 0 → 全用深圳热门（等同现状）
+- **探索地点**：city 过滤后 `results.length ≥ 6` → 纯 city；< 6 → 补深圳热门至 6 条；= 0 → 全用深圳热门
+- **阈值意义**：触发即「graceful degradation」——避免异地用户首页空白
+- **cache 分桶**：每城 2 桶（pure / mixed），cache key 加 `:pure` / `:mixed` 后缀（§4.1 详）
+
+## 4. 实现方案
+
+### 4.1 后端
+
+#### `/api/recommendations/home` 软过滤（api/src/services/recommendations.ts）
+
+- `fetchSignals` 增加可选 `cityFilter?: string | null` 参数
+- SQL 末尾加 `WHERE l.cityId = ${cityFilter}`（参数化防注入）
+- 算法入口 `recommendHome`：根据 `getCurrentCity` 结果决定：
+  - city = fallback（深圳）+ sessionCity = null → 不传 cityFilter（全表，现状）
+  - city = sessionCity 真实值 → 传 cityFilter
+- 候选不足时（filter 后 < 3 张）→ 二次 SQL `fetchSignals` 不带 filter，全表兜底，两池合并后跑 `computePool`
+- `cache key` 增加 city 维度：异地用户和深圳用户**不共享候选池**，避免 cache 跨城污染
+- 响应增加 `_meta.cityMatch: 'exact' | 'mixed' | 'fallback'` 让前端可显示「混搭热门」标识（可选 N1）
+
+#### `/api/locations?cityId=xxx` 增强（api/src/routes/locations/queries.ts）
+
+- cityId 过滤逻辑已存在（line 81），**不重写**
+- 增加：cityId 过滤后结果 < pageSize → 自动二次查询不带 cityId 的热门 pageSize-N 条合并
+- 响应增加 `_meta.cityMatch` 同上
+
+### 4.2 前端
+
+#### 本周三个选择（`home-recommendations-section.tsx`）
+
+- 不动 UI 结构（保留首页极简 v1.1 验收）
+- 不动请求结构（fetch `/api/recommendations/home` 不带参数，city 由 session 提供）
+- 备选 N1：响应 `_meta.cityMatch: 'mixed' | 'fallback'` 时，卡片下方小灰字「混搭深圳热门」一行（可选，A/B 时定）
+
+#### 探索地点（`home-locations-section.tsx` + `use-home-data.ts`）
+
+- `useHomeData` 接收 `userCity?: string | null`（useSession 提供）
+- `useLocations(page, pageSize, initialData, cityId?)` 增加 cityId 可选参数
+- 城市未设 → 不传 cityId（现状）；设了 → 传 cityId
+- 标题右侧加城市 chip：「📍 深圳」（仅登录 + 已设时显示，匿名/未设不显示，与 #185 引导卡口径一致）
+- 备选 N2：城市 chip 可点击跳「设置城市」页（与 #185 引导卡 CTA 复用）
+
+### 4.3 数据 fact-check
+
+- [x] ~~Jeff 跑 `SELECT cityId, COUNT(*) FROM locations GROUP BY cityId`~~ —— **取消**（事实层：seed 数据已覆盖阈值推导；动态规则下不需要硬绑数字）
+- [x] ~~Jeff 跑 `SELECT cityId, COUNT(*) FROM users WHERE city IS NOT NULL GROUP BY cityId`~~ —— **取消**（用户 city 全 NULL，spec 解决「写入链路已就绪但首页无响应」的预见性问题，不是修当前 bug）
+- seed 数据已用：深圳 3 个地点（city_sz）+ 广州 1 个地点（city_gz）—— 广州用户必触发混搭阈值，证明动态规则必要
+
+### 4.4 i18n（v1.1 新增）
+
+挂 `home.recommendations.cityHint` / `home.locations.cityChip` 命名空间，复用 `home.localCircle.neighborCount` 的 `{city}` 占位惯例：
+
+| key | zh-CN | en | ja |
+|---|---|---|---|
+| `home.recommendations.cityHint.mixed` | `混搭{city}热门` | `Mixed with {city} popular picks` | `{city}の人気とミックス` |
+| `home.recommendations.cityHint.fallback` | `{city}暂无推荐，看看其他热门` | `No picks for {city} yet — see other popular` | `{city}のおすすめはまだありません — 他の人気をチェック` |
+| `home.locations.cityChip` | `📍 {city}` | `📍 {city}` | `📍 {city}` |
+
+三语各 3 条，共 9 条。`city` 占位由前端通过 `i18n.format()` 注入（与 #185 引导卡同款机制）。
+
+## 5. 验收标准
+
+1. 异地登录用户（如杭州）首页：本周三个选择 ≥ 1 张是杭州地点 + 探索地点前 6 条 ≥ 3 条是杭州地点（数据允许范围内）
+2. 异地零候选用户（如拉萨）：首页显示深圳热门 + 明示「拉萨暂无推荐，深圳热门」一行小灰字
+3. 匿名/未设 city 用户：行为与现状完全一致（无 regression）
+4. 缓存：异地用户与深圳用户 cache key 不串扰
+5. 本地圈子（已上线）行为不回归
+6. i18n 三语通过；移动端横滑/紧凑卡行为不破
+
+## 6. 任务拆分建议
+
+| 任务 | 内容 | 工作量 |
+|---|---|---|
+| T1 | 后端 recommendations.ts 软过滤 + cache key city 维度（pure/mixed 分桶）+ _meta.cityMatch ——**单 commit 内原子完成**（Martin 防跨城 cache 污染） | M |
+| T2 | 后端 locations/queries.ts city 不足回退 + _meta.cityMatch | S |
+| T3 | 前端 useHomeData + useLocations cityId 参数 + 标题城市 chip（不可点击）+ 异地明示（§4.4 文案） | S-M |
+| T4 | i18n keys（§4.4 三语 9 条） | S |
+
+T4 与 T1+T2 可并行（不同模块 / 不同文件），T3 等 T1/T2 后端 ready 才能闭环（消费 _meta.cityMatch）。
+
+## 7. Out of scope
+
+- 不动首页极简视觉（v1.1 已收官）
+- 不动 P0-A / P0-B / P0-D 任何 spec
+- 不动 use-local-circle 的 cityId 模式（已正确）
+- 不做按用户徒步历史的个性化（#182 P2）
+
+## 8. 风险与回滚
+
+- **风险 1**：软过滤触发频率远超预期 → cache miss 飙升 → Jeff 监控 cache hit rate，回滚阈值降级到硬过滤（B 路径）
+- **风险 2**：异地明示文案引发「为啥默认深圳」的吐槽 → 文案改为「按热门排序」（隐藏默认城市）
+- **回滚**：所有改动走独立 PR（推荐 home + locations + 前端），不与本周极简 PR 链合并；revert 单 PR 即可全回退
+
+---
+
+_v1.0 2026-07-26 @Steven。事实基线一手 grep：`fetchSignals` SQL 全表（recommendations.ts:225-291）/ `?cityId=` 后端已支持（locations/queries.ts:65/81）/ 前端未传（use-locations.ts:33）/ 本地圈子已传（use-local-circle.ts:30-32 复用模式）/ 用户 city 写入链路已就绪（#181）。_
+
+_v1.1 2026-07-26 @Steven。Martin CR msg=c034dc4b PASS 阈值动态 + cache key 随 T1 + i18n 命名空间；Victor DM msg=abd23a91 拍 Q2「热门」+ Q3 chip 不可点击；fact-check 双取消（seed 已证伪硬绑数 + city 全 NULL 是预见性问题）。4 任务 T1/T2/T4 并行 + T3 串行依赖。_


### PR DESCRIPTION
## 改动范围

4 commits, 6 files changed, 165 insertions, 32 deletions

### T1: recommendations.ts city 软过滤 + cache key pure/mixed 分桶 + `_meta.cityMatch` (#195)
- `fetchSignals` 加可选 `cityFilter` 参数
- `recommendHome` 当 `cityIdFilter` 设时，先按 city 过滤；pool < 3 时混合深圳热门兜底（两池合并去重再跑 computePool）
- cache key 纯 city → `:pure` 后缀，混搭 → `:mixed` 后缀（双桶 KV 防跨城污染）
- 响应附加 `_meta.cityMatch: 'exact' | 'mixed' | 'fallback'`
- route handler 传 `cityIdFilter = sessionCity`

### T2: locations city 不足回退 + `_meta.cityMatch` (#192)
- view=card 模式下 cityId 过滤结果 < pageSize → 自动补 created_at DESC hot 位
- 只影响首页「探索地点」路径，不干扰城市筛选常规行为

### T4: i18n 首页 city 个性化三语 9 条 (#194)
- `home.recommendations.cityHint.{mixed,fallback}` + `home.locations.cityChip`
- zh/en/ja 各 3 条

### spec
- `notes/gomate-home-city-personalization-spec.md` v1.1 入库

## 验证
- API type-check ✅
- API 332/333 PASS（唯一失败 = pre-existing local-circle timeout）
- 59/59 recommendation 单测全绿

## Martin CR nit 响应
- T2 fallback 排序：`created_at DESC`（现有 query 无 ORDER BY，新创建地点作为「热门」语义）

## 红线遗留
- 无

Co-Authored-By: Claude <noreply@anthropic.com>