### PR TITLE
feat(auth): 升级 better-auth 1.6.11→1.6.25 + 安装 @better-auth/api-key

### DIFF
--- a/api/db/migrations/0017_add_api_keys.sql
+++ b/api/db/migrations/0017_add_api_keys.sql
@@ -1,0 +1,31 @@
+--> statement-breakpoint
+CREATE TABLE `apikey` (
+	`id` text PRIMARY KEY NOT NULL,
+	`config_id` text NOT NULL,
+	`name` text,
+	`start` text,
+	`reference_id` text NOT NULL,
+	`key` text NOT NULL,
+	`prefix` text,
+	`refill_interval` integer,
+	`refill_amount` integer,
+	`last_refill_at` integer,
+	`enabled` integer DEFAULT true NOT NULL,
+	`rate_limit_enabled` integer DEFAULT true NOT NULL,
+	`rate_limit_time_window` integer,
+	`rate_limit_max` integer,
+	`request_count` integer DEFAULT 0 NOT NULL,
+	`remaining` integer,
+	`last_request` integer,
+	`expires_at` integer,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`permissions` text,
+	`metadata` text
+);
+--> statement-breakpoint
+CREATE INDEX `apikey_config_id_idx` ON `apikey` (`config_id`);
+--> statement-breakpoint
+CREATE INDEX `apikey_reference_id_idx` ON `apikey` (`reference_id`);
+--> statement-breakpoint
+CREATE INDEX `apikey_key_idx` ON `apikey` (`key`);

--- a/api/db/migrations/0017_add_api_keys.sql
+++ b/api/db/migrations/0017_add_api_keys.sql
@@ -1,5 +1,5 @@
 --> statement-breakpoint
-CREATE TABLE `apikey` (
+CREATE TABLE IF NOT EXISTS `apikey` (
 	`id` text PRIMARY KEY NOT NULL,
 	`config_id` text NOT NULL,
 	`name` text,
@@ -24,8 +24,8 @@ CREATE TABLE `apikey` (
 	`metadata` text
 );
 --> statement-breakpoint
-CREATE INDEX `apikey_config_id_idx` ON `apikey` (`config_id`);
+CREATE INDEX IF NOT EXISTS `apikey_config_id_idx` ON `apikey` (`config_id`);
 --> statement-breakpoint
-CREATE INDEX `apikey_reference_id_idx` ON `apikey` (`reference_id`);
+CREATE INDEX IF NOT EXISTS `apikey_reference_id_idx` ON `apikey` (`reference_id`);
 --> statement-breakpoint
-CREATE INDEX `apikey_key_idx` ON `apikey` (`key`);
+CREATE INDEX IF NOT EXISTS `apikey_key_idx` ON `apikey` (`key`);

--- a/api/db/migrations/meta/_journal.json
+++ b/api/db/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1785002483000,
       "tag": "0016_p0d_t1_local_circle_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1785247200000,
+      "tag": "0017_add_api_keys",
+      "breakpoints": true
     }
   ]
 }

--- a/api/package.json
+++ b/api/package.json
@@ -19,7 +19,7 @@
     "@gomate/types": "workspace:*",
     "@hono/zod-validator": "^0.4.0",
     "@resvg/resvg-wasm": "^2.6.2",
-    "better-auth": "^1.6.11",
+    "better-auth": "^1.6.25",
     "drizzle-orm": "^0.36.0",
     "hono": "^4.6.0",
     "kysely": "^0.28.5",
@@ -27,7 +27,8 @@
     "qrcode": "^1.5.4",
     "resend": "^4.0.0",
     "satori": "^0.12.0",
-    "zod": "^3.23.0"
+    "zod": "^3.23.0",
+    "@better-auth/api-key": "^1.6.25"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260409.1",

--- a/api/src/lib/auth.ts
+++ b/api/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import { betterAuth } from "better-auth";
 import { nanoid } from "nanoid";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { apiKey } from "@better-auth/api-key";
 import { createDb } from "../db";
 import * as schema from "../db/schema";
 import { sendPasswordResetEmail, sendWelcomeEmail } from "./email";
@@ -181,5 +182,6 @@ export function createAuth(env: Env) {
       "https://gomate.live",
       "https://api.gomate.live",
     ],
+    plugins: [apiKey()],
   });
 }

