### PR TITLE
fix §C.3: reduced-motion matchMedia gate — 瞬时硬切

### DIFF
--- a/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
+++ b/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
@@ -14,7 +14,7 @@
  * Round 3 §C 过渡动效：
  *  - 点击换一批 → fade-out(150ms) → skeleton → fade-in(200ms)
  *  - 快取门控：fade-out 完成时数据已 ready → 跳过骨架直接 fade-in
- *  - reduced-motion：全部瞬时（由全局 CSS handles）
+ *  - reduced-motion：matchMedia JS gate，跳过相位机直接 fetch+swap（旧硬切行为）
  *  - 失败：旧卡复原（fade-in 200ms 自然淡回 opacity-100）
  *  - skeleton 复用现有 testid，测试断言零改动
  *  - 移动端换一批后 snap 回首张
@@ -121,6 +121,19 @@ export function HomeRecommendationsSection({ userCity, cityName }: HomeRecommend
 
     const currentSeed = state.nextSeed;
 
+    // §C.3 reduced-motion：瞬时 = 旧硬切，不跑相位机
+    if (typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      const data = await fetchRecommendations(currentSeed).catch((err) => {
+        console.error("[HomeRecommendations] refresh failed:", err);
+        return null;
+      });
+      if (data) {
+        setState({ status: "ready", recommendations: data.recommendations, nextSeed: data.nextSeed, cityMatch: data._meta?.cityMatch ?? null });
+        setDisplayedData(data.recommendations);
+      }
+      return;
+    }
+
     // --- fade-out 阶段（150ms）---
     setPhase("fadingOut");
 
@@ -191,7 +204,7 @@ export function HomeRecommendationsSection({ userCity, cityName }: HomeRecommend
   const showSkeleton = isLoading && (phase === "showingSkeleton" || state.status === "loading");
 
   // opacity 类：idle=opacity-100 / fadingOut=opacity-0(150ms) / fadingIn=opacity-100(200ms)
-  // reduced-motion 瞬时：全局 CSS .transition-none 覆盖
+  // reduced-motion 由 handleRefresh 入口 JS gate 处理，此处不介入
   const containerClass = [
     "transition-opacity",
     phase === "idle" ? "opacity-100" : "",


### PR DESCRIPTION
## N1 follow-up：reduced-motion JS gate（Martin 授权 msg=6bcf8818）\n\n**问题**：组件注释称「reduced-motion 由全局 CSS .transition-none 覆盖」，但该规则不存在。OS 级 reduced-motion 用户仍看到 150/200ms opacity 动画。\n\n**修复**：\n-  入口加  gate\n- 命中时：直接 fetch → setState 硬切，跳过全部相位机（即 §C.3「瞬时 = 旧硬切行为」）\n- 两处注释修正：删虚构的「全局 CSS handles」说明\n\n**不搭 #201**：animation vs transition 耦合不同， 对 opacity transition 无效，必须独立 gate。\n\nMartin 预授权，Wen 补验 reduced-motion 硬切路径后 task #200/#33 再关。