### PR TITLE
fix #201: Round 3 T3 - onboarding modal 进出场动效

### DIFF
--- a/frontend/src/components/features/onboarding/onboarding-modal.tsx
+++ b/frontend/src/components/features/onboarding/onboarding-modal.tsx
@@ -113,6 +113,12 @@ function OnboardingModalInner({ user, initial }: { user: SessionUser; initial: R
     }
   }, [animateOut, animatingOut, t]);
 
+  /** 第 3 步关闭：出场动画后关闭（marker 已在 join 时写入） */
+  const closeStep3 = React.useCallback(() => {
+    if (animatingOut) return;
+    animateOut(() => setClosed(true));
+  }, [animateOut, animatingOut]);
+
   // Esc / focus trap / 焦点还原（Esc = 跳过语义）
   useModalA11y(!closed && !animatingOut, panelRef, closeAsSkip);
 
@@ -191,12 +197,6 @@ function OnboardingModalInner({ user, initial }: { user: SessionUser; initial: R
       setSubmitting(false);
     }
   };
-
-  /** 第 3 步关闭：出场动画后关闭（marker 已在 join 时写入） */
-  const closeStep3 = React.useCallback(() => {
-    if (animatingOut) return;
-    animateOut(() => setClosed(true));
-  }, [animateOut, animatingOut]);
 
   const dots = (active: number) => (
     <div className="flex justify-center gap-1.5 mb-4" aria-hidden="true">

--- a/frontend/src/components/features/onboarding/onboarding-modal.tsx
+++ b/frontend/src/components/features/onboarding/onboarding-modal.tsx
@@ -102,14 +102,16 @@ function OnboardingModalInner({ user, initial }: { user: SessionUser; initial: R
     });
   }, [animateOut, animatingOut]);
 
-  // 放弃并永久隐藏；marker 延迟到出场后写入
+  // 放弃并永久隐藏（§7）：先 confirm → 通过才 animateOut + marker 延迟写入
   const confirmDismiss = React.useCallback(() => {
     if (animatingOut) return;
-    animateOut(() => {
-      markOnboardingDismissed();
-      setClosed(true);
-    });
-  }, [animateOut, animatingOut]);
+    if (window.confirm(t("onboarding.dismiss"))) {
+      animateOut(() => {
+        markOnboardingDismissed();
+        setClosed(true);
+      });
+    }
+  }, [animateOut, animatingOut, t]);
 
   // Esc / focus trap / 焦点还原（Esc = 跳过语义）
   useModalA11y(!closed && !animatingOut, panelRef, closeAsSkip);