--- a/frontend/src/components/layout/navbar.tsx
+++ b/frontend/src/components/layout/navbar.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import * as React from "react";
+import { authClient } from "@/lib/auth-client";
 import { Mountain, Menu, X, User, Settings, Plus, LogOut, Heart, ChevronDown, MessageCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { fetchCurrentUser, API_BASE } from "@/lib/api";
+import { fetchCurrentUser } from "@/lib/api";
 import { Avatar } from "@/components/ui/avatar";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { LocaleToggle } from "@/components/layout/locale-toggle";
@@ -93,10 +94,7 @@ export function Navbar({ className }: NavbarProps) {
   }, [showUserMenu]);
 
   const handleLogout = async () => {
-    await fetch(
-      `${API_BASE}/auth/sign-out`,
-      { method: "POST", credentials: "include" }
-    );
+    await authClient.signOut();
     setSession(null);
     window.location.href = "/";
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
 
   api:
     dependencies:
+      "@better-auth/api-key":
+        specifier: ^1.6.25
+        version: 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(better-auth@1.6.25(@cloudflare/workers-types@4.20260530.1)(better-sqlite3@12.10.0)(drizzle-kit@0.28.1)(drizzle-orm@0.36.4(@cloudflare/workers-types@4.20260530.1)(@types/better-sqlite3@7.6.13)(@types/react@18.3.29)(better-sqlite3@12.10.0)(kysely@0.28.17)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@2.1.9(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)))(better-call@1.3.7(zod@4.4.3))
       "@gomate/lib":
         specifier: workspace:*
         version: link:../packages/lib
@@ -44,8 +47,8 @@ importers:
         specifier: ^2.6.2
         version: 2.6.2
       better-auth:
-        specifier: ^1.6.11
-        version: 1.6.12(@cloudflare/workers-types@4.20260530.1)(better-sqlite3@12.10.0)(drizzle-kit@0.28.1)(drizzle-orm@0.36.4(@cloudflare/workers-types@4.20260530.1)(@types/better-sqlite3@7.6.13)(@types/react@18.3.29)(better-sqlite3@12.10.0)(kysely@0.28.17)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@2.1.9(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0))
+        specifier: ^1.6.25
+        version: 1.6.25(@cloudflare/workers-types@4.20260530.1)(better-sqlite3@12.10.0)(drizzle-kit@0.28.1)(drizzle-orm@0.36.4(@cloudflare/workers-types@4.20260530.1)(@types/better-sqlite3@7.6.13)(@types/react@18.3.29)(better-sqlite3@12.10.0)(kysely@0.28.17)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@2.1.9(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0))
       drizzle-orm:
         specifier: ^0.36.0
         version: 0.36.4(@cloudflare/workers-types@4.20260530.1)(@types/better-sqlite3@7.6.13)(@types/react@18.3.29)(better-sqlite3@12.10.0)(kysely@0.28.17)(react@18.3.1)
@@ -532,6 +535,17 @@ packages:
         integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==,
       }
 
