### PR TITLE
fix #197: profile页增加所在城市展示

### DIFF
--- a/frontend/public/locales/en/locations.json
+++ b/frontend/public/locales/en/locations.json
@@ -1,5 +1,6 @@
 {
   "pageTitle": "Explore Locations",
+  "pageSubtitle": "Cafes, parks, mountains, coastlines — find your next destination",
   "locationIntro": "Location Intro",
   "locationList": "Locations",
   "defaultCity": "All",

--- a/frontend/public/locales/ja/locations.json
+++ b/frontend/public/locales/ja/locations.json
@@ -1,5 +1,6 @@
 {
   "pageTitle": "スポットを探索",
+  "pageSubtitle": "カフェ、公園、山、海岸。あなたに合った次の目的地を見つけよう",
   "locationIntro": "スポット紹介",
   "locationList": "スポット一覧",
   "defaultCity": "すべて",

--- a/frontend/public/locales/zh-CN/locations.json
+++ b/frontend/public/locales/zh-CN/locations.json
@@ -1,5 +1,6 @@
 {
   "pageTitle": "探索地点",
+  "pageSubtitle": "咖啡馆、公园，山野、海岸，找到适合你的下一个目的地",
   "locationIntro": "地点介绍",
   "locationList": "地点列表",
   "defaultCity": "全部",

--- a/frontend/src/__tests__/home-recommendations-section.test.tsx
+++ b/frontend/src/__tests__/home-recommendations-section.test.tsx
@@ -163,8 +163,8 @@ describe("HomeRecommendationsSection", () => {
     mockFetch.mockResolvedValueOnce(okResponse(makeResponse()));
     fireEvent.click(screen.getByTestId("recommendation-retry-btn"));
     await waitFor(() => {
-      const desktopContainer = screen.getByTestId("recommendation-cards-desktop");
-      expect(within(desktopContainer).getByTestId("recommendation-card-steady")).toBeTruthy();
+      const desktopReadyContainer = screen.getByTestId("recommendation-cards-desktop");
+      expect(within(desktopReadyContainer).getByTestId("recommendation-card-steady")).toBeTruthy();
     });
     errSpy.mockRestore();
   });

--- a/frontend/src/components/features/profile-client.tsx
+++ b/frontend/src/components/features/profile-client.tsx
@@ -18,7 +18,7 @@ import { Footer } from "@/components/layout/footer";
 import { StatusBadge } from "@/components/ui/status-badge";
 import { cn } from "@/lib/utils";
 import { formatBirthday, getAgeNumber } from "@/lib/user-utils";
-import type { SessionUser, Team } from "@/lib/types";
+import type { SessionUser, Team, City } from "@/lib/types";
 
 const LEVEL_CONFIG: Record<string, {
   badge: string;
@@ -69,6 +69,7 @@ export function ProfileClient() {
   const [createdTotal, setCreatedTotal] = React.useState(0);
   const [joinedTotal, setJoinedTotal] = React.useState(0);
   const [completedTotal, setCompletedTotal] = React.useState(0);
+  const [cityName, setCityName] = React.useState<string | null>(null);
 
   const loadProfile = React.useCallback(async () => {
     setIsLoading(true);
@@ -77,6 +78,15 @@ export function ProfileClient() {
       if (!u) return;
       setUser((u as unknown) as SessionUser);
       loadTeams(u.id as string);
+      // 解析 cityId → cityName
+      if ((u as unknown as SessionUser).city) {
+        try {
+          const res = await fetchAPI("/api/cities?pageSize=100");
+          const json = await res.json() as { cities?: City[] };
+          const match = json.cities?.find((c) => c.id === (u as unknown as SessionUser).city);
+          if (match) setCityName(match.name);
+        } catch { /* silent */ }
+      }
     } finally {
       setIsLoading(false);
     }
@@ -251,6 +261,12 @@ export function ProfileClient() {
             <section className="space-y-5">
               {/* 徽章行 */}
               <div className="flex flex-wrap gap-1.5">
+                {cityName && (
+                  <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-stone-50 dark:bg-zinc-800 text-stone-600 dark:text-zinc-400 border border-stone-100 dark:border-zinc-700">
+                    <MapPin className="h-3 w-3" />
+                    {cityName}
+                  </span>
+                )}
                 {(user.completedHikes ?? 0) > 0 && (
                   <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-stone-50 dark:bg-zinc-800 text-stone-600 dark:text-zinc-400 border border-stone-100 dark:border-zinc-700">
                     <Mountain className="h-3 w-3" />


### PR DESCRIPTION
## fix #197 — profile 页增加所在城市展示

**改动**： 中，在个人简介的徽章行增加城市显示 badge：
- 头像/昵称下方现有标签列表中新增一行 MapPin + 城市名
- 通过  解析 cityId 到 cityName
- 未设置 city 时不显示
- 风格与现有性别/生日/徒步数标签一致（stone 色 pill badge）

**验收**：
1. 登录未设 city 用户 → 无城市标签（旧行为不变）
2. 设了 city 的用户 → 标签行出现「📍 深圳」风格 badge
3. 空/网络错误时静默降级，不阻塞页面