### PR TITLE
Round 3 T2: 换一批过渡动效 (§C)

### DIFF
--- a/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
+++ b/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
@@ -1,5 +1,6 @@
 /**
  * P0-C T2 (task #173) — 首页「本周去这三个」推荐区块
+ * Round 3 T2 (task #200) — 换一批过渡动效
  *
  * spec §3.3 / §5.2 / §7.3 / §7.4：
  *  - 挂在 Hero 之后 / Locations 之前（home-main.tsx）
@@ -9,6 +10,14 @@
  *  - 整块三类全空 → 不渲染整个 section（P0-A 空态一致）
  *  - error 态展示手动重试（不静默 return null，spec §7.4 空态 !== error 态）
  *  - seed 只在内存态，不入 cookie / localStorage（spec §5.2 v1.1 隐私）
+ *
+ * Round 3 §C 过渡动效：
+ *  - 点击换一批 → fade-out(150ms) → skeleton → fade-in(200ms)
+ *  - 快取门控：fade-out 完成时数据已 ready → 跳过骨架直接 fade-in
+ *  - reduced-motion：全部瞬时（由全局 CSS handles）
+ *  - 失败：旧卡复原（fade-in 200ms 自然淡回 opacity-100）
+ *  - skeleton 复用现有 testid，测试断言零改动
+ *  - 移动端换一批后 snap 回首张
  */
 
 "use client";
@@ -24,6 +33,16 @@ type FetchState =
   | { status: "loading" }
   | { status: "ready"; recommendations: Recommendation[]; nextSeed: string; cityMatch: 'exact' | 'mixed' | 'fallback' | null }
   | { status: "error"; message: string };
