### PR TITLE
feat(v1): OpenAPI P1a — /v1/ read endpoints ×6 + openapi.json scaffold

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -19,6 +19,7 @@ import storiesRoute from "./routes/stories";
 import { shareImageRoute } from "./routes/share-image";
 import { recommendationsHomeRoute } from "./routes/recommendations/home";
 import { localCircleHomeRoute } from "./routes/local-circle/home";
+import { v1Route } from "./routes/v1/index";
 import { updateExpiredTeams } from "./lib/team-status";
 import { createDb } from "./db";
 import { fetchWithTimeout } from "./lib/timeout";
@@ -52,6 +53,7 @@ app.route("/stories", storiesRoute);
 app.route("/share-image", shareImageRoute);
 app.route("/recommendations/home", recommendationsHomeRoute);
 app.route("/local-circle/home", localCircleHomeRoute);
+app.route("/v1", v1Route);
 
 // R2 本地代理（挂在顶层，对齐原 Next.js /api/r2/* 路径）
 app.get("/r2/*", async (c) => {

--- a/api/src/lib/auth.ts
+++ b/api/src/lib/auth.ts
@@ -196,6 +196,10 @@ export function createAuth(env: Env) {
         keyExpiration: {
           defaultExpiresIn: 365 * 24 * 60 * 60, // 1 year
         },
+        // enableSessionForAPIKeys: API key 自动注入 session
+        // 安全前提：gomate 每用户自建 key，key→userId 一一对应，无跨用户风险
+        // 10-key cap 由 auth.ts 自定义 wrapper 处理，不受此影响
+        enableSessionForAPIKeys: true,
       }),
     ],
   });

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -2,10 +2,10 @@ import { APIErrors } from "../lib/api-errors";
 import { logger } from "../lib/logger";
 import { Hono } from "hono";
 import { z } from "zod";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { createAuth, type Env } from "../lib/auth";
 import { createDb } from "../db";
-import { users } from "../db/schema";
+import { users, apiKeys } from "../db/schema";
 import { checkRateLimit, getClientIP } from "../lib/rate-limit";
 
 const auth = new Hono<{ Bindings: Env }>();
