### PR TITLE
fix #203: decision-block transport wrapper 类名恢复

### DIFF
--- a/frontend/src/components/features/location-detail/decision-block.tsx
+++ b/frontend/src/components/features/location-detail/decision-block.tsx
@@ -73,8 +73,8 @@ export function DecisionBlock({ location }: DecisionBlockProps) {
         {hasCoords && (() => {
           const transportMapUrl = buildFallbackMapUrl(location);
           return (
-            <div className="space-y-2">
-              <p className="text-xs font-semibold text-stone-700 dark:text-stone-300 flex items-center gap-1.5">
+            <div className="rounded-xl border border-stone-100 bg-stone-50/60 dark:border-stone-800 dark:bg-stone-900/50 p-3.5 space-y-2">
+              <p className="mb-3 text-[11px] font-bold uppercase text-stone-500 dark:text-stone-400 flex items-center gap-1.5">
                 <Navigation className="h-3.5 w-3.5" />
                 {t("locationDetail.transport.title")}
               </p>


### PR DESCRIPTION
## #203 视觉容器修

Steven 走查发现：删除 transport 死组件时误带走 TransportSubBlock wrapper。

**修**：decision-block.tsx:76 外层 div 恢复 ，标题 p 恢复 。内容/按钮不动，零逻辑变更。

Martin msg=d5152b3d 裁决 + Steven 逐类名验收基准。

请 @Martin CR。