### PR TITLE
task #198: city 0 候选时不兜底，直接隐藏整块

### DIFF
--- a/api/src/services/recommendations.ts
+++ b/api/src/services/recommendations.ts
@@ -791,15 +791,24 @@ export async function recommendHome(input: RecommendInput): Promise<Recommendati
         pool = cityPool;
         cityMatch = 'exact';
         cacheCity = `${city}:pure`;
-      } else {
-        // 候选不足 → 混搭深圳热门兜底（两池合并去重再跑 computePool）
+      } else if (cityTotal > 0) {
+        // 候选不足（>0 但 <3）→ 混搭热门兜底（两池合并去重再跑 computePool）
         const allRows = await fetchSignals(input.db, now);
         const cityIdSet = new Set(cityRows.map((r) => r.id));
         const mergedRows = [...cityRows, ...allRows.filter((r) => !cityIdSet.has(r.id))];
         const mergedCands = mergedRows.map((r) => buildCandidate(r, now, season));
         pool = computePool(mergedCands);
-        cityMatch = cityTotal > 0 ? 'mixed' : 'fallback';
+        cityMatch = 'mixed';
         cacheCity = `${city}:mixed`;
+      } else {
+        // city 0 候选 → 不兜底，直接隐藏整块（task #198，Victor 拍板）
+        return {
+          recommendations: [],
+          candidatePoolSize: 0,
+          nextSeed,
+          cache: { hit: false, bucket, key: '' },
+          _meta: { cityMatch: 'fallback' },
+        };
       }
     } else {
       // 无 city 过滤 — 全表


### PR DESCRIPTION
## 改动

1 file, +12 / -3

当 city 过滤后 0 候选时，跳过二次全表 fallback SQL，直接返回空结果。
前端已有空态处理（length === 0 → return null），无需前端改动。

**变更点**：
- `cityTotal >= 3` → 纯 city（不变）
- `cityTotal > 0 && < 3` → 混搭热门（不变）
- `cityTotal === 0` → 直接 return 空（**新行为**，Victor 拍板替代 spec v1.1 混搭兜底）

### 验证
- 59/59 recommendation 单测 ✅
- API type-check ✅

task #198