### PR TITLE
ci+docs: 显式 staging 部署配置 + 冻结 redirect 路径 --env 前端部署

### DIFF
--- a/docs/prod-change-policy.md
+++ b/docs/prod-change-policy.md
@@ -75,6 +75,10 @@ staging 保持自由度，但破坏性操作（清数据/覆盖部署）同样�
 
 **在验证出其他安全路径之前，手工 `wrangler deploy` 前端一律冻结；staging 部署只许走下述显式配置。**
 
+### rollback 版本选择必须核实 lineage
+
+`wrangler deployments list` 只给版本号和时间，不给内容。事故回滚时**必须核实目标版本的 lineage**（对应哪次 CI 部署/哪个 commit），不能凭列表位置猜——2026-07-28 实证：回滚目标 7fc8740f 看似「事故前版本」，实际是上一起误部署的事故版本，prod 因此一直在跑分支代码。核实方法：对照 CI deploy run 的时间与版本号，或让 CR owner 确认。
+
 ### 前端 staging 部署（Workers，实证安全路径）
 
 ```bash

--- a/docs/prod-change-policy.md
+++ b/docs/prod-change-policy.md
@@ -69,7 +69,30 @@ staging 保持自由度，但破坏性操作（清数据/覆盖部署）同样�
 
 ## 三、分支预部署 staging SOP
 
-涉及 D1 schema 变更的 PR：
+### ⚠️ 头号条款：前端禁止在 redirected config 路径下用 `--env` 部署
+
+`frontend/wrangler.toml` 的 `main` 指向 `@astrojs/cloudflare/entrypoints/server`，wrangler 部署时会 redirected 到构建产物 `dist/server/wrangler.json`——该产物**只有顶层配置，env 块不随生成**。此时 `wrangler deploy --env staging` 会**静默回退到顶层（prod）配置**，把代码部署到 prod worker `gomate-frontend`，全程无警告（2026-07-28 已实证一次，~2 分钟回滚）。prod 部署没出事纯属巧合：顶层 name 本来就是 prod。
+
+**在验证出其他安全路径之前，手工 `wrangler deploy` 前端一律冻结；staging 部署只许走下述显式配置。**
+
+### 前端 staging 部署（Workers，实证安全路径）
+
+```bash
+pnpm --filter @gomate/frontend build
+npx wrangler deploy --config frontend/wrangler.staging.toml
+```
+
+`frontend/wrangler.staging.toml` 是显式配置：字面 `name = "gomate-frontend-staging"`、staging KV id、`PUBLIC_API_URL=https://api-staging.gomate.live`、路由 `staging.gomate.live`（custom domain）。无 `--env`、无 redirect，不存在回退机制。
+
+### API staging 部署（Workers）
+
+`deploy-staging.yml`（push:main）自动执行；手工触发用 `pnpm --filter @gomate/api exec wrangler deploy --env staging`（API 的 wrangler.toml 无 adapter redirect，`--env` 安全）。
+
+### Pages 项目
+
+Pages 项目（非本仓库前端）走 Git integration preview 部署，wrangler CLI 不触达。
+
+### D1 schema 变更的 PR
 
 1. migration 文件随 PR 提交（幂等写法 + journal entry 齐全）
 2. 合并到 main → pipeline 自动对 staging 和 prod 应用迁移（staging 先行验证）

--- a/frontend/wrangler.staging.toml
+++ b/frontend/wrangler.staging.toml
@@ -1,0 +1,30 @@
+# Staging 前端 Worker 部署配置（显式、无 --env、无 redirected config 陷阱）
+# 背景：frontend/wrangler.toml 的 main 指向 @astrojs/cloudflare entrypoint，
+# wrangler 会 redirected 到 dist/server/wrangler.json（无 env 块），
+# `wrangler deploy --env staging` 会静默回退到顶层（prod）配置。
+# 因此 staging 部署必须使用本显式配置：wrangler deploy --config wrangler.staging.toml
+# 注意：main/assets 指向构建产物，部署前必须先 pnpm --filter @gomate/frontend build
+name = "gomate-frontend-staging"
+account_id = "e3afbb613458022947cd9dc9f5bd6334"
+compatibility_date = "2026-02-26"
+compatibility_flags = ["nodejs_compat", "global_fetch_strictly_public"]
+
+main = "./dist/server/entry.mjs"
+
+[assets]
+directory = "./dist/client"
+binding = "ASSETS"
+
+[observability]
+enabled = true
+
+[vars]
+PUBLIC_API_URL = "https://api-staging.gomate.live"
+
+[[kv_namespaces]]
+binding = "SESSION"
+id = "f8480fa769054962ab59333aa7015ff6"
+
+[[routes]]
+pattern = "staging.gomate.live"
+custom_domain = true


### PR DESCRIPTION
## 背景（2026-07-28 实证事故）

Astro v13 adapter 的 redirected config（`dist/server/wrangler.json`）只带顶层配置，env 块不随生成。`wrangler deploy --env staging` 在 redirect 路径下**静默回退顶层（prod）配置**，无警告。今天 Jeff 和我先后踩中，我的一次落到 prod worker（version 39453ce8，~2 分钟 rollback 到 7fc8740f）。prod 日常部署没出事纯属巧合：顶层 name 本来就是 prod。

## 改动

- **`frontend/wrangler.staging.toml`**（新）：显式 staging 配置——字面 name `gomate-frontend-staging`、staging KV、`PUBLIC_API_URL=api-staging`、路由 custom domain。无 `--env`、无 redirect、无回退机制
- **`docs/prod-change-policy.md`**：SOP 节修订——头号条款冻结 redirect 路径手工 `--env` 前端部署；前端 staging 走显式配置；API `--env` 安全（无 adapter redirect）；Pages 走 Git integration preview

## 验证（已实证，非纸面）

- [x] 陷阱复现：`--env staging` dry-run 走 redirect，显式 `--config dist/server/wrangler.json --env staging` 报「No environment found」
- [x] 安全路径：`wrangler.staging.toml` dry-run 绑定全对（staging KV id、staging API URL），实部署到 `gomate-frontend-staging`（version 800b9345），staging.gomate.live 200 在线（当前内容为 #451 构建，供 Wen 补测）

🤖 Generated with [Claude Code](https://claude.com/claude-code)