### PR TITLE
P1: 首页 city 个性化 T3（前端闭环 — 城市 chip + 异地明示 + cityId 参数）

### DIFF
--- a/frontend/src/components/features/home/home-locations-section.tsx
+++ b/frontend/src/components/features/home/home-locations-section.tsx
@@ -5,15 +5,29 @@ import { LocationCard } from "./home-location-card";
 type HomeData = ReturnType<typeof useHomeData>;
 
 export function HomeLocationsSection({ data }: { data: HomeData }) {
-  const { locations, isLoading, locationsRef, locationsInView } = data;
+  const { locations, isLoading, locationsRef, locationsInView, userCity, cityMatch } = data;
   const { t } = useI18n(["home", "locations", "common"]);
+
+  // P1 city 个性化 #193 T3: 标题右侧城市 chip（仅已设 city + exact/mixed 可识别城市名时）
+  const showCityChip = userCity && cityMatch && cityMatch !== "fallback" && locations[0]?.cityName;
+  const cityChipName = showCityChip ? locations[0].cityName : null;
 
   return (
     <section id="locations" ref={locationsRef}
       className={`py-12 sm:py-16 lg:py-20 bg-background section-hidden ${locationsInView ? "section-visible" : ""}`}>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12">
-          <h2 className="text-4xl md:text-5xl font-bold text-foreground">{t("locations.pageTitle")}</h2>
+          <h2 className="text-4xl md:text-5xl font-bold text-foreground inline-flex items-center gap-3 justify-center">
+            {t("locations.pageTitle")}
+            {cityChipName && (
+              <span
+                className="inline-flex items-center text-base font-normal text-stone-500 dark:text-stone-400"
+                data-testid="locations-city-chip"
+              >
+                {t("home.locations.cityChip", { city: cityChipName })}
+              </span>
+            )}
+          </h2>
         </div>
 
         {isLoading ? (

--- a/frontend/src/components/features/home/home-main.tsx
+++ b/frontend/src/components/features/home/home-main.tsx
@@ -32,7 +32,7 @@ export function HomeClient({ initialData }: { initialData?: HomeInitialData }) {
         <Navbar />
         <HomeHero data={data} />
         {/* P0-C T2：本周三个选择（Hero 之后 / Locations 之前） */}
-        <HomeRecommendationsSection userCity={data.userCity} cityName={data.locations[0]?.cityName ?? null} />
+        <HomeRecommendationsSection userCity={data.userCity} cityName={data.locations.length > 0 ? data.locations[0].cityName : null} />
         {/* P0-D T2：首页本地圈子模块（推荐位之后 / Locations 之前） */}
         <HomeLocalCircleSection />
         <HomeLocationsSection data={data} />

--- a/frontend/src/components/features/home/home-main.tsx
+++ b/frontend/src/components/features/home/home-main.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as React from "react";
 import { Navbar } from "@/components/layout/navbar";
 import { useHomeData, type HomeInitialData } from "./use-home-data";
 import { HomeHero } from "./home-hero";
@@ -9,9 +10,19 @@ import { HomeRecommendationsSection } from "./recommendations/home-recommendatio
 import { HomeLocalCircleSection } from "./local-circle/home-local-circle-section";
 import { OnboardingModal } from "@/components/features/onboarding/onboarding-modal";
 import { PreloadImages } from "./preload-images";
+import { fetchCurrentUser } from "@/lib/api";
 
 export function HomeClient({ initialData }: { initialData?: HomeInitialData }) {
-  const data = useHomeData(initialData);
+  const [userCity, setUserCity] = React.useState<string | null | undefined>(undefined);
+
+  // P1 city 个性化 #193 T3: 获取用户 city，用于探索地点城市筛选
+  React.useEffect(() => {
+    fetchCurrentUser()
+      .then((user) => setUserCity(user?.city ?? null))
+      .catch(() => setUserCity(null));
+  }, []);
+
+  const data = useHomeData(initialData, userCity);
 
   return (
     <>
@@ -21,7 +32,7 @@ export function HomeClient({ initialData }: { initialData?: HomeInitialData }) {
         <Navbar />
         <HomeHero data={data} />
         {/* P0-C T2：本周三个选择（Hero 之后 / Locations 之前） */}
-        <HomeRecommendationsSection />
+        <HomeRecommendationsSection userCity={data.userCity} cityName={data.locations[0]?.cityName ?? null} />
         {/* P0-D T2：首页本地圈子模块（推荐位之后 / Locations 之前） */}
         <HomeLocalCircleSection />
         <HomeLocationsSection data={data} />

--- a/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
+++ b/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
@@ -22,7 +22,7 @@ import type { Recommendation, RecommendationsResponse } from "./types";
 
 type FetchState =
   | { status: "loading" }
-  | { status: "ready"; recommendations: Recommendation[]; nextSeed: string }
+  | { status: "ready"; recommendations: Recommendation[]; nextSeed: string; cityMatch: 'exact' | 'mixed' | 'fallback' | null }
   | { status: "error"; message: string };
 
 async function fetchRecommendations(seed?: string): Promise<RecommendationsResponse> {
@@ -36,7 +36,14 @@ async function fetchRecommendations(seed?: string): Promise<RecommendationsRespo
   return (await res.json()) as RecommendationsResponse;
 }
 
-export function HomeRecommendationsSection() {
+interface HomeRecommendationsSectionProps {
+  /** P1 city 个性化 #193 T3: 用户 cityId */
+  userCity?: string | null;
+  /** userCity 对应的城市名（来自探索地点首个 location.cityName），用于异地明示文案插值 */
+  cityName?: string | null;
+}
+
+export function HomeRecommendationsSection({ userCity, cityName }: HomeRecommendationsSectionProps) {
   const { t } = useI18n(["home", "enums"]);
   const [state, setState] = React.useState<FetchState>({ status: "loading" });
   const [refreshing, setRefreshing] = React.useState(false);
@@ -52,6 +59,7 @@ export function HomeRecommendationsSection() {
           status: "ready",
           recommendations: data.recommendations,
           nextSeed: data.nextSeed,
+          cityMatch: data._meta?.cityMatch ?? null,
         });
       })
       .catch((err) => {
@@ -78,6 +86,7 @@ export function HomeRecommendationsSection() {
         status: "ready",
         recommendations: data.recommendations,
         nextSeed: data.nextSeed,
+        cityMatch: data._meta?.cityMatch ?? null,
       });
     } catch (err) {
       console.error("[HomeRecommendations] refresh failed:", err);
@@ -170,6 +179,17 @@ export function HomeRecommendationsSection() {
               ))}
             </div>
           </>
+        )}
+
+        {/* P1 city 个性化 #193 T3: cityMatch 非 exact 时异地明示 */}
+        {state.status === "ready" && userCity && state.cityMatch && state.cityMatch !== "exact" && (
+          <div className="mt-4 text-center">
+            <p className="text-xs text-stone-500 dark:text-stone-400" data-testid="recommendation-city-hint">
+              {state.cityMatch === "mixed"
+                ? t("home.recommendations.cityHint.mixed", { city: cityName ?? "" })
+                : t("home.recommendations.cityHint.fallback", { city: cityName ?? "" })}
+            </p>
+          </div>
         )}
 
         {/* Refresh CTA — 桌面居右标题行（弱化为文字按钮）；移动端居中可见

--- a/frontend/src/components/features/home/recommendations/types.ts
+++ b/frontend/src/components/features/home/recommendations/types.ts
@@ -65,4 +65,7 @@ export interface RecommendationsResponse {
   recommendations: Recommendation[];
   candidatePoolSize: number;
   nextSeed: string;
+  _meta?: {
+    cityMatch: 'exact' | 'mixed' | 'fallback';
+  };
 }

--- a/frontend/src/components/features/home/use-home-data.ts
+++ b/frontend/src/components/features/home/use-home-data.ts
@@ -12,10 +12,15 @@ export interface HomeInitialData {
   teams?: Team[];
 }
 
-export function useHomeData(initialData?: HomeInitialData) {
-  // 使用 SWR 获取地点列表（带缓存）
+/**
+ * @param userCity 用户的 cityId（P1 city 个性化 #193 T3），空/null 时不传
+ */
+export function useHomeData(initialData?: HomeInitialData, userCity?: string | null) {
+  // 使用 SWR 获取地点列表（带缓存 + city 维度）
   const [currentPage, setCurrentPage] = React.useState(1);
-  const { locations, pagination, isLoading, error: _error } = useLocations(currentPage, 6, initialData?.locations);
+  const { locations, pagination, cityMatch, isLoading, error: _error } = useLocations(
+    currentPage, 6, initialData?.locations, userCity,
+  );
 
   const [teams, setTeams] = React.useState<Team[]>(initialData?.teams ?? []);
   const [teamsLoading, setTeamsLoading] = React.useState(!initialData?.teams);
@@ -83,11 +88,12 @@ export function useHomeData(initialData?: HomeInitialData) {
   };
 
   return {
-    locations, teams, teamsLoading, isLoading, currentPage, pagination, isDark,
+    locations, teams, teamsLoading, isLoading, currentPage, pagination, cityMatch, isDark,
     preloadImages,
     animate, parallaxY, search,
     locationsRef, locationsInView,
     teamsRef, teamsInView,
+    userCity: userCity ?? null,
     setCurrentPage, fetchLocations, handleSearch,
   };
 }

--- a/frontend/src/hooks/use-locations.ts
+++ b/frontend/src/hooks/use-locations.ts
@@ -13,12 +13,16 @@ export interface LocationsResponse {
     total: number;
     totalPages: number;
   };
+  _meta?: {
+    cityMatch: 'exact' | 'mixed' | 'fallback';
+  };
 }
 
 /**
- * 获取地点列表，支持分页
+ * 获取地点列表，支持分页和城市筛选
+ * @param cityId 可选 cityId，登录用户已设城市时传入（P1 city 个性化 #193 T3）
  */
-export function useLocations(page = 1, pageSize = 6, initialData?: LocationsResponse | null) {
+export function useLocations(page = 1, pageSize = 6, initialData?: LocationsResponse | null, cityId?: string | null) {
   const [data, setData] = useState<LocationsResponse | null>(initialData ?? null);
   const [isLoading, setIsLoading] = useState(!initialData);
   const [error, setError] = useState<Error | null>(null);
@@ -30,7 +34,8 @@ export function useLocations(page = 1, pageSize = 6, initialData?: LocationsResp
     setIsLoading(true);
     setError(null);
     try {
-      const res = await fetchPublicAPI(`/api/locations?page=${page}&pageSize=${pageSize}&view=card`);
+      const cityParam = cityId ? `&cityId=${encodeURIComponent(cityId)}` : "";
+      const res = await fetchPublicAPI(`/api/locations?page=${page}&pageSize=${pageSize}&view=card${cityParam}`);
       const json = await res.json();
       if (!json.success) {
         throw new Error(json.error || "获取地点列表失败");
@@ -41,7 +46,7 @@ export function useLocations(page = 1, pageSize = 6, initialData?: LocationsResp
     } finally {
       setIsLoading(false);
     }
-  }, [page, pageSize]);
+  }, [page, pageSize, cityId]);
 
   useEffect(() => {
     const key = `${page}:${pageSize}`;
@@ -59,6 +64,7 @@ export function useLocations(page = 1, pageSize = 6, initialData?: LocationsResp
   return {
     locations: data?.locations ?? [],
     pagination: data?.pagination ?? { page, pageSize, total: 0, totalPages: 0 },
+    cityMatch: data?._meta?.cityMatch ?? null,
     isLoading,
     error,
     mutate,


### PR DESCRIPTION
## 改动范围

6 files, +74 / -14

### T3: 前端首页 city 个性化闭环 (#193)

- **useLocations**: 新增  参数，设时传至 API；响应含 
- **useHomeData**: 接收 ，传入 ；返回  + 
- **home-main**: 调用  获取 
- **HomeLocationsSection**: 标题右侧城市 chip「📍 {city}」（仅已设 city 时显示）
- **HomeRecommendationsSection**: 消费 ，mixed/fallback 时小灰字异地明示
- i18n keys: `home.locations.cityChip` + `home.recommendations.cityHint.*`

### 依赖
- 后端 T1/T2（PR #423）已合 main

### 验证
- Frontend tsc —noEmit ✅
- pnpm i18n:build ✅

Co-Authored-By: Claude <noreply@anthropic.com>