### PR TITLE
feat(home): #215 MapPin icon + left-align fallbackHint + #216 show hint on empty recommendations

### DIFF
--- a/frontend/src/components/features/home/home-locations-section.tsx
+++ b/frontend/src/components/features/home/home-locations-section.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, MapPin } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import type { useHomeData } from "./use-home-data";
 import { LocationCard } from "./home-location-card";
@@ -33,11 +33,14 @@ export function HomeLocationsSection({ data }: { data: HomeData }) {
               </span>
             )}
           </h2>
-          {/* #213 B路线：cityMatch=fallback 时显示降级提示（用户有 city 但该城市无地点） */}
+          {/* #215 方案B：cityMatch=fallback 时显示降级提示（MapPin icon + 左对齐） */}
           {userCity && cityMatch === "fallback" && locations.length > 0 && (
-            <p className="mt-3 text-sm font-medium text-amber-700 dark:text-amber-400">
-              {t("home.locations.fallbackHint")}
-            </p>
+            <div className="mt-3 flex items-center gap-1.5">
+              <MapPin className="h-3.5 w-3.5 text-amber-700 dark:text-amber-400 flex-shrink-0" />
+              <p className="text-sm font-medium text-amber-700 dark:text-amber-400">
+                {t("home.locations.fallbackHint")}
+              </p>
+            </div>
           )}
         </div>
 

--- a/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
+++ b/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
@@ -174,8 +174,24 @@ export function HomeRecommendationsSection({ userCity, cityName }: HomeRecommend
 
   // --- 渲染分支 ---
 
-  // 空态：三类全空 → 不渲染整个 section（spec §7.4）
+  // #216：推荐位 fallback + 0 候选时只显示 hint，不渲染卡片（Victor 反馈）
   if (state.status === "ready" && state.recommendations.length === 0) {
+    if (state.cityMatch === "fallback" && userCity) {
+      return (
+        <section id="recommendations" className="py-12 sm:py-16 lg:py-20 bg-background" data-testid="home-recommendations-section">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="text-center mb-8 sm:mb-10">
+              <h2 className="text-2xl sm:text-3xl font-bold text-foreground">
+                {t("home.recommendations.title")}
+              </h2>
+            </div>
+            <p className="text-sm text-stone-500 dark:text-stone-400 text-center" data-testid="recommendation-city-hint">
+              {t("home.recommendations.cityHint.fallback", { city: cityName ?? "" })}
+            </p>
+          </div>
+        </section>
+      );
+    }
     return null;
   }
 


### PR DESCRIPTION
## #215 + #216

**#215 视觉迭代（方案B）**：
- ：fallback hint 改为  左对齐，添加  icon 前缀
- 文字样式：
- 复用  i18n key（#460 已注册，不新增 key）

**#216 新需求**：
- ： + 0 候选时，显示 hint 文案替代空白 section
- 复用  i18n key（）

**验证**：type-check ✅ / i18n:gen-types ✅（fallbackHint already in types.ts） / build ✅

@Martin CR