### PR TITLE
fix #205: 清理样式残留（globals.css 死 animate token + keyframes）

### DIFF
--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -193,9 +193,11 @@
     50%       { transform: translateY(-4px); }
   }
 
-
-
-
+  /* section 进入动画：fade + 轻微上移 */
+  @keyframes section-in {
+    from { opacity: 0; transform: translateY(24px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
 
   /* 清空按钮旋转出现（简化版） */
   @keyframes spin-in {
@@ -204,11 +206,6 @@
   }
 
   /* section 进入动画：fade + 轻微上移 */
-  @keyframes section-in {
-    from { opacity: 0; transform: translateY(24px); }
-    to   { opacity: 1; transform: translateY(0); }
-  }
-
   /* shimmer 扫光骨架屏 */
   @keyframes shimmer {
     from { background-position: -200% 0; }
@@ -219,20 +216,10 @@
   --animate-bounce-in: bounce-in 0.25s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
 
   /* 清空按钮旋转消失 */
-  @keyframes spin-out {
-    from { transform: rotate(0deg) scale(1); opacity: 1; }
-    to   { transform: rotate(90deg) scale(0.6); opacity: 0; }
-  }
-
   /* 清空按钮旋转出现（CSS 变量版） */
   --animate-spin-in: spin-in 0.2s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
 
   /* 卡片 overlay 从底部滑入 */
-  @keyframes slide-up-in {
-    from { transform: translateY(100%); opacity: 0; }
-    to   { transform: translateY(0); opacity: 1; }
-  }
-
   /* section 进入动画（CSS 变量版） */
 
   /* 状态切换：fade + scale 入场 */
@@ -258,8 +245,6 @@
     from { opacity: 0; transform: translateY(16px); }
     to   { opacity: 1; transform: translateY(0); }
   }
-
-
 
   /* Toast 退出淡出（fade-out） */
   --animate-fade-out: fade-out 0.2s ease-in both;
@@ -711,9 +696,7 @@
 
   /* ---- 微交互动画工具类 ---- */
   .animate-bounce-in  { animation: var(--animate-bounce-in); }
-  .animate-spin-out   { animation: var(--animate-spin-out); }
-  .animate-spin-in    { animation: var(--animate-spin-in); }
-  .animate-slide-up-in { animation: var(--animate-slide-up-in); }
+    .animate-spin-in    { animation: var(--animate-spin-in); }
 
   /* Profile staggered fade-up (slower, more deliberate) */
   @keyframes fade-up-slow {

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -137,9 +137,7 @@
   --animate-scale-in:       scale-in 0.2s cubic-bezier(0.16, 1, 0.3, 1) forwards;
   --animate-slide-in-right: slide-in-right 0.35s cubic-bezier(0.16, 1, 0.3, 1) forwards;
   --animate-float:          float 3s ease-in-out infinite;
-  --animate-pulse-soft:     pulse-soft 2s ease-in-out infinite;
   --animate-heartbeat:      heartbeat 0.3s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
-  --animate-success-bounce: success-bounce 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
   --animate-overlay-in:     overlay-in 150ms ease-out forwards;
   --animate-overlay-out:    overlay-out 150ms ease-in forwards;
   --animate-panel-in:       panel-in 200ms ease-out forwards;
@@ -195,10 +193,6 @@
     50%       { transform: translateY(-4px); }
   }
 
-  @keyframes pulse-soft {
-    0%, 100% { opacity: 1; }
-    50%       { opacity: 0.5; }
-  }
 
 
 
@@ -225,7 +219,6 @@
   --animate-bounce-in: bounce-in 0.25s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
 
   /* 清空按钮旋转消失 */
-  --animate-spin-out: spin-out 0.2s ease-in forwards;
   @keyframes spin-out {
     from { transform: rotate(0deg) scale(1); opacity: 1; }
     to   { transform: rotate(90deg) scale(0.6); opacity: 0; }
@@ -235,14 +228,12 @@
   --animate-spin-in: spin-in 0.2s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
 
   /* 卡片 overlay 从底部滑入 */
-  --animate-slide-up-in: slide-up-in 0.3s cubic-bezier(0.16, 1, 0.3, 1) forwards;
   @keyframes slide-up-in {
     from { transform: translateY(100%); opacity: 0; }
     to   { transform: translateY(0); opacity: 1; }
   }
 
   /* section 进入动画（CSS 变量版） */
-  --animate-section-in: section-in 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
 
   /* 状态切换：fade + scale 入场 */
   @keyframes fadeScaleIn {

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -177,21 +177,7 @@ const config: Config = {
         },
       },
 
-      /* ---- Animation 工具类 ---- */
-      animation: {
-        "fade-in":        "fade-in 0.3s ease-out forwards",
-        "fade-up":        "fade-up 0.35s cubic-bezier(0.16, 1, 0.3, 1) forwards",
-        "fade-down":      "fade-down 0.3s ease-out forwards",
-        "scale-in":       "scale-in 0.2s cubic-bezier(0.16, 1, 0.3, 1) forwards",
-        "slide-in-right": "slide-in-right 0.35s cubic-bezier(0.16, 1, 0.3, 1) forwards",
-        "float":          "float 3s ease-in-out infinite",
-        "pulse-soft":     "pulse-soft 2s ease-in-out infinite",
-        "shimmer":        "shimmer 1.8s ease-in-out infinite",
-        "overlay-in":     "overlay-in 150ms ease-out both",
-        "overlay-out":    "overlay-out 150ms ease-in both",
-        "panel-in":       "panel-in 200ms ease-out both",
-        "panel-out":      "panel-out 150ms ease-in both",
-      },
+
 
       /* ---- 阴影 ---- */
       boxShadow: {

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -167,10 +167,6 @@ const config: Config = {
           "0%, 100%": { transform: "translateY(0px)" },
           "50%":      { transform: "translateY(-4px)" },
         },
-        "pulse-soft": {
-          "0%, 100%": { opacity: "1" },
-          "50%":      { opacity: "0.5" },
-        },
         "shimmer": {
           from: { backgroundPosition: "-200% 0" },
           to:   { backgroundPosition: "200% 0" },


### PR DESCRIPTION
## fix #205 — 样式残留清理

**改动**：
- 删 5 个未用 animate token：pulse-soft / success-bounce / spin-out / slide-up-in / section-in
- 删对应 5 组 @keyframes + 1 个未用 .animate-spin-out 工具类

**不影响**：bounce-in / spin-in / fade-out 等活 animate token 保留

请 @Martin CR