+  "@better-auth/api-key@1.6.25":
+    resolution:
+      {
+        integrity: sha512-A6f3YLN8Ve+D4R7f8jrSKh8Mpu9+bmc8PIb9BFgGgspcedM1PjpSEI5JKAWPUhiGgMeJdCGeCpRP+27jQmW9/w==,
+      }
+    peerDependencies:
+      "@better-auth/core": ^1.6.25
+      "@better-auth/utils": 0.4.2
+      better-auth: ^1.6.25
+      better-call: 1.3.7
+
   "@better-auth/core@1.6.12":
     resolution:
       {
@@ -543,6 +557,26 @@ packages:
       "@cloudflare/workers-types": ">=4"
       "@opentelemetry/api": ^1.9.0
       better-call: 1.3.5
+      jose: ^6.1.0
+      kysely: ^0.28.5 || ^0.29.0
+      nanostores: ^1.0.1
+    peerDependenciesMeta:
+      "@cloudflare/workers-types":
+        optional: true
+      "@opentelemetry/api":
+        optional: true
+
+  "@better-auth/core@1.6.25":
+    resolution:
+      {
+        integrity: sha512-lMTlhtwyK4NpY9kPF+2rQCRKYpg136d3gM2xl8esxT1PjJx5Nh5YwZvxcYCIjDuO759sx6TCloJTuwcZGG6ZBw==,
+      }
+    peerDependencies:
+      "@better-auth/utils": 0.4.2
+      "@better-fetch/fetch": 1.3.1
+      "@cloudflare/workers-types": ">=4"
+      "@opentelemetry/api": ^1.9.0
+      better-call: 1.3.7
       jose: ^6.1.0
       kysely: ^0.28.5 || ^0.29.0
       nanostores: ^1.0.1
@@ -565,6 +599,19 @@ packages:
       drizzle-orm:
         optional: true
 
+  "@better-auth/drizzle-adapter@1.6.25":
+    resolution:
+      {
+        integrity: sha512-ru/DeKjFPQUVeKkxF/ScazmPqIY7lwfkAV5Yt4j24wmn1Y8vFwoiPRnHgXUeZqBs10+nubaRwEqLF39CP6EhRw==,
+      }
+    peerDependencies:
+      "@better-auth/core": ^1.6.25
+      "@better-auth/utils": 0.4.2
+      drizzle-orm: ^0.45.2
+    peerDependenciesMeta:
+      drizzle-orm:
+        optional: true
+
   "@better-auth/kysely-adapter@1.6.12":
     resolution:
       {
@@ -573,6 +620,19 @@ packages:
     peerDependencies:
       "@better-auth/core": ^1.6.12
       "@better-auth/utils": 0.4.1
+      kysely: ^0.28.17 || ^0.29.0
+    peerDependenciesMeta:
+      kysely:
+        optional: true
+
+  "@better-auth/kysely-adapter@1.6.25":
+    resolution:
+      {
+        integrity: sha512-zxiePhtN1YClS1irKYPVwWfN6kYp+QoYlz1hdQUOj8hXyo2aE/ny4RNAb6v332b0+U6Vu88EhYITRPdmvCo6uA==,
+      }
+    peerDependencies:
+      "@better-auth/core": ^1.6.25
+      "@better-auth/utils": 0.4.2
       kysely: ^0.28.17 || ^0.29.0
     peerDependenciesMeta:
       kysely:
@@ -587,6 +647,15 @@ packages:
       "@better-auth/core": ^1.6.12
       "@better-auth/utils": 0.4.1
 
+  "@better-auth/memory-adapter@1.6.25":
+    resolution:
+      {
+        integrity: sha512-GhEzTumc8yfTz+OZ6pMg06BA49xob49x1bX+1mEl/FStDJoSF+6mTfI5M2ytFxaiN89336/aUjkW8u+qRyLexw==,
+      }
+    peerDependencies:
+      "@better-auth/core": ^1.6.25
+      "@better-auth/utils": 0.4.2
+
   "@better-auth/mongo-adapter@1.6.12":
     resolution:
       {
@@ -595,6 +664,19 @@ packages:
     peerDependencies:
       "@better-auth/core": ^1.6.12
       "@better-auth/utils": 0.4.1
+      mongodb: ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      mongodb:
+        optional: true
+
+  "@better-auth/mongo-adapter@1.6.25":
+    resolution:
+      {
+        integrity: sha512-ZtMmjcOdXR2Ziqx5y8ptTOaNpe0snNfALbBUPXJsgeyeRkDJDYzyLZ8MpuvNBTNllNeIFDbiXWAK5k+pEBZrUQ==,
+      }
+    peerDependencies:
+      "@better-auth/core": ^1.6.25
+      "@better-auth/utils": 0.4.2
       mongodb: ^6.0.0 || ^7.0.0
     peerDependenciesMeta:
       mongodb:
@@ -616,6 +698,22 @@ packages:
       prisma:
         optional: true
 
+  "@better-auth/prisma-adapter@1.6.25":
+    resolution:
+      {
+        integrity: sha512-ym7B6Iqcry+/4aQnYpFwqP/GBIiXvjrm/5B6+0qmx8mkTY/apHFTpHuGzUYYNf4vPTtzF3eYY2+s2GOsomKaRg==,
+      }
+    peerDependencies:
+      "@better-auth/core": ^1.6.25
+      "@better-auth/utils": 0.4.2
+      "@prisma/client": ^5.0.0 || ^6.0.0 || ^7.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      "@prisma/client":
+        optional: true
+      prisma:
+        optional: true
+
   "@better-auth/telemetry@1.6.12":
     resolution:
       {
@@ -626,16 +724,38 @@ packages:
       "@better-auth/utils": 0.4.1
       "@better-fetch/fetch": 1.1.21
 
+  "@better-auth/telemetry@1.6.25":
+    resolution:
+      {
+        integrity: sha512-2ZfC9lp7tU6Jw/q2Lz/bKfQqGMdMwc/IQDTYdBhvtGi24qInYVnhp2ZCW57hHM9j+fq1ULOtxgg6M3T1LEaihw==,
+      }
+    peerDependencies:
+      "@better-auth/core": ^1.6.25
+      "@better-auth/utils": 0.4.2
+      "@better-fetch/fetch": 1.3.1
+
   "@better-auth/utils@0.4.1":
     resolution:
       {
         integrity: sha512-SZBPRPF3z0nBvE5ygOkxae35wnnXPRShmqFo78S+qslLeFoPu/pMgnXAuNKFMMybac3tiLaVg1e3MQW5MC+1iA==,
       }
 
+  "@better-auth/utils@0.4.2":
+    resolution:
+      {
+        integrity: sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==,
+      }
+
   "@better-fetch/fetch@1.1.21":
     resolution:
       {
         integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==,
+      }
+
+  "@better-fetch/fetch@1.3.1":
+    resolution:
+      {
+        integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==,
       }
 
   "@bramus/specificity@2.4.2":
@@ -3557,10 +3677,86 @@ packages:
       vue:
         optional: true
 
+  better-auth@1.6.25:
+    resolution:
+      {
+        integrity: sha512-fvoq+oCO+FF5fpP3XfU7znRyGFpHB77UG2EyxsKNy+Cak7Q5pELu+auvvDveQbWQxcoKugZ7jYQQPFQLpUTGOw==,
+      }
+    peerDependencies:
+      "@lynx-js/react": "*"
+      "@prisma/client": ^5.0.0 || ^6.0.0 || ^7.0.0
+      "@sveltejs/kit": ^2.0.0
+      "@tanstack/react-start": ^1.0.0
+      "@tanstack/solid-start": ^1.0.0
+      better-sqlite3: ^12.0.0
+      drizzle-kit: ">=0.31.4"
+      drizzle-orm: ^0.45.2
+      mongodb: ^6.0.0 || ^7.0.0
+      mysql2: ^3.0.0
+      next: ^14.0.0 || ^15.0.0 || ^16.0.0
+      pg: ^8.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      solid-js: ^1.0.0
+      svelte: ^4.0.0 || ^5.0.0
+      vitest: ^2.0.0 || ^3.0.0 || ^4.0.0
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      "@lynx-js/react":
+        optional: true
+      "@prisma/client":
+        optional: true
+      "@sveltejs/kit":
+        optional: true
+      "@tanstack/react-start":
+        optional: true
+      "@tanstack/solid-start":
+        optional: true
+      better-sqlite3:
+        optional: true
+      drizzle-kit:
+        optional: true
+      drizzle-orm:
+        optional: true
+      mongodb:
+        optional: true
+      mysql2:
+        optional: true
+      next:
+        optional: true
+      pg:
+        optional: true
+      prisma:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vitest:
+        optional: true
+      vue:
+        optional: true
+
   better-call@1.3.5:
     resolution:
       {
         integrity: sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==,
+      }
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  better-call@1.3.7:
+    resolution:
+      {
+        integrity: sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==,
       }
     peerDependencies:
       zod: ^4.0.0
@@ -8185,6 +8381,14 @@ snapshots:
 
   "@bcoe/v8-coverage@0.2.3": {}
 
+  "@better-auth/api-key@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(better-auth@1.6.25(@cloudflare/workers-types@4.20260530.1)(better-sqlite3@12.10.0)(drizzle-kit@0.28.1)(drizzle-orm@0.36.4(@cloudflare/workers-types@4.20260530.1)(@types/better-sqlite3@7.6.13)(@types/react@18.3.29)(better-sqlite3@12.10.0)(kysely@0.28.17)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@2.1.9(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)))(better-call@1.3.7(zod@4.4.3))":
+    dependencies:
+      "@better-auth/core": 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      "@better-auth/utils": 0.4.2
+      better-auth: 1.6.25(@cloudflare/workers-types@4.20260530.1)(better-sqlite3@12.10.0)(drizzle-kit@0.28.1)(drizzle-orm@0.36.4(@cloudflare/workers-types@4.20260530.1)(@types/better-sqlite3@7.6.13)(@types/react@18.3.29)(better-sqlite3@12.10.0)(kysely@0.28.17)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@2.1.9(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0))
+      better-call: 1.3.7(zod@3.25.76)
+      zod: 4.4.3
+
   "@better-auth/core@1.6.12(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)":
     dependencies:
       "@better-auth/utils": 0.4.1
@@ -8199,10 +8403,31 @@ snapshots:
     optionalDependencies:
       "@cloudflare/workers-types": 4.20260530.1
 
+  "@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)":
+    dependencies:
+      "@better-auth/utils": 0.4.2
+      "@better-fetch/fetch": 1.3.1
+      "@opentelemetry/semantic-conventions": 1.41.1
+      "@standard-schema/spec": 1.1.0
+      better-call: 1.3.7(zod@3.25.76)
+      jose: 6.2.3
+      kysely: 0.28.17
+      nanostores: 1.3.0
+      zod: 4.4.3
+    optionalDependencies:
+      "@cloudflare/workers-types": 4.20260530.1
+
   "@better-auth/drizzle-adapter@1.6.12(@better-auth/core@1.6.12(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.36.4(@cloudflare/workers-types@4.20260530.1)(@types/better-sqlite3@7.6.13)(@types/react@18.3.29)(better-sqlite3@12.10.0)(kysely@0.28.17)(react@18.3.1))":
     dependencies:
       "@better-auth/core": 1.6.12(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       "@better-auth/utils": 0.4.1
+    optionalDependencies:
+      drizzle-orm: 0.36.4(@cloudflare/workers-types@4.20260530.1)(@types/better-sqlite3@7.6.13)(@types/react@18.3.29)(better-sqlite3@12.10.0)(kysely@0.28.17)(react@18.3.1)
+
+  "@better-auth/drizzle-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.36.4(@cloudflare/workers-types@4.20260530.1)(@types/better-sqlite3@7.6.13)(@types/react@18.3.29)(better-sqlite3@12.10.0)(kysely@0.28.17)(react@18.3.1))":
+    dependencies:
+      "@better-auth/core": 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      "@better-auth/utils": 0.4.2
     optionalDependencies:
       drizzle-orm: 0.36.4(@cloudflare/workers-types@4.20260530.1)(@types/better-sqlite3@7.6.13)(@types/react@18.3.29)(better-sqlite3@12.10.0)(kysely@0.28.17)(react@18.3.1)
 
@@ -8213,20 +8438,42 @@ snapshots:
     optionalDependencies:
       kysely: 0.28.17
 
+  "@better-auth/kysely-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)":
+    dependencies:
+      "@better-auth/core": 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      "@better-auth/utils": 0.4.2
+    optionalDependencies:
+      kysely: 0.28.17
+
   "@better-auth/memory-adapter@1.6.12(@better-auth/core@1.6.12(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)":
     dependencies:
       "@better-auth/core": 1.6.12(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       "@better-auth/utils": 0.4.1
+
+  "@better-auth/memory-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)":
+    dependencies:
+      "@better-auth/core": 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      "@better-auth/utils": 0.4.2
 
   "@better-auth/mongo-adapter@1.6.12(@better-auth/core@1.6.12(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)":
     dependencies:
       "@better-auth/core": 1.6.12(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       "@better-auth/utils": 0.4.1
 
+  "@better-auth/mongo-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)":
+    dependencies:
+      "@better-auth/core": 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      "@better-auth/utils": 0.4.2
+
   "@better-auth/prisma-adapter@1.6.12(@better-auth/core@1.6.12(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)":
     dependencies:
       "@better-auth/core": 1.6.12(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       "@better-auth/utils": 0.4.1
+
+  "@better-auth/prisma-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)":
+    dependencies:
+      "@better-auth/core": 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      "@better-auth/utils": 0.4.2
 
   "@better-auth/telemetry@1.6.12(@better-auth/core@1.6.12(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)":
     dependencies:
@@ -8234,11 +8481,23 @@ snapshots:
       "@better-auth/utils": 0.4.1
       "@better-fetch/fetch": 1.1.21
 
+  "@better-auth/telemetry@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)":
+    dependencies:
+      "@better-auth/core": 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      "@better-auth/utils": 0.4.2
+      "@better-fetch/fetch": 1.3.1
+
   "@better-auth/utils@0.4.1":
     dependencies:
       "@noble/hashes": 2.2.0
 
+  "@better-auth/utils@0.4.2":
+    dependencies:
+      "@noble/hashes": 2.2.0
+
   "@better-fetch/fetch@1.1.21": {}
+
+  "@better-fetch/fetch@1.3.1": {}
 
   "@bramus/specificity@2.4.2":
     dependencies:
@@ -9713,10 +9972,49 @@ snapshots:
       - "@cloudflare/workers-types"
       - "@opentelemetry/api"
 
+  better-auth@1.6.25(@cloudflare/workers-types@4.20260530.1)(better-sqlite3@12.10.0)(drizzle-kit@0.28.1)(drizzle-orm@0.36.4(@cloudflare/workers-types@4.20260530.1)(@types/better-sqlite3@7.6.13)(@types/react@18.3.29)(better-sqlite3@12.10.0)(kysely@0.28.17)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@2.1.9(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)):
+    dependencies:
+      "@better-auth/core": 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      "@better-auth/drizzle-adapter": 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.36.4(@cloudflare/workers-types@4.20260530.1)(@types/better-sqlite3@7.6.13)(@types/react@18.3.29)(better-sqlite3@12.10.0)(kysely@0.28.17)(react@18.3.1))
+      "@better-auth/kysely-adapter": 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)
+      "@better-auth/memory-adapter": 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      "@better-auth/mongo-adapter": 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      "@better-auth/prisma-adapter": 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      "@better-auth/telemetry": 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260530.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      "@better-auth/utils": 0.4.2
+      "@better-fetch/fetch": 1.3.1
+      "@noble/ciphers": 2.2.0
+      "@noble/hashes": 2.2.0
+      better-call: 1.3.7(zod@3.25.76)
+      defu: 6.1.7
+      jose: 6.2.3
+      kysely: 0.28.17
+      nanostores: 1.3.0
+      zod: 4.4.3
+    optionalDependencies:
+      better-sqlite3: 12.10.0
+      drizzle-kit: 0.28.1
+      drizzle-orm: 0.36.4(@cloudflare/workers-types@4.20260530.1)(@types/better-sqlite3@7.6.13)(@types/react@18.3.29)(better-sqlite3@12.10.0)(kysely@0.28.17)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      vitest: 2.1.9(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - "@cloudflare/workers-types"
+      - "@opentelemetry/api"
+
   better-call@1.3.5(zod@3.25.76):
     dependencies:
       "@better-auth/utils": 0.4.1
       "@better-fetch/fetch": 1.1.21
+      rou3: 0.7.12
+      set-cookie-parser: 3.1.0
+    optionalDependencies:
+      zod: 3.25.76
+
+  better-call@1.3.7(zod@3.25.76):
+    dependencies:
+      "@better-auth/utils": 0.4.2
+      "@better-fetch/fetch": 1.3.1
       rou3: 0.7.12
       set-cookie-parser: 3.1.0
     optionalDependencies:


### PR DESCRIPTION
## #208 OpenAPI P0

### better-auth 升级 1.6.11→1.6.25

**无 breaking change**（1.6.x 区间均为 bugfix + 少数新 feature）：

- Apple OAuth PKCE bugfix（1.6.25）
- Google One Tap bugfix（1.6.25）
- 新增 `verifyIdToken` 第三参数 `ctx`（1.6.24）
- Yandex OAuth provider（1.6.23）
- `getCookieCache` 返回 null 处理（1.6.18-21 多版修复）
- 详细 changelog 见 [better-auth releases](https://github.com/better-auth/better-auth/releases)

### @better-auth/api-key 安装（v1.6.25）

OpenAPI 认证支持：

- 新增 API Key 插件，支持 Bearer Token / `X-API-Key` header 认证
- 数据库迁移 `0017_add_api_keys.sql`（`apikey` 表，staging + prod 已执行）
- `auth.ts`：添加 `plugins: [apiKey()]`
- API 端点：`/auth/api-key/*`（list/create/get/update/delete）

### 验证

- Type-check：0 errors
- Tests：313 passed（18 test files）

请 @Martin CR。