@@ -64,10 +64,46 @@ auth.post("/forgot-password", async (c) => {
 });
 
 /**
+ * POST /auth/api-key/create
+ * 自定义 wrapper：10-key 上限拦截（P1a spec：beforeKeyCreate hook 等效）
+ * 必须在 auth.all("/*", ...) 之前注册，否则被通配符吞掉。
+ */
+const MAX_API_KEYS = 10;
+
+auth.post("/api-key/create", async (c) => {
+  const authInstance = createAuth(c.env);
+  // 解析 session（API key 认证产生的 session 等效于 key 对应的用户身份）
+  const session = await authInstance.api.getSession({ headers: c.req.raw.headers }).catch(() => null);
+  if (!session) {
+    return c.json(APIErrors.unauthorized("请先登录"), 401);
+  }
+
+  const userId = session.user.id;
+  const db = createDb(c.env.DB);
+
+  // 统计该用户已有 key 数量
+  const [{ cnt }] = await db
+    .select({ cnt: sql<number>`count(*)` })
+    .from(apiKeys)
+    .where(eq(apiKeys.referenceId, userId));
+
+  if (cnt >= MAX_API_KEYS) {
+    return c.json(
+      { success: false, error: "MAX_API_KEYS_EXCEEDED", message: `每位用户最多 ${MAX_API_KEYS} 个 API Key，当前已有 ${cnt} 个` },
+      403
+    );
+  }
+
+  // 放行：交由 better-auth 内部 createApiKey 处理
+  return authInstance.handler(c.req.raw);
+});
+
+/**
  * ALL /auth/*
  * Better Auth 处理所有认证请求（登录、注册、登出、会话等）
  *
  * 对 sign-in 和 sign-up 端点应用限流。
+ * 注意：/auth/api-key/create 已由上方的 post 路由处理，不会落入此处。
  */
 auth.all("/*", async (c) => {
   const path = new URL(c.req.url).pathname;

--- a/api/src/routes/v1/enums.ts
+++ b/api/src/routes/v1/enums.ts
@@ -1,0 +1,73 @@
+import { Hono } from "hono";
+import { createDb } from "../../db";
+import type { Env } from "../../lib/auth";
+
+const enums = new Hono<{ Bindings: Env }>();
+
+/**
+ * GET /v1/enums
+ * Agent 合法值发现入口：一次性返回所有枚举/选项值。
+ */
+enums.get("/", async (c) => {
+  try {
+    const db = createDb(c.env.DB);
+
+    // Cities
+    const cities = await db.query.cities.findMany({
+      columns: { id: true, name: true },
+      orderBy: (cities, { asc }) => [asc(cities.name)],
+    });
+
+    // Tags (all)
+    const tags = await db.query.tags.findMany({
+      columns: { id: true, name: true, type: true },
+      orderBy: (tags, { asc }) => [asc(tags.type), asc(tags.name)],
+    });
+
+    // Durations (distinct from locations.durationMin)
+    const durations = [
+      { value: 60, label: "1 小时" },
+      { value: 120, label: "2 小时" },
+      { value: 180, label: "3 小时" },
+      { value: 240, label: "4 小时" },
+      { value: 300, label: "5 小时" },
+      { value: 360, label: "6 小时" },
+      { value: 480, label: "8 小时" },
+      { value: 540, label: "9 小时" },
+      { value: 600, label: "10 小时" },
+      { value: 720, label: "12 小时" },
+      { value: 1440, label: "1 天" },
+    ];
+
+    // Difficulty levels
+    const difficulties = [
+      { value: "easy", label: "简单" },
+      { value: "moderate", label: "适中" },
+      { value: "hard", label: "困难" },
+    ];
+
+    // Team statuses
+    const teamStatuses = [
+      { value: "recruiting", label: "招募中" },
+      { value: "ongoing", label: "进行中" },
+      { value: "completed", label: "已完成" },
+      { value: "cancelled", label: "已取消" },
+    ];
+
+    return c.json({
+      success: true,
+      enums: {
+        cities,
+        tags,
+        durations,
+        difficulties,
+        teamStatuses,
+      },
+    });
+  } catch (error) {
+    console.error("[v1/enums] error:", error);
+    return c.json({ success: false, error: "获取枚举值失败" }, 500);
+  }
+});
+
+export { enums as enumsRoute };

--- a/api/src/routes/v1/index.ts
+++ b/api/src/routes/v1/index.ts
@@ -1,0 +1,15 @@
+import { Hono } from "hono";
+import type { Env } from "../../lib/auth";
+import { teamsRoute } from "./teams";
+import { locationsRoute } from "./locations";
+import { enumsRoute } from "./enums";
+import { storiesRoute } from "./stories";
+
+const v1 = new Hono<{ Bindings: Env }>();
+
+v1.route("/teams", teamsRoute);
+v1.route("/locations", locationsRoute);
+v1.route("/enums", enumsRoute);
+v1.route("/stories", storiesRoute);
+
+export { v1 as v1Route };

--- a/api/src/routes/v1/locations.ts
+++ b/api/src/routes/v1/locations.ts
@@ -1,0 +1,146 @@
+import { Hono } from "hono";
+import { eq, like, and, sql } from "drizzle-orm";
+import { createDb } from "../../db";
+import * as schema from "../../db/schema";
+import type { Env } from "../../lib/auth";
+import { APIErrors } from "../../lib/api-errors";
+import { safeJsonParse } from "../locations/utils";
+
+const locations = new Hono<{ Bindings: Env }>();
+
+/**
+ * GET /v1/locations
+ * 公开读端点：地点列表，支持分页、cityId、keyword 过滤。
+ */
+locations.get("/", async (c) => {
+  try {
+    const db = createDb(c.env.DB);
+
+    const page = Math.max(1, parseInt(c.req.query("page") || "1", 10));
+    const pageSize = Math.min(100, Math.max(1, parseInt(c.req.query("pageSize") || "12", 10)));
+    const search = c.req.query("keyword") || c.req.query("search") || "";
+    const cityId = c.req.query("cityId") || "";
+    const offset = (page - 1) * pageSize;
+
+    const conditions = [];
+    if (search) {
+      conditions.push(like(schema.locations.name, `%${search}%`));
+    }
+    if (cityId) {
+      conditions.push(eq(schema.locations.cityId, cityId));
+    }
+    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+    // Count
+    const [{ cnt }] = await db
+      .select({ cnt: sql<number>`count(*)` })
+      .from(schema.locations)
+      .where(whereClause);
+    const total = cnt;
+    const totalPages = Math.ceil(total / pageSize);
+    const hasMore = page < totalPages;
+
+    // Fetch
+    const rows = await db.query.locations.findMany({
+      where: whereClause,
+      columns: {
+        id: true,
+        name: true,
+        slug: true,
+        coverImage: true,
+        cityId: true,
+        difficulty: true,
+        durationMin: true,
+        description: true,
+        images: true,
+        bestSeason: true,
+        coordinates: true,
+        gearEssential: true,
+        gearOptional: true,
+        extra: true,
+      },
+      orderBy: (locations, { desc }) => [desc(locations.createdAt)],
+      limit: pageSize,
+      offset,
+    });
+
+    const locations_ = rows.map((loc) => ({
+      id: loc.id,
+      name: loc.name,
+      slug: loc.slug,
+      coverImage: loc.coverImage,
+      cityId: loc.cityId,
+      difficulty: loc.difficulty,
+      durationMin: loc.durationMin,
+      description: loc.description,
+      images: safeJsonParse(loc.images, []),
+      bestSeason: safeJsonParse(loc.bestSeason, []),
+      coordinates: safeJsonParse(loc.coordinates, { lat: 0, lng: 0 }),
+      gearEssential: parseCsvField(loc.gearEssential),
+      gearOptional: parseCsvField(loc.gearOptional),
+    }));
+
+    return c.json({ success: true, locations: locations_, pagination: { page, pageSize, total, totalPages, hasMore } });
+  } catch (error) {
+    console.error("[v1/locations] list error:", error);
+    return c.json(APIErrors.internalError("获取地点列表失败"), 500);
+  }
+});
+
+/**
+ * GET /v1/locations/:id
+ * 公开读端点：地点详情，含坐标/交通/标签。
+ */
+locations.get("/:id", async (c) => {
+  try {
+    const db = createDb(c.env.DB);
+    const idOrSlug = c.req.param("id");
+
+    // Try by id first, then by slug
+    let location = await db.query.locations.findFirst({
+      where: eq(schema.locations.id, idOrSlug),
+    });
+    if (!location) {
+      location = await db.query.locations.findFirst({
+        where: eq(schema.locations.slug, idOrSlug),
+      });
+    }
+    if (!location) return c.json(APIErrors.notFound("地点不存在"), 404);
+
+    // Fetch tags
+    const tagRelations = await db
+      .select({ tagId: schema.entityToTags.tagId, tagName: schema.tags.name, tagType: schema.tags.type })
+      .from(schema.entityToTags)
+      .innerJoin(schema.tags, eq(schema.tags.id, schema.entityToTags.tagId))
+      .where(
+        and(
+          eq(schema.entityToTags.entityType, "location"),
+          eq(schema.entityToTags.entityId, location.id)
+        )
+      );
+    const tags = tagRelations.map((r) => ({ id: r.tagId, name: r.tagName, type: r.tagType }));
+
+    return c.json({
+      success: true,
+      location: {
+        ...location,
+        images: safeJsonParse(location.images, []),
+        bestSeason: safeJsonParse(location.bestSeason, []),
+        coordinates: safeJsonParse(location.coordinates, { lat: 0, lng: 0 }),
+        gearEssential: parseCsvField(location.gearEssential),
+        gearOptional: parseCsvField(location.gearOptional),
+        tags,
+      },
+    });
+  } catch (error) {
+    console.error("[v1/locations/:id] error:", error);
+    return c.json(APIErrors.internalError("获取地点详情失败"), 500);
+  }
+});
+
+function parseCsvField(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  return raw.split(/[,、]/).map((s) => s.trim()).filter(Boolean);
+}
+
+export { locations as locationsRoute };

--- a/api/src/routes/v1/openapi.json
+++ b/api/src/routes/v1/openapi.json
@@ -1,0 +1,686 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Gomate API",
+    "description": "Gomate 公开 API — 支持 session cookie 和 API Key 两种认证方式。",
+    "version": "1.0.0"
+  },
+  "servers": [
+    { "url": "https://api.gomate.live", "description": "生产环境" },
+    { "url": "https://api-staging.gomate.live", "description": "Staging 环境" }
+  ],
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-api-key",
+        "description": "API Key（格式：gm_live_<key>），通过 P1b UI 或 POST /auth/api-key/create 创建"
+      },
+      "SessionCookie": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Web 端 session cookie（登录后自动携带）"
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "success": { "type": "boolean", "example": false },
+          "error": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      },
+      "Pagination": {
+        "type": "object",
+        "properties": {
+          "page": { "type": "integer" },
+          "pageSize": { "type": "integer" },
+          "total": { "type": "integer" },
+          "totalPages": { "type": "integer" },
+          "hasMore": { "type": "boolean" }
+        }
+      },
+      "TeamCard": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "locationId": { "type": "string" },
+          "leaderId": { "type": "string" },
+          "title": { "type": "string" },
+          "description": { "type": "string", "nullable": true },
+          "startTime": { "type": "string", "format": "date-time" },
+          "endTime": { "type": "string", "format": "date-time" },
+          "durationMin": { "type": "integer", "nullable": true },
+          "maxMembers": { "type": "integer" },
+          "requirements": { "type": "string", "nullable": true },
+          "icon": { "type": "string" },
+          "status": {
+            "type": "string",
+            "enum": ["recruiting", "ongoing", "completed", "cancelled"]
+          },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "updatedAt": { "type": "string", "format": "date-time" },
+          "currentMembers": { "type": "integer" },
+          "leader": { "$ref": "#/components/schemas/Leader" },
+          "location": {
+            "$ref": "#/components/schemas/LocationSummary",
+            "nullable": true
+          }
+        }
+      },
+      "TeamDetail": {
+        "allOf": [
+          { "$ref": "#/components/schemas/TeamCard" },
+          {
+            "type": "object",
+            "properties": {
+              "myStatus": {
+                "type": "string",
+                "enum": ["none", "pending", "approved", "rejected", "member"]
+              },
+              "currentMembers": { "type": "integer" }
+            }
+          }
+        ]
+      },
+      "Leader": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "nickname": { "type": "string", "nullable": true },
+          "level": { "type": "string", "nullable": true },
+          "image": { "type": "string", "nullable": true }
+        }
+      },
+      "LocationSummary": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string", "nullable": true },
+          "coverImage": { "type": "string", "nullable": true },
+          "difficulty": { "type": "string", "nullable": true }
+        }
+      },
+      "LocationDetail": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "slug": { "type": "string", "nullable": true },
+          "coverImage": { "type": "string", "nullable": true },
+          "cityId": { "type": "string", "nullable": true },
+          "difficulty": { "type": "string", "nullable": true },
+          "durationMin": { "type": "integer", "nullable": true },
+          "description": { "type": "string", "nullable": true },
+          "images": { "type": "array", "items": { "type": "string" } },
+          "bestSeason": { "type": "array", "items": { "type": "string" } },
+          "coordinates": { "$ref": "#/components/schemas/Coordinates" },
+          "gearEssential": { "type": "array", "items": { "type": "string" } },
+          "gearOptional": { "type": "array", "items": { "type": "string" } },
+          "tags": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Tag" }
+          }
+        }
+      },
+      "Coordinates": {
+        "type": "object",
+        "properties": {
+          "lat": { "type": "number" },
+          "lng": { "type": "number" }
+        }
+      },
+      "Tag": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "type": { "type": "string", "nullable": true }
+        }
+      },
+      "City": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" }
+        }
+      },
+      "Duration": {
+        "type": "object",
+        "properties": {
+          "value": { "type": "integer", "description": "分钟数" },
+          "label": { "type": "string" }
+        }
+      },
+      "Difficulty": {
+        "type": "object",
+        "properties": {
+          "value": { "type": "string" },
+          "label": { "type": "string" }
+        }
+      },
+      "TeamStatus": {
+        "type": "object",
+        "properties": {
+          "value": { "type": "string" },
+          "label": { "type": "string" }
+        }
+      },
+      "StoryCard": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "title": { "type": "string" },
+          "coverImage": { "type": "string", "nullable": true },
+          "summary": { "type": "string" },
+          "content": { "type": "string" },
+          "viewCount": { "type": "integer" },
+          "likeCount": { "type": "integer" },
+          "status": { "type": "string" },
+          "publishedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "author": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" },
+              "name": { "type": "string" },
+              "image": { "type": "string", "nullable": true }
+            },
+            "nullable": true
+          },
+          "location": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" },
+              "name": { "type": "string" },
+              "slug": { "type": "string", "nullable": true }
+            },
+            "nullable": true
+          }
+        }
+      },
+      "StoryDetail": {
+        "allOf": [
+          { "$ref": "#/components/schemas/StoryCard" },
+          {
+            "type": "object",
+            "properties": {
+              "isLiked": { "type": "boolean" },
+              "tags": {
+                "type": "array",
+                "items": { "$ref": "#/components/schemas/Tag" }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "paths": {
+    "/v1/teams": {
+      "get": {
+        "operationId": "listTeams",
+        "summary": "获取队伍列表",
+        "description": "公开读端点，支持分页和多种过滤条件。",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": { "type": "integer", "default": 1 },
+            "description": "页码（从 1 开始）"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": { "type": "integer", "default": 12, "maximum": 100 },
+            "description": "每页条数"
+          },
+          {
+            "name": "cityId",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "按城市 ID 过滤"
+          },
+          {
+            "name": "tagId",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "按标签 ID 过滤"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "状态过滤（recruiting/ongoing/completed/cancelled），逗号分隔多个"
+          },
+          {
+            "name": "keyword",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "标题/描述关键词搜索"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "队伍列表",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "teams": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/TeamCard" }
+                    },
+                    "pagination": { "$ref": "#/components/schemas/Pagination" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/teams/{id}": {
+      "get": {
+        "operationId": "getTeamDetail",
+        "summary": "获取队伍详情",
+        "description": "公开读端点。认证后可获取当前用户的 myStatus。",
+        "security": [{ "ApiKeyAuth": [] }, { "SessionCookie": [] }],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "队伍 ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "队伍详情",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "team": { "$ref": "#/components/schemas/TeamDetail" }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "队伍不存在",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/teams/{id}/my-status": {
+      "get": {
+        "operationId": "getMyTeamStatus",
+        "summary": "获取当前用户在本队伍的身份",
+        "description": "需认证。未加入返回 {status:\"none\"}；pending 时返回 pollAfterSeconds=300（5分钟轮询建议）。",
+        "security": [{ "ApiKeyAuth": [] }, { "SessionCookie": [] }],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "队伍 ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "身份状态",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "none",
+                        "pending",
+                        "approved",
+                        "rejected",
+                        "member"
+                      ]
+                    },
+                    "pollAfterSeconds": {
+                      "type": "integer",
+                      "description": "当 status=pending 时为 300"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/locations": {
+      "get": {
+        "operationId": "listLocations",
+        "summary": "获取地点列表",
+        "description": "公开读端点，支持分页、城市和关键词过滤。",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": { "type": "integer", "default": 1 }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": { "type": "integer", "default": 12, "maximum": 100 }
+          },
+          {
+            "name": "keyword",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "地点名称搜索"
+          },
+          {
+            "name": "cityId",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "按城市 ID 过滤"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "地点列表",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "locations": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/LocationDetail" }
+                    },
+                    "pagination": { "$ref": "#/components/schemas/Pagination" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/locations/{id}": {
+      "get": {
+        "operationId": "getLocationDetail",
+        "summary": "获取地点详情",
+        "description": "公开读端点，支持按 ID 或 slug 查询。返回坐标、标签、装备建议等完整信息。",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "地点 ID 或 slug"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "地点详情",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "location": {
+                      "$ref": "#/components/schemas/LocationDetail"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "地点不存在",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/enums": {
+      "get": {
+        "operationId": "getEnums",
+        "summary": "获取枚举值",
+        "description": "Agent 合法值发现入口：一次性返回 cities / tags / durations / difficulties / teamStatuses。",
+        "responses": {
+          "200": {
+            "description": "所有枚举值",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "enums": {
+                      "type": "object",
+                      "properties": {
+                        "cities": {
+                          "type": "array",
+                          "items": { "$ref": "#/components/schemas/City" }
+                        },
+                        "tags": {
+                          "type": "array",
+                          "items": { "$ref": "#/components/schemas/Tag" }
+                        },
+                        "durations": {
+                          "type": "array",
+                          "items": { "$ref": "#/components/schemas/Duration" }
+                        },
+                        "difficulties": {
+                          "type": "array",
+                          "items": { "$ref": "#/components/schemas/Difficulty" }
+                        },
+                        "teamStatuses": {
+                          "type": "array",
+                          "items": { "$ref": "#/components/schemas/TeamStatus" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/stories": {
+      "get": {
+        "operationId": "listStories",
+        "summary": "获取已发布故事列表",
+        "description": "公开读端点，仅返回 published 状态的故事。",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": { "type": "integer", "default": 1 }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": { "type": "integer", "default": 10, "maximum": 20 }
+          },
+          {
+            "name": "locationId",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "按地点 ID 过滤"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "故事列表",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "stories": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/StoryCard" }
+                    },
+                    "pagination": { "$ref": "#/components/schemas/Pagination" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/stories/{id}": {
+      "get": {
+        "operationId": "getStoryDetail",
+        "summary": "获取故事详情",
+        "description": "公开读端点。认证用户可看到 isLiked 状态；draft/hidden 仅对作者本人或 admin 可见。",
+        "security": [{ "ApiKeyAuth": [] }, { "SessionCookie": [] }],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "故事 ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "故事详情",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "story": { "$ref": "#/components/schemas/StoryDetail" }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "故事不存在",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/api-key/create": {
+      "post": {
+        "operationId": "createApiKey",
+        "summary": "创建 API Key",
+        "description": "需认证。每位用户最多 10 个 Key，超额返回 403。",
+        "security": [{ "ApiKeyAuth": [] }, { "SessionCookie": [] }],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Key 名称（可选）"
+                  },
+                  "expiresIn": {
+                    "type": "integer",
+                    "description": "过期时间（秒），默认 365 天"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Key 创建成功（仅此时返回明文 key）",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "name": { "type": "string", "nullable": true },
+                    "key": {
+                      "type": "string",
+                      "description": "明文 Key，仅此次返回，请妥善保存"
+                    },
+                    "prefix": { "type": "string" },
+                    "startsAt": { "type": "string", "format": "date-time" },
+                    "expiresAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "enabled": { "type": "boolean" }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "未认证",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          },
+          "403": {
+            "description": "超过 10-key 上限",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean", "example": false },
+                    "error": {
+                      "type": "string",
+                      "example": "MAX_API_KEYS_EXCEEDED"
+                    },
+                    "message": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/src/routes/v1/stories.ts
+++ b/api/src/routes/v1/stories.ts
@@ -1,0 +1,191 @@
+import { Hono } from "hono";
+import { eq, ne, and, desc, sql } from "drizzle-orm";
+import { createAuth } from "../../lib/auth";
+import { createDb } from "../../db";
+import * as schema from "../../db/schema";
+import type { Env } from "../../lib/auth";
+import { APIErrors } from "../../lib/api-errors";
+
+const stories = new Hono<{ Bindings: Env }>();
+
+/**
+ * GET /v1/stories
+ * 公开读端点：已发布故事列表。
+ */
+stories.get("/", async (c) => {
+  try {
+    const db = createDb(c.env.DB);
+
+    const page = Math.max(1, parseInt(c.req.query("page") || "1", 10));
+    const pageSize = Math.min(20, Math.max(1, parseInt(c.req.query("pageSize") || "10", 10)));
+    const locationId = c.req.query("locationId") || "";
+    const offset = (page - 1) * pageSize;
+
+    const conditions = [eq(schema.stories.status, "published")];
+    if (locationId) {
+      conditions.push(eq(schema.stories.locationId, locationId));
+    }
+    const whereClause = and(...conditions);
+
+    // Count total
+    const [{ cnt }] = await db
+      .select({ cnt: sql<number>`count(*)` })
+      .from(schema.stories)
+      .where(whereClause);
+    const total = cnt;
+    const totalPages = Math.ceil(total / pageSize);
+    const hasMore = page < totalPages;
+
+    // Fetch stories with author + location
+    const rows = await db
+      .select({
+        story: schema.stories,
+        authorId: schema.users.id,
+        authorName: schema.users.name,
+        authorNickname: schema.users.nickname,
+        authorImage: schema.users.image,
+        locationId: schema.locations.id,
+        locationName: schema.locations.name,
+        locationSlug: schema.locations.slug,
+      })
+      .from(schema.stories)
+      .leftJoin(schema.users, eq(schema.stories.authorId, schema.users.id))
+      .leftJoin(schema.locations, eq(schema.stories.locationId, schema.locations.id))
+      .where(whereClause)
+      .orderBy(desc(schema.stories.createdAt))
+      .limit(pageSize)
+      .offset(offset);
+
+    const result = rows.map((row) => ({
+      id: row.story.id,
+      title: row.story.title,
+      coverImage: row.story.coverImage,
+      summary: row.story.summary,
+      content: row.story.content,
+      viewCount: row.story.viewCount ?? 0,
+      likeCount: row.story.likeCount ?? 0,
+      status: row.story.status,
+      createdAt: row.story.createdAt,
+      author: row.authorId ? {
+        id: row.authorId,
+        name: row.authorNickname || row.authorName,
+        image: row.authorImage,
+      } : null,
+      location: row.locationId ? {
+        id: row.locationId,
+        name: row.locationName,
+        slug: row.locationSlug,
+      } : null,
+    }));
+
+    return c.json({
+      success: true,
+      stories: result,
+      pagination: { page, pageSize, total, totalPages, hasMore },
+    });
+  } catch (error) {
+    console.error("[v1/stories] list error:", error);
+    return c.json(APIErrors.internalError("获取故事列表失败"), 500);
+  }
+});
+
+/**
+ * GET /v1/stories/:id
+ * 公开读端点：已发布故事详情，draft/hidden 不可见。
+ */
+stories.get("/:id", async (c) => {
+  try {
+    const db = createDb(c.env.DB);
+    const auth = createAuth(c.env);
+    const id = c.req.param("id");
+
+    const session = await auth.api.getSession({ headers: c.req.raw.headers }).catch(() => null);
+
+    const result = await db
+      .select({
+        story: schema.stories,
+        authorId: schema.users.id,
+        authorName: schema.users.name,
+        authorNickname: schema.users.nickname,
+        authorImage: schema.users.image,
+        locationId: schema.locations.id,
+        locationName: schema.locations.name,
+        locationSlug: schema.locations.slug,
+      })
+      .from(schema.stories)
+      .leftJoin(schema.users, eq(schema.stories.authorId, schema.users.id))
+      .leftJoin(schema.locations, eq(schema.stories.locationId, schema.locations.id))
+      .where(and(eq(schema.stories.id, id), ne(schema.stories.status, "hidden")))
+      .limit(1);
+
+    if (!result.length) {
+      return c.json(APIErrors.notFound("故事不存在"), 404);
+    }
+
+    const { story, authorId, authorName, authorNickname, authorImage, locationId, locationName, locationSlug } = result[0];
+
+    // draft 只对作者本人或 admin 可见
+    if (story.status !== "published") {
+      const canView = session && (session.user.id === story.authorId || session.user.role === "admin");
+      if (!canView) return c.json(APIErrors.notFound("故事不存在"), 404);
+    }
+
+    // Increment view count for published stories
+    if (story.status === "published") {
+      await db
+        .update(schema.stories)
+        .set({ viewCount: (story.viewCount ?? 0) + 1 })
+        .where(eq(schema.stories.id, id));
+    }
+
+    // Fetch tags
+    const tagRows = await db
+      .select({ id: schema.tags.id, name: schema.tags.name })
+      .from(schema.entityToTags)
+      .innerJoin(schema.tags, eq(schema.entityToTags.tagId, schema.tags.id))
+      .where(
+        and(
+          eq(schema.entityToTags.entityId, id),
+          eq(schema.entityToTags.entityType, "story")
+        )
+      );
+
+    // Check isLiked
+    let isLiked = false;
+    if (session) {
+      const like = await db.query.userStoryLikes.findFirst({
+        where: and(
+          eq(schema.userStoryLikes.userId, session.user.id),
+          eq(schema.userStoryLikes.storyId, id)
+        ),
+        columns: { userId: true },
+      });
+      isLiked = !!like;
+    }
+
+    return c.json({
+      success: true,
+      story: {
+        ...story,
+        viewCount: story.status === "published" ? (story.viewCount ?? 0) + 1 : story.viewCount ?? 0,
+        isLiked,
+        tags: tagRows,
+        author: authorId ? {
+          id: authorId,
+          name: authorNickname || authorName,
+          image: authorImage,
+        } : null,
+        location: locationId ? {
+          id: locationId,
+          name: locationName,
+          slug: locationSlug,
+        } : null,
+      },
+    });
+  } catch (error) {
+    console.error("[v1/stories/:id] error:", error);
+    return c.json(APIErrors.internalError("获取故事详情失败"), 500);
+  }
+});
+
+export { stories as storiesRoute };

--- a/api/src/routes/v1/teams.ts
+++ b/api/src/routes/v1/teams.ts
@@ -1,0 +1,307 @@
+import { Hono } from "hono";
+import { desc, eq, and, sql, inArray } from "drizzle-orm";
+import { createAuth } from "../../lib/auth";
+import { createDb } from "../../db";
+import * as schema from "../../db/schema";
+import type { Env } from "../../lib/auth";
+import { APIErrors } from "../../lib/api-errors";
+
+const teams = new Hono<{ Bindings: Env }>();
+
+/**
+ * GET /v1/teams
+ * 公开读端点：队伍列表，支持分页、cityId/tagId/status/keyword 过滤。
+ * API key 或 session 可选传入（用于个性化，不影响公开数据返回）。
+ */
+teams.get("/", async (c) => {
+  try {
+    const db = createDb(c.env.DB);
+    const auth = createAuth(c.env);
+
+    // Resolve actor (API key or session) — list is public, actor available for personalization
+    await auth.api
+      .getSession({ headers: c.req.raw.headers })
+      .catch(() => null);
+
+    // Query params
+    const page = Math.max(1, parseInt(c.req.query("page") || "1", 10));
+    const pageSize = Math.min(100, parseInt(c.req.query("pageSize") || "12", 10));
+    const cityId = c.req.query("cityId") || "";
+    const tagId = c.req.query("tagId") || "";
+    const status = c.req.query("status") || "";
+    const keyword = c.req.query("keyword") || "";
+    const offset = (page - 1) * pageSize;
+
+    // CTE: current member count per team
+    const teamMemberCounts = db.$with("team_member_counts").as(
+      db
+        .select({
+          teamId: schema.teamMembers.teamId,
+          count: sql<number>`count(*)`.as("count"),
+        })
+        .from(schema.teamMembers)
+        .where(inArray(schema.teamMembers.status, ["approved", "leave_pending"]))
+        .groupBy(schema.teamMembers.teamId)
+    );
+
+    const teamColumns = {
+      id: schema.teams.id,
+      locationId: schema.teams.locationId,
+      leaderId: schema.teams.leaderId,
+      title: schema.teams.title,
+      description: schema.teams.description,
+      startTime: schema.teams.startTime,
+      endTime: schema.teams.endTime,
+      durationMin: schema.teams.durationMin,
+      maxMembers: schema.teams.maxMembers,
+      requirements: schema.teams.requirements,
+      icon: schema.teams.icon,
+      status: schema.teams.status,
+      createdAt: schema.teams.createdAt,
+      updatedAt: schema.teams.updatedAt,
+      currentMembers: sql<number>`coalesce(${teamMemberCounts.count}, 0)`.as("currentMembers"),
+      leaderImage: schema.users.image,
+      leaderName: schema.users.name,
+      leaderNickname: schema.users.nickname,
+      leaderLevel: schema.users.level,
+      locationName: schema.locations.name,
+      locationCoverImage: schema.locations.coverImage,
+      locationDifficulty: schema.locations.difficulty,
+    };
+
+    type TeamRow = {
+      id: string; locationId: string; leaderId: string;
+      title: string; description: string | null; startTime: Date; endTime: Date;
+      durationMin: number | null; maxMembers: number; requirements: string | null;
+      icon: string; status: string; createdAt: Date; updatedAt: Date;
+      currentMembers: number; leaderImage: string | null; leaderName: string;
+      leaderNickname: string | null; leaderLevel: string | null;
+      locationName: string | null; locationCoverImage: string | null;
+      locationDifficulty: string | null;
+    };
+
+    // Build WHERE conditions
+    const conditions: ReturnType<typeof eq>[] = [];
+
+    if (status) {
+      const statuses = status.split(",").filter(Boolean) as schema.TeamStatus[];
+      if (statuses.length === 1) {
+        conditions.push(eq(schema.teams.status, statuses[0]));
+      } else if (statuses.length > 1) {
+        conditions.push(inArray(schema.teams.status, statuses));
+      }
+    }
+
+    if (cityId) {
+      conditions.push(eq(schema.locations.cityId, cityId));
+    }
+
+    if (keyword) {
+      conditions.push(
+        sql`(${schema.teams.title} LIKE ${"%" + keyword + "%"} OR ${schema.teams.description} LIKE ${"%" + keyword + "%"})`
+      );
+    }
+
+    // Tag filter: find teams with this tag
+    let taggedTeamIds: string[] | null = null;
+    if (tagId) {
+      const tagResults = await db
+        .select({ entityId: schema.entityToTags.entityId })
+        .from(schema.entityToTags)
+        .where(
+          and(
+            eq(schema.entityToTags.entityType, "activity"),
+            eq(schema.entityToTags.tagId, tagId)
+          )
+        );
+      taggedTeamIds = tagResults.map((r) => r.entityId);
+      if (taggedTeamIds.length === 0) {
+        return c.json({ success: true, teams: [], pagination: { page, pageSize, total: 0, totalPages: 0, hasMore: false } });
+      }
+      conditions.push(inArray(schema.teams.id, taggedTeamIds));
+    }
+
+    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+    // Count total
+    const [{ cnt }] = await db
+      .with(teamMemberCounts)
+      .select({ cnt: sql<number>`count(distinct ${schema.teams.id})` })
+      .from(schema.teams)
+      .leftJoin(schema.locations, eq(schema.locations.id, schema.teams.locationId))
+      .where(whereClause);
+    const total = cnt;
+    const totalPages = Math.ceil(total / pageSize);
+    const hasMore = page < totalPages;
+
+    // Fetch rows
+    const rows = await db
+      .with(teamMemberCounts)
+      .select(teamColumns)
+      .from(schema.teams)
+      .innerJoin(schema.users, eq(schema.users.id, schema.teams.leaderId))
+      .leftJoin(schema.locations, eq(schema.locations.id, schema.teams.locationId))
+      .leftJoin(teamMemberCounts, eq(teamMemberCounts.teamId, schema.teams.id))
+      .where(whereClause)
+      .orderBy(desc(schema.teams.createdAt))
+      .limit(pageSize)
+      .offset(offset) as TeamRow[];
+
+    const teams = rows.map((row) => ({
+      id: row.id,
+      locationId: row.locationId,
+      leaderId: row.leaderId,
+      title: row.title,
+      description: row.description,
+      startTime: row.startTime,
+      endTime: row.endTime,
+      durationMin: row.durationMin,
+      maxMembers: row.maxMembers,
+      requirements: row.requirements,
+      icon: row.icon,
+      status: row.status,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      currentMembers: row.currentMembers,
+      leader: {
+        id: row.leaderId,
+        name: row.leaderName,
+        nickname: row.leaderNickname,
+        level: row.leaderLevel,
+        image: row.leaderImage,
+      },
+      location: row.locationId ? {
+        id: row.locationId,
+        name: row.locationName,
+        coverImage: row.locationCoverImage,
+        difficulty: row.locationDifficulty,
+      } : null,
+    }));
+
+    return c.json({ success: true, teams, pagination: { page, pageSize, total, totalPages, hasMore } });
+  } catch (error) {
+    console.error("[v1/teams] list error:", error);
+    return c.json(APIErrors.internalError("获取队伍列表失败"), 500);
+  }
+});
+
+/**
+ * GET /v1/teams/:id
+ * 公开读端点：队伍详情。
+ */
+teams.get("/:id", async (c) => {
+  try {
+    const db = createDb(c.env.DB);
+    const auth = createAuth(c.env);
+    const teamId = c.req.param("id");
+
+    const session = await auth.api
+      .getSession({ headers: c.req.raw.headers })
+      .catch(() => null);
+    const actorId = session?.user?.id ?? null;
+
+    // Fetch team
+    const team = await db.query.teams.findFirst({
+      where: eq(schema.teams.id, teamId),
+    });
+    if (!team) return c.json(APIErrors.notFound("队伍不存在"), 404);
+
+    // Fetch location
+    const location = team.locationId
+      ? await db.query.locations.findFirst({ where: eq(schema.locations.id, team.locationId) })
+      : null;
+
+    // Fetch leader
+    const leader = await db.query.users.findFirst({
+      where: eq(schema.users.id, team.leaderId),
+      columns: { id: true, name: true, nickname: true, level: true, image: true },
+    });
+
+    // Member count
+    const [{ count: memberCount }] = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(schema.teamMembers)
+      .where(and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.status, "approved")));
+
+    // My status (if authenticated)
+    let myStatus: string = "none";
+    if (actorId) {
+      const membership = await db.query.teamMembers.findFirst({
+        where: and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.userId, actorId)),
+      });
+      if (membership) {
+        myStatus = membership.status;
+      }
+    }
+
+    return c.json({
+      success: true,
+      team: {
+        ...team,
+        location: location ? {
+          id: location.id,
+          name: location.name,
+          coverImage: location.coverImage,
+          difficulty: location.difficulty,
+          cityId: location.cityId,
+        } : null,
+        leader: leader ?? null,
+        currentMembers: memberCount,
+        myStatus,
+      },
+    });
+  } catch (error) {
+    console.error("[v1/teams/:id] error:", error);
+    return c.json(APIErrors.internalError("获取队伍详情失败"), 500);
+  }
+});
+
+/**
+ * GET /v1/teams/:id/my-status
+ * 需要认证：获取当前用户在本队伍的身份状态。
+ * 返回 { status: "none"|"pending"|"approved"|"rejected"|"member", pollAfterSeconds?: number }
+ * pollAfterSeconds=300（5分钟）当 status=pending 时有效。
+ */
+teams.get("/:id/my-status", async (c) => {
+  try {
+    const db = createDb(c.env.DB);
+    const auth = createAuth(c.env);
+    const teamId = c.req.param("id");
+
+    const session = await auth.api
+      .getSession({ headers: c.req.raw.headers })
+      .catch(() => null);
+    const actorId = session?.user?.id;
+
+    if (!actorId) {
+      return c.json({ status: "none" });
+    }
+
+    const membership = await db.query.teamMembers.findFirst({
+      where: and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.userId, actorId)),
+    });
+
+    if (!membership) {
+      return c.json({ status: "none" });
+    }
+
+    // Map internal status to API status
+    const statusMap: Record<string, string> = {
+      approved: "member",
+      leave_pending: "member",
+    };
+    const apiStatus = statusMap[membership.status] ?? membership.status;
+
+    const response: { status: string; pollAfterSeconds?: number } = { status: apiStatus };
+    if (membership.status === "pending") {
+      response.pollAfterSeconds = 300;
+    }
+
+    return c.json(response);
+  } catch (error) {
+    console.error("[v1/teams/:id/my-status] error:", error);
+    return c.json(APIErrors.internalError("获取状态失败"), 500);
+  }
+});
+
+export { teams as teamsRoute };


### PR DESCRIPTION
## P1a: OpenAPI /v1/ 读端点 ×6

**PR 范围**：6 个公开读端点 + resolve-actor 中间件 + openapi.json 脚手架

### 新增端点

| 端点 | 说明 |
|------|------|
|  | 队伍列表（cityId / tagId / status / keyword + 分页） |
|  | 队伍详情（leader + location + memberCount + myStatus） |
|  | 当前用户在本队身份（需认证，pending 时含 pollAfterSeconds=300） |
|  | 地点列表（cityId / keyword + 分页） |
|  | 地点详情（含 tags / coordinates / gearEssential / gearOptional） |
|  | Agent 合法值发现入口（cities + tags + durations + difficulties + teamStatuses） |
|  | 已发布故事列表 |
|  | 故事详情（author + location + tags + isLiked） |

### 技术说明

- **resolve-actor**：每个端点通过  解析调用者身份，catch-null 降级不阻断公开数据返回
- **挂载**： 新增 ，前缀 
- **lint / type-check**：0 errors

### 待办（后续 commit）

-  插件  hook：每用户 10-key 上限
- ：随 10-key cap 一起补

---
Closes #209