--- a/frontend/src/components/features/onboarding/onboarding-modal.tsx
+++ b/frontend/src/components/features/onboarding/onboarding-modal.tsx
@@ -69,6 +69,7 @@ function OnboardingModalInner({ user, initial }: { user: SessionUser; initial: R
   const roleConfig = getRoleConfig(t);
 
   const [closed, setClosed] = React.useState(false);
+  const [animatingOut, setAnimatingOut] = React.useState(false);
   const [step, setStep] = React.useState<1 | 2 | 3>(1);
   const [pool, setPool] = React.useState<RecommendOnboardingResponse>(initial);
   const [poolIndex, setPoolIndex] = React.useState(0);
@@ -79,13 +80,39 @@ function OnboardingModalInner({ user, initial }: { user: SessionUser; initial: R
 
   const panelRef = React.useRef<HTMLDivElement | null>(null);
 
-  const closeAsSkip = React.useCallback(() => {
-    markOnboardingSeen(); // §7：跳过 = 本设备已看过，不再弹
-    setClosed(true);
+  // Round 3 §D: 出场动画后关闭（延迟 marker 写入）
+  const animateOut = React.useCallback((onComplete: () => void) => {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      onComplete();
+      return;
+    }
+    setAnimatingOut(true);
+    setTimeout(() => {
+      setAnimatingOut(false);
+      onComplete();
+    }, 200);
   }, []);
 
+  // §7：跳过 = 本设备已看过；marker 延迟到出场后写入
+  const closeAsSkip = React.useCallback(() => {
+    if (animatingOut) return;
+    animateOut(() => {
+      markOnboardingSeen();
+      setClosed(true);
+    });
+  }, [animateOut, animatingOut]);
+
+  // 放弃并永久隐藏；marker 延迟到出场后写入
+  const confirmDismiss = React.useCallback(() => {
+    if (animatingOut) return;
+    animateOut(() => {
+      markOnboardingDismissed();
+      setClosed(true);
+    });
+  }, [animateOut, animatingOut]);
+
   // Esc / focus trap / 焦点还原（Esc = 跳过语义）
-  useModalA11y(!closed, panelRef, closeAsSkip);
+  useModalA11y(!closed && !animatingOut, panelRef, closeAsSkip);
 
   if (closed) return null;
 
@@ -163,12 +190,11 @@ function OnboardingModalInner({ user, initial }: { user: SessionUser; initial: R
     }
   };
 
-  const confirmDismiss = () => {
-    if (window.confirm(t("onboarding.dismiss"))) {
-      markOnboardingDismissed();
-      setClosed(true);
-    }
-  };
+  /** 第 3 步关闭：出场动画后关闭（marker 已在 join 时写入） */
+  const closeStep3 = React.useCallback(() => {
+    if (animatingOut) return;
+    animateOut(() => setClosed(true));
+  }, [animateOut, animatingOut]);
 
   const dots = (active: number) => (
     <div className="flex justify-center gap-1.5 mb-4" aria-hidden="true">
@@ -192,12 +218,15 @@ function OnboardingModalInner({ user, initial }: { user: SessionUser; initial: R
   );
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 sm:p-4" data-testid="onboarding-modal">
+    <div
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/50 sm:p-4 ${animatingOut ? "animate-overlay-out" : "animate-overlay-in"}`}
+      data-testid="onboarding-modal"
+    >
       <div
         ref={panelRef}
         role="dialog"
         aria-modal="true"
-        className="w-full h-full sm:h-auto sm:max-w-md bg-white dark:bg-stone-900 sm:rounded-2xl shadow-xl p-6 sm:p-8 overflow-y-auto"
+        className={`w-full h-full sm:h-auto sm:max-w-md bg-white dark:bg-stone-900 sm:rounded-2xl shadow-xl p-6 sm:p-8 overflow-y-auto ${animatingOut ? "animate-panel-out" : "animate-panel-in"}`}
       >
         {/* ─── 第 1 步：偏好 ─── */}
         {step === 1 && (
@@ -363,7 +392,7 @@ function OnboardingModalInner({ user, initial }: { user: SessionUser; initial: R
                 </a>
                 <button
                   type="button"
-                  onClick={() => setClosed(true)}
+                  onClick={closeStep3}
                   className="w-full py-2.5 rounded-xl border border-stone-200 dark:border-stone-700 text-sm text-stone-600 dark:text-stone-400 hover:bg-stone-50 dark:hover:bg-stone-800 transition-colors"
                 >
                   {t("onboarding.success.cta.home")}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -186,15 +186,6 @@
     to   { opacity: 0; transform: scale(0.97); }
   }
 
-  @media (prefers-reduced-motion: reduce) {
-    .animate-overlay-in,
-    .animate-overlay-out,
-    .animate-panel-in,
-    .animate-panel-out {
-      animation: none !important;
-    }
-  }
-
   @keyframes float {
     0%, 100% { transform: translateY(0); }
     50%       { transform: translateY(-4px); }

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -166,6 +166,35 @@
     to   { opacity: 1; transform: translateX(0); }
   }
 
+  @keyframes overlay-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+
+  @keyframes overlay-out {
+    from { opacity: 1; }
+    to   { opacity: 0; }
+  }
+
+  @keyframes panel-in {
+    from { opacity: 0; transform: scale(0.95); }
+    to   { opacity: 1; transform: scale(1); }
+  }
+
+  @keyframes panel-out {
+    from { opacity: 1; transform: scale(1); }
+    to   { opacity: 0; transform: scale(0.97); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .animate-overlay-in,
+    .animate-overlay-out,
+    .animate-panel-in,
+    .animate-panel-out {
+      animation: none !important;
+    }
+  }
+
   @keyframes float {
     0%, 100% { transform: translateY(0); }
     50%       { transform: translateY(-4px); }

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -140,6 +140,10 @@
   --animate-pulse-soft:     pulse-soft 2s ease-in-out infinite;
   --animate-heartbeat:      heartbeat 0.3s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
   --animate-success-bounce: success-bounce 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  --animate-overlay-in:     overlay-in 150ms ease-out forwards;
+  --animate-overlay-out:    overlay-out 150ms ease-in forwards;
+  --animate-panel-in:       panel-in 200ms ease-out forwards;
+  --animate-panel-out:      panel-out 150ms ease-in forwards;
 
   @keyframes fade-in {
     from { opacity: 0; }

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -424,6 +424,15 @@
 /* ============================================================
    Base Layer — 全局基础样式
    ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+  .animate-overlay-in,
+  .animate-overlay-out,
+  .animate-panel-in,
+  .animate-panel-out {
+    animation: none !important;
+  }
+}
+
 @layer base {
   *, *::before, *::after {
     @apply border-border box-border;

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -187,6 +187,10 @@ const config: Config = {
         "float":          "float 3s ease-in-out infinite",
         "pulse-soft":     "pulse-soft 2s ease-in-out infinite",
         "shimmer":        "shimmer 1.8s ease-in-out infinite",
+        "overlay-in":     "overlay-in 150ms ease-out both",
+        "overlay-out":    "overlay-out 150ms ease-in both",
+        "panel-in":       "panel-in 200ms ease-out both",
+        "panel-out":      "panel-out 150ms ease-in both",
       },
 
       /* ---- 阴影 ---- */

--- a/notes/gomate-p1-1-onboarding-spec.md
+++ b/notes/gomate-p1-1-onboarding-spec.md
@@ -3,6 +3,7 @@
 > 需求：@Victor 2026-07-20 DM（「先出 spec」+ P1 重新评估中强推项）
 > 依据：`notes/gomate-ux-experience-analysis.md` §三-P1-1
 > 设计者：@Steven
+> **v1.2.2**（2026-07-27）：modal 进出场动效条款归 Round 3 spec §D 管辖（`notes/gomate-home-round3-ux-spec.md`），本 spec 不做双写
 > 范围：注册流程尾部 + 首页 `/`（新增 modal）+ 队伍详情页（无变更）
 > 交付给：Martin CR + 拆任务
 > v1.1（2026-07-24）：P0 全线收官后按现行代码事实刷新——三处 v1.0 与代码冲突修正（§4.1 偏好枚举 / §6 审核制 join / §6.4 wechat 门槛），砍 T3


### PR DESCRIPTION
## fix #201 Round 3 T3 §D

**改动**：4 文件，零文件交叠

1. ：进场 scale+fade / 出场反向 150ms + 延迟 unmount；marker 三关闭路径统一延迟到出场动画完成回调；animatingOut guard 防双击；useModalA11y + !animatingOut 动画开始即释放焦点陷阱
2. ：4 组 keyframes + @media prefers-reduced-motion 禁用动画（SSR/客户端一致）
3. ：overlay-in/out + panel-in/out keyframes + animation utilities
4. ：v1.2.2 指针一行

**来自 main 分支**：干净的文件列表，不含任何无关改动。请 @Martin re-CR