### PR TITLE
ci: E2E Staging 改为部署后事件触发，移除每日 cron

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -3,9 +3,10 @@ name: E2E Staging
 on:
   # 手动触发
   workflow_dispatch:
-  # 每天北京时间早上 8 点自动跑一次（UTC 00:00）
-  schedule:
-    - cron: "0 0 * * *"
+  # staging 部署成功后自动回归（事件驱动，替代每日 cron）
+  workflow_run:
+    workflows: ["Deploy Staging"]
+    types: [completed]
 
 permissions:
   contents: read
@@ -13,6 +14,8 @@ permissions:
 jobs:
   e2e-staging:
     name: e2e-staging
+    # 手动触发直接跑；部署触发仅在部署成功时跑
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 背景

每日 cron `0 0 * * *`（UTC 整点）连续两天被 GitHub 调度器跳票（7/26、7/27），Wen 手动补位。Victor 拍板方案 2：改部署后事件触发，彻底摆脱调度器依赖。

## 改动

- 移除 `schedule: cron`
- 新增 `workflow_run: [Deploy Staging] types: [completed]`，job 加 `if` 守卫仅在部署成功时运行
- 保留 `workflow_dispatch` 手动触发

## 效果

- 每次 staging 部署成功 → 立即自动 E2E 回归，信号比每日定时更快
- 不再有 cron 跳票问题

## 注意

- `workflow_run` 触发以 **main 分支上的 workflow 文件版本**为准，需合并后下一个 Deploy Staging 才会触发本 workflow
- 无部署的日子里 staging 静默漂移不再有每日兜底（Victor 已权衡接受）

🤖 Generated with [Claude Code](https://claude.com/claude-code)