### PR TITLE
fix #212: expose GET /v1/openapi.json

### DIFF
--- a/api/src/routes/v1/index.ts
+++ b/api/src/routes/v1/index.ts
@@ -8,7 +8,7 @@ import { storiesRoute } from "./stories";
 const v1 = new Hono<{ Bindings: Env }>();
 
 // Serve openapi.json for tooling discovery (GET /v1/openapi.json)
-import openapiSpec from "./openapi.json" with { type: "json" };
+import openapiSpec from "./openapi.json";
 v1.get("/openapi.json", (c) => c.json(openapiSpec));
 
 v1.route("/teams", teamsRoute);

--- a/api/src/routes/v1/index.ts
+++ b/api/src/routes/v1/index.ts
@@ -7,6 +7,10 @@ import { storiesRoute } from "./stories";
 
 const v1 = new Hono<{ Bindings: Env }>();
 
+// Serve openapi.json for tooling discovery (GET /v1/openapi.json)
+import openapiSpec from "./openapi.json" with { type: "json" };
+v1.get("/openapi.json", (c) => c.json(openapiSpec));
+
 v1.route("/teams", teamsRoute);
 v1.route("/locations", locationsRoute);
 v1.route("/enums", enumsRoute);

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ES2022",
+    "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "strict": true,
     "lib": ["ES2022"],


### PR DESCRIPTION
## fix #212

 加  路由，serve openapi.json 文件内容。
 加  支持 JSON import。

 → 200 (OpenAPI 3.0.3 spec)
type-check 0 errors。

请 @Martin CR