### PR TITLE
fix: activity-posts 双前缀404 + 0016 journal补录

### DIFF
--- a/api/db/migrations/meta/_journal.json
+++ b/api/db/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1784480725173,
       "tag": "0015_p0a_t4_p0b_t1_city_and_decision_fields",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1785002483000,
+      "tag": "0016_p0d_t1_local_circle_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -49,7 +49,7 @@ app.route("/favorites", favoritesRoute);
 app.route("/admin", adminRoute);
 app.route("/amap", amapRoute);
 app.route("/messages", messagesRoute);
-app.route("/activity-posts", activityPostsRoute);
+app.route("/", activityPostsRoute);
 app.route("/stories", storiesRoute);
 app.route("/share-image", shareImageRoute);
 app.route("/recommendations/home", recommendationsHomeRoute);

--- a/api/src/routes/activity-posts.ts
+++ b/api/src/routes/activity-posts.ts
@@ -16,7 +16,7 @@ const activityPosts = new Hono<{ Bindings: Env }>();
  * GET /teams/:id/activity-posts
  * 获取队伍的活动后分享列表
  */
-activityPosts.get("/teams/:id/activity-posts", async (c) => {
+activityPosts.get("teams/:id/activity-posts", async (c) => {
   try {
     const db = createDb(c.env.DB);
     const teamId = c.req.param("id");
@@ -90,7 +90,7 @@ activityPosts.get("/teams/:id/activity-posts", async (c) => {
  * 创建活动后分享
  * 权限：登录用户 + 队伍成员 + 队伍已完成
  */
-activityPosts.post("/teams/:id/activity-posts", async (c) => {
+activityPosts.post("teams/:id/activity-posts", async (c) => {
   try {
     const auth = createAuth(c.env);
     const session = await auth.api.getSession({ headers: c.req.raw.headers });
@@ -176,7 +176,7 @@ activityPosts.post("/teams/:id/activity-posts", async (c) => {
  * 删除活动后分享
  * 权限：作者或管理员
  */
-activityPosts.delete("/activity-posts/:id", async (c) => {
+activityPosts.delete("activity-posts/:id", async (c) => {
   try {
     const auth = createAuth(c.env);
     const session = await auth.api.getSession({ headers: c.req.raw.headers });
@@ -229,7 +229,7 @@ activityPosts.delete("/activity-posts/:id", async (c) => {
  * GET /locations/:id/activity-posts
  * 获取地点的活动后分享列表
  */
-activityPosts.get("/locations/:id/activity-posts", async (c) => {
+activityPosts.get("locations/:id/activity-posts", async (c) => {
   try {
     const db = createDb(c.env.DB);
     const locationId = c.req.param("id");

--- a/api/src/routes/upload.ts
+++ b/api/src/routes/upload.ts
@@ -269,4 +269,36 @@ upload.post("/story", async (c) => {
   }
 });
 
+/**
+ * POST /upload/activity-post
+ * 上传活动动态图片（需要登录）
+ */
+upload.post("/activity-post", async (c) => {
+  try {
+    const authInstance = createAuth(c.env);
+    const session = await authInstance.api.getSession({ headers: c.req.raw.headers });
+    if (!session) return c.json(APIErrors.unauthorized("请先登录"), 401);
+
+    const formData = await c.req.formData();
+    const file = formData.get("file") as File | null;
+    if (!file) return c.json(APIErrors.badRequest("No file provided"), 400);
+
+    // 速率限制
+    const rateLimit = await checkRateLimit(c.env.GOMATE_KV, `rate:upload:${session.user.id}`, UPLOAD_RATE_LIMIT_MAX, UPLOAD_RATE_LIMIT_WINDOW);
+    if (!rateLimit.allowed) return c.json(APIErrors.badRequest(`上传过于频繁，请 ${rateLimit.retryAfter} 秒后重试`), 429);
+
+    const extValidation = validateFileExtension(file);
+    if (!extValidation.valid) return c.json(APIErrors.badRequest(extValidation.error || "Invalid file"), 400);
+
+    const ext = extValidation.ext;
+    const key = `activity-posts/${session.user.id}-${Date.now()}.${ext}`;
+    const result = await uploadImageFile(c, file, key);
+    if ("error" in result) return c.json(result.error, result.status);
+    return c.json(result.data);
+  } catch (error) {
+    logger.error("Activity post image upload error:", error);
+    return c.json(APIErrors.internalError("Failed to upload activity post image"), 500);
+  }
+});
+
 export { upload as uploadRoute };

--- a/frontend/src/components/features/activity-posts/activity-post-form.tsx
+++ b/frontend/src/components/features/activity-posts/activity-post-form.tsx
@@ -49,7 +49,7 @@ export function ActivityPostForm({ teamId, onSuccess, onCancel, className }: Act
         const formData = new FormData();
         formData.append("file", file);
 
-        const res = await fetchAPI("/api/upload", {
+        const res = await fetchAPI("/upload/activity-post", {
           method: "POST",
           body: formData,
         });

--- a/frontend/src/components/features/activity-posts/location-activity-posts.tsx
+++ b/frontend/src/components/features/activity-posts/location-activity-posts.tsx
@@ -21,7 +21,7 @@ export function LocationActivityPosts({ locationId, className }: LocationActivit
     const loadPosts = async () => {
       setIsLoading(true);
       try {
-        const res = await fetchAPI(`/activity-posts/locations/${locationId}/activity-posts?limit=6`);
+        const res = await fetchAPI(`/locations/${locationId}/activity-posts?limit=6`);
         const data = await res.json();
         if (data.success) {
           setPosts(data.data || []);


### PR DESCRIPTION
## task #202 P0 修复\n\n**根因**：activity-posts 路由在 index.ts 挂载于  前缀，但内部写的是绝对路径（ 等），导致真实路径双前缀 ，前端调  永远 404。\n\n**修法（Martin定案）**：\n- 内部路由去  前缀（相对路径）\n- 挂载点从  改为 \n\n**改动**:\n1. : 4个路由去  前缀\n2. : 挂载点  → \n3. : 新增 \n4. :  → \n5. :  → \n6. : 0016条目补录（仅JSON，不碰prod数据）\n\n**路由对照**:\n| 前端调用 | 修复前 | 修复后 |\n|---|---|---|\n| GET /teams/:id/activity-posts | 404 | 200 |\n| POST /teams/:id/activity-posts | 404 | 200 |\n| DELETE /activity-posts/:id | 404 | 200 |\n| GET /locations/:id/activity-posts | 200 | 200 |\n| POST /upload/activity-post | N/A | 200 |\n\ntype-check 0 errors / 331 test PASS\n\n@Martin CR