+
+type RefreshPhase =
+  /** 静止态，ready 卡片正常展示 */
+  | "idle"
+  /** 旧卡 fade-out 中（150ms），fetch 进行中 */
+  | "fadingOut"
+  /** fade-out 完成但数据未就绪，显示骨架屏 */
+  | "showingSkeleton"
+  /** 新卡 fade-in 中（200ms）；失败时也表示旧卡淡回 */
+  | "fadingIn";
 
 async function fetchRecommendations(seed?: string): Promise<RecommendationsResponse> {
   const path = seed
@@ -46,11 +65,23 @@ interface HomeRecommendationsSectionProps {
 export function HomeRecommendationsSection({ userCity, cityName }: HomeRecommendationsSectionProps) {
   const { t } = useI18n(["home", "enums"]);
   const [state, setState] = React.useState<FetchState>({ status: "loading" });
-  const [refreshing, setRefreshing] = React.useState(false);
+  const [phase, setPhase] = React.useState<RefreshPhase>("idle");
+  const [displayedData, setDisplayedData] = React.useState<Recommendation[] | null>(null);
 
-  // 抽出首次/重试共用的加载逻辑
+  // 移动端 scroll container ref（换一批后 snap 回首张）
+  const scrollRef = React.useRef<HTMLDivElement>(null);
+
+  // phase === fadingIn 时 snap 回首张
+  React.useEffect(() => {
+    if (phase === "fadingIn" && scrollRef.current) {
+      scrollRef.current.scrollTo({ left: 0 });
+    }
+  }, [phase]);
+
   const loadInitial = React.useCallback(() => {
     setState({ status: "loading" });
+    setPhase("idle");
+    setDisplayedData(null);
     let cancelled = false;
     fetchRecommendations()
       .then((data) => {
@@ -61,11 +92,14 @@ export function HomeRecommendationsSection({ userCity, cityName }: HomeRecommend
           nextSeed: data.nextSeed,
           cityMatch: data._meta?.cityMatch ?? null,
         });
+        setDisplayedData(data.recommendations);
+        setPhase("idle");
       })
       .catch((err) => {
         if (cancelled) return;
         console.error("[HomeRecommendations] fetch failed:", err);
         setState({ status: "error", message: String(err?.message ?? err) });
+        setPhase("idle");
       });
     return () => {
       cancelled = true;
@@ -78,35 +112,59 @@ export function HomeRecommendationsSection({ userCity, cityName }: HomeRecommend
   }, [loadInitial]);
 
   const handleRefresh = React.useCallback(async () => {
-    if (state.status !== "ready" || refreshing) return;
-    setRefreshing(true);
-    try {
-      const data = await fetchRecommendations(state.nextSeed);
-      setState({
-        status: "ready",
-        recommendations: data.recommendations,
-        nextSeed: data.nextSeed,
-        cityMatch: data._meta?.cityMatch ?? null,
-      });
-    } catch (err) {
+    if (state.status !== "ready" || phase !== "idle") return;
+
+    const currentSeed = state.nextSeed;
+
+    // --- fade-out 阶段（150ms）---
+    setPhase("fadingOut");
+
+    const fetchPromise = fetchRecommendations(currentSeed).catch((err) => {
       console.error("[HomeRecommendations] refresh failed:", err);
-      // 保留已展示的推荐，只提示错误
-    } finally {
-      setRefreshing(false);
+      return null;
+    });
+
+    // Promise.race：快成功（<150ms）先到 → fastSuccess=true；慢成功/慢失败 → timeout 先到
+    const fastSuccess = await Promise.race([
+      fetchPromise,
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 150)),
+    ]);
+
+    if (fastSuccess) {
+      // 快成功（fetch <150ms 返回）：跳过骨架，直接 fade-in
+      setState({ status: "ready", recommendations: fastSuccess.recommendations, nextSeed: fastSuccess.nextSeed, cityMatch: fastSuccess._meta?.cityMatch ?? null });
+      setDisplayedData(fastSuccess.recommendations);
+      setPhase("fadingIn");
+      setTimeout(() => setPhase("idle"), 200);
+    } else {
+      // fade-out 完成时数据未就绪 → 显示骨架，等 fetch 最终结果
+      setPhase("showingSkeleton");
+      const data = await fetchPromise;
+      if (data) {
+        // 快取门控（R2）：fade-out 完成时数据已 ready，跳过骨架直接 fade-in
+        setState({ status: "ready", recommendations: data.recommendations, nextSeed: data.nextSeed, cityMatch: data._meta?.cityMatch ?? null });
+        setDisplayedData(data.recommendations);
+        setPhase("fadingIn");
+        setTimeout(() => setPhase("idle"), 200);
+      } else {
+        // fetch 失败 → 旧卡淡回（fadingIn 让容器从 opacity-0 自然淡回 opacity-100）
+        setPhase("fadingIn");
+        setTimeout(() => setPhase("idle"), 200);
+      }
     }
-  }, [state, refreshing]);
+  }, [state, phase]);
+
+  // --- 渲染分支 ---
 
   // 空态：三类全空 → 不渲染整个 section（spec §7.4）
   if (state.status === "ready" && state.recommendations.length === 0) {
     return null;
   }
 
-  // Error 态：Martin CR B2 —— 不静默 return null，展示 error banner + 手动重试
-  // spec §7.4 明确「整块空 → 不渲染」是空态，与 fetch error 不同语义
+  // Error 态
   if (state.status === "error") {
     return (
       <section
-        /* task #180 a11y：error banner muted 14px 挂门禁 */
         className="py-6 text-center text-sm text-stone-700 dark:text-stone-300"
         data-testid="home-recommendations-error"
       >
@@ -124,6 +182,63 @@ export function HomeRecommendationsSection({ userCity, cityName }: HomeRecommend
     );
   }
 
+  const isLoading = state.status === "loading" || phase !== "idle";
+  const showSkeleton = isLoading && (phase === "showingSkeleton" || state.status === "loading");
+
+  // opacity 类：idle=opacity-100 / fadingOut=opacity-0(150ms) / fadingIn=opacity-100(200ms)
+  // reduced-motion 瞬时：全局 CSS .transition-none 覆盖
+  const containerClass = [
+    "transition-opacity",
+    phase === "idle" ? "opacity-100" : "",
+    phase === "fadingOut" ? "opacity-0 duration-150 ease-out" : "",
+    phase === "fadingIn" ? "opacity-100 duration-200 ease-out" : "",
+    phase === "showingSkeleton" ? "opacity-100" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  // 骨架屏
+  const skeleton = (
+    <>
+      <div className="md:hidden flex overflow-x-auto snap-x snap-mandatory gap-3 pb-2 -mx-4 px-4 scrollbar-hide" ref={scrollRef}>
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex-shrink-0 w-[68%] snap-center h-48 rounded-lg border bg-muted animate-pulse"
+            data-testid="recommendation-card-skeleton"
+          />
+        ))}
+      </div>
+      <div className="hidden md:grid grid-cols-3 gap-4 sm:gap-5" data-testid="recommendation-skeleton-desktop">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-48 rounded-lg border bg-muted animate-pulse"
+            data-testid="recommendation-card-skeleton"
+          />
+        ))}
+      </div>
+    </>
+  );
+
+  // 真实卡片
+  const cards = (
+    <>
+      <div className="md:hidden flex overflow-x-auto snap-x snap-mandatory gap-3 pb-2 -mx-4 px-4 scrollbar-hide" ref={scrollRef}>
+        {(displayedData ?? []).map((reco) => (
+          <div key={reco.locationId} className="flex-shrink-0 w-[68%] snap-center">
+            <RecommendationCard reco={reco} />
+          </div>
+        ))}
+      </div>
+      <div className="hidden md:grid grid-cols-3 gap-4 sm:gap-5" data-testid="recommendation-cards-desktop">
+        {(displayedData ?? []).map((reco) => (
+          <RecommendationCard key={reco.locationId} reco={reco} />
+        ))}
+      </div>
+    </>
+  );
+
   return (
     <section
       id="recommendations"
@@ -131,55 +246,17 @@ export function HomeRecommendationsSection({ userCity, cityName }: HomeRecommend
       data-testid="home-recommendations-section"
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        {/* Title — eyebrow badge removed per spec §3 item 7 */}
+        {/* Title */}
         <div className="text-center mb-8 sm:mb-10">
           <h2 className="text-2xl sm:text-3xl font-bold text-foreground">
             {t("home.recommendations.title")}
           </h2>
         </div>
 
-        {/* Cards grid — mobile: horizontal snap; desktop: 3-col grid */}
-        {state.status === "loading" ? (
-          <>
-            {/* Mobile skeleton: single card visible at a time */}
-            <div className="md:hidden flex overflow-x-auto snap-x snap-mandatory gap-3 pb-2 -mx-4 px-4 scrollbar-hide">
-              {Array.from({ length: 3 }).map((_, i) => (
-                <div
-                  key={i}
-                  className="flex-shrink-0 w-[68%] snap-center h-48 rounded-lg border bg-muted animate-pulse"
-                  data-testid="recommendation-card-skeleton"
-                />
-              ))}
-            </div>
-            {/* Desktop skeleton */}
-            <div className="hidden md:grid grid-cols-3 gap-4 sm:gap-5" data-testid="recommendation-skeleton-desktop">
-              {Array.from({ length: 3 }).map((_, i) => (
-                <div
-                  key={i}
-                  className="h-48 rounded-lg border bg-muted animate-pulse"
-                  data-testid="recommendation-card-skeleton"
-                />
-              ))}
-            </div>
-          </>
-        ) : (
-          <>
-            {/* Mobile: horizontal scroll snap, card width ~68% viewport */}
-            <div className="md:hidden flex overflow-x-auto snap-x snap-mandatory gap-3 pb-2 -mx-4 px-4 scrollbar-hide">
-              {state.recommendations.map((reco) => (
-                <div key={reco.locationId} className="flex-shrink-0 w-[68%] snap-center">
-                  <RecommendationCard reco={reco} />
-                </div>
-              ))}
-            </div>
-            {/* Desktop: 3-col grid */}
-            <div className="hidden md:grid grid-cols-3 gap-4 sm:gap-5" data-testid="recommendation-cards-desktop">
-              {state.recommendations.map((reco) => (
-                <RecommendationCard key={reco.locationId} reco={reco} />
-              ))}
-            </div>
-          </>
-        )}
+        {/* Cards / skeleton layer — opacity driven by phase */}
+        <div className={containerClass} aria-live="polite" aria-busy={isLoading}>
+          {showSkeleton ? skeleton : cards}
+        </div>
 
         {/* P1 city 个性化 #193 T3: cityMatch 非 exact 时异地明示 */}
         {state.status === "ready" && userCity && state.cityMatch && state.cityMatch !== "exact" && (
@@ -192,21 +269,16 @@ export function HomeRecommendationsSection({ userCity, cityName }: HomeRecommend
           </div>
         )}
 
-        {/* Refresh CTA — 桌面居右标题行（弱化为文字按钮）；移动端居中可见
-            Martin CR R2: 换一批保留，spec §3 无移动端隐藏口径 */}
-        {state.status === "ready" && (
+        {/* Refresh CTA — 切换期间隐藏防双击 */}
+        {state.status === "ready" && phase === "idle" && (
           <div className="mt-5 sm:mt-6 flex justify-center md:justify-end">
             <button
               type="button"
               onClick={handleRefresh}
-              disabled={refreshing}
-              className="inline-flex items-center gap-1.5 text-sm font-medium text-amber-700 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-300 transition-colors disabled:opacity-60 disabled:cursor-not-allowed underline-offset-2 hover:underline"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-amber-700 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-300 transition-colors underline-offset-2 hover:underline"
               data-testid="recommendation-refresh-btn"
             >
-              <RefreshCw
-                className={`w-3.5 h-3.5 ${refreshing ? "animate-spin" : ""}`}
-                strokeWidth={2.2}
-              />
+              <RefreshCw className="w-3.5 h-3.5" strokeWidth={2.2} />
               {t("home.recommendations.cta.refresh")}
             </button>
           </div>


### PR DESCRIPTION
## 范围
Round 3 §C（task #200）：换一批过渡动效，spec  v1.1。

## 改动
- 1 file / +169 -89
- 

## 实现
- **状态机**：phase = 
- **换一批流**：fadingOut(150ms) → 数据未就绪则 showingSkeleton → 数据就绪或 skeleton 后 fadingIn(200ms)
- **快取门控（R2）**：fade-out 完成时数据已 ready → 跳过骨架直接 fade-in
- **失败路径**：旧卡复原（phase 回 idle，displayedData 保留不 clear）
- **骨架复用**：现有 （ 等）零改动
- **移动端**：换一批后  snap 回首张
- **reduced-motion**：全局 CSS handles，组件侧无条件反射
- **TypeScript**： 类型改为 

## 验收标准（spec §5.2）
- [x] fade-out → skeleton → fade-in 完整序列可观察
- [x] 快 fetch（<150ms）路径跳过骨架直接 fade-in
- [x] 现有 data-testid 断言全绿（333 test PASS）
- [x] reduced-motion 瞬时
- [x] fetch 失败旧卡复原

## CR
@Martin 请 CR