### PR TITLE
fix #198: city 0候选时不兜底热门，直接隐藏推荐区

### DIFF
--- a/api/src/services/recommendations.ts
+++ b/api/src/services/recommendations.ts
@@ -791,15 +791,28 @@ export async function recommendHome(input: RecommendInput): Promise<Recommendati
         pool = cityPool;
         cityMatch = 'exact';
         cacheCity = `${city}:pure`;
-      } else {
-        // 候选不足 → 混搭深圳热门兜底（两池合并去重再跑 computePool）
+      } else if (cityTotal > 0) {
+        // 候选不足（1-2 条）→ 混搭热门兜底
         const allRows = await fetchSignals(input.db, now);
         const cityIdSet = new Set(cityRows.map((r) => r.id));
         const mergedRows = [...cityRows, ...allRows.filter((r) => !cityIdSet.has(r.id))];
         const mergedCands = mergedRows.map((r) => buildCandidate(r, now, season));
         pool = computePool(mergedCands);
-        cityMatch = cityTotal > 0 ? 'mixed' : 'fallback';
+        cityMatch = 'mixed';
         cacheCity = `${city}:mixed`;
+      } else {
+        // city 0 候选 → 不兜底热门，直接返回空（#198）
+        return {
+          recommendations: [],
+          candidatePoolSize: 0,
+          nextSeed,
+          cache: {
+            hit: false,
+            bucket,
+            key: await buildCacheKey({ salt, ip, ua, city: `${city}:fallback`, bucket }),
+          },
+          _meta: { cityMatch: 'fallback' },
+        };
       }
     } else {
       // 无 city 过滤 — 全表

--- a/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
+++ b/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
@@ -97,7 +97,8 @@ export function HomeRecommendationsSection({ userCity, cityName }: HomeRecommend
   }, [state, refreshing]);
 
   // 空态：三类全空 → 不渲染整个 section（spec §7.4）
-  if (state.status === "ready" && state.recommendations.length === 0) {
+  // 也：设了 city 但 0 候选（fallback）→ 不兜底热门，直接隐藏
+  if (state.status === "ready" && (state.recommendations.length === 0 || (userCity && state.cityMatch === "fallback"))) {
     return null;
   }
 

--- a/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
+++ b/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
@@ -97,8 +97,7 @@ export function HomeRecommendationsSection({ userCity, cityName }: HomeRecommend
   }, [state, refreshing]);
 
   // 空态：三类全空 → 不渲染整个 section（spec §7.4）
-  // 也：设了 city 但 0 候选（fallback）→ 不兜底热门，直接隐藏
-  if (state.status === "ready" && (state.recommendations.length === 0 || (userCity && state.cityMatch === "fallback"))) {
+  if (state.status === "ready" && state.recommendations.length === 0) {
     return null;
   }
 


### PR DESCRIPTION
## fix #198

**背景**：Victor 设广州后看到深圳推荐（广州 0 条地点 → fallback 到全表热门）。Martin/Steven 确定根因是数据现状，不是 bug。

**改动**：`api/src/services/recommendations.ts`：
- city 过滤后候选数 = 0 → 直接返回空推荐（不再兜底全表热门）
- 前端无须改动——现存的 `recommendations.length === 0 → return null` 已覆盖
- city 候选 1-2 条时仍混搭兜底 hot，行为不变

**不影响**：
- 匿名用户（无 city）→ 旧行为不变（全表推荐）
- exact/mixed → 正常显示
- error/loading/换一批 → 不变