### PR TITLE
fix: add apikey table to drizzle schema + configure apiKey plugin

### DIFF
--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -597,3 +597,42 @@ export const shareEvents = sqliteTable(
 
 export type ShareEvent = typeof shareEvents.$inferSelect;
 export type NewShareEvent = typeof shareEvents.$inferInsert;
+
+// ==================== Better Auth API Key 表（@better-auth/api-key 插件）====================
+// 表由 0017_add_api_keys.sql 创建（IF NOT EXISTS 幂等），Drizzle schema 供 drizzleAdapter 使用。
+// config_id 列由 better-auth apiKey 插件内部自动填充（单配置部署无需命名 configId）
+export const apiKeys = sqliteTable(
+  "apikey",
+  {
+    id: text("id").primaryKey(),
+    configId: text("config_id").notNull(),
+    name: text("name"),
+    start: text("start"),
+    referenceId: text("reference_id").notNull(), // userId
+    key: text("key").notNull(), // hashed
+    prefix: text("prefix"),
+    refillInterval: integer("refill_interval"),
+    refillAmount: integer("refill_amount"),
+    lastRefillAt: integer("last_refill_at", { mode: "timestamp_ms" }),
+    enabled: integer("enabled", { mode: "boolean" }).default(true).notNull(),
+    rateLimitEnabled: integer("rate_limit_enabled", { mode: "boolean" }).default(true).notNull(),
+    rateLimitTimeWindow: integer("rate_limit_time_window"),
+    rateLimitMax: integer("rate_limit_max"),
+    requestCount: integer("request_count").default(0).notNull(),
+    remaining: integer("remaining"),
+    lastRequest: integer("last_request", { mode: "timestamp_ms" }),
+    expiresAt: integer("expires_at", { mode: "timestamp_ms" }),
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
+    permissions: text("permissions"), // JSON string
+    metadata: text("metadata"), // JSON string
+  },
+  (table) => ({
+    configIdIdx: index("apikey_config_id_idx").on(table.configId),
+    referenceIdIdx: index("apikey_reference_id_idx").on(table.referenceId),
+    keyIdx: index("apikey_key_idx").on(table.key),
+  })
+);
+
+export type ApiKey = typeof apiKeys.$inferSelect;
+export type NewApiKey = typeof apiKeys.$inferInsert;

--- a/api/src/lib/auth.ts
+++ b/api/src/lib/auth.ts
@@ -101,6 +101,7 @@ export function createAuth(env: Env) {
         session: schema.sessions,
         account: schema.accounts,
         verification: schema.verifications,
+        apikey: schema.apiKeys,
       },
     }),
     secondaryStorage: buildKvSecondaryStorage(env.GOMATE_KV),
@@ -182,6 +183,20 @@ export function createAuth(env: Env) {
       "https://gomate.live",
       "https://api.gomate.live",
     ],
-    plugins: [apiKey()],
+    plugins: [
+      apiKey({
+        defaultPrefix: "gm_live_",
+        defaultKeyLength: 48,
+        // rate limit：读 scope 每小时 1000 次（插件内部 per-key enforce）
+        rateLimit: {
+          enabled: true,
+          timeWindow: 1000 * 60 * 60, // 1 hour
+          maxRequests: 1000,
+        },
+        keyExpiration: {
+          defaultExpiresIn: 365 * 24 * 60 * 60, // 1 year
+        },
+      }),
+    ],
   });
 }


### PR DESCRIPTION
## fix: apikey schema + plugin config (P1a blocker fix)

### 根因（Wen 发现，Martin 一手核实）

已认证调用  → 500。
-  已在 D1 建表 ✅
-  的  schema **没有 apikey 模型** ❌
- auth API plugin 写入/查询 apikey 表时，Drizzle 找不到模型定义 → 500

### 修复内容

1. **schema.ts**：补  Drizzle table 定义（对齐 0017 DDL 列名 + 索引）
2. **auth.ts**：adapter schema 挂接  + 配置  插件参数

### 验证

修复后已认证调用  → 200（连同 Bob P1b UI 一起验）

### prod 影响

- 零用户面影响（无消费者：UI 未合、/v1/ 不存在、无已签发 key）
- 走正常 merge 流程，不需紧急通道
