### PR TITLE
feat(api): #217 P2-1 — v1 write endpoints ×4 + idempotency + actor api_key_id schema

### DIFF
--- a/api/db/migrations/0018_add_actor_api_key_id.sql
+++ b/api/db/migrations/0018_add_actor_api_key_id.sql
@@ -1,0 +1,13 @@
+-- #217 P2-1: Add actor_api_key_id nullable column to 4 tables
+-- Idempotency: Relies on wrangler d1_migrations ledger to skip replay.
+--   If 0018 is already in the ledger (from a prior apply), wrangler will not re-execute.
+--   The D1 migrations journal (applied in order via wrangler d1 migrations apply) guarantees
+--   that each migration runs exactly once per environment.
+--> statement-breakpoint
+ALTER TABLE `teams` ADD COLUMN `actor_api_key_id` text;
+--> statement-breakpoint
+ALTER TABLE `team_members` ADD COLUMN `actor_api_key_id` text;
+--> statement-breakpoint
+ALTER TABLE `locations` ADD COLUMN `actor_api_key_id` text;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `actor_api_key_id` text;

--- a/api/db/migrations/meta/_journal.json
+++ b/api/db/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1785247200000,
       "tag": "0017_add_api_keys",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1785300000000,
+      "tag": "0018_add_actor_api_key_id",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/__tests__/helpers/db.ts
+++ b/api/src/__tests__/helpers/db.ts
@@ -108,6 +108,7 @@ export function createTestDb() {
       gear_essential TEXT,
       gear_optional TEXT,
       extra TEXT,
+      actor_api_key_id TEXT,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     );
@@ -143,6 +144,7 @@ export function createTestDb() {
       status TEXT NOT NULL DEFAULT 'recruiting',
       -- task #163：Team「行动本」checklist（TEXT JSON，nullable）
       checklist TEXT,
+      actor_api_key_id TEXT,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     );
@@ -155,6 +157,7 @@ export function createTestDb() {
       joined_at INTEGER,
       status_updated_at INTEGER,
       extra TEXT,
+      actor_api_key_id TEXT,
       created_at INTEGER NOT NULL,
       UNIQUE(team_id, user_id)
     );
@@ -189,6 +192,7 @@ export function createTestDb() {
       status TEXT NOT NULL DEFAULT 'published',
       view_count INTEGER NOT NULL DEFAULT 0,
       like_count INTEGER NOT NULL DEFAULT 0,
+      actor_api_key_id TEXT,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     );

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -161,6 +161,8 @@ export const locations = sqliteTable(
     extra: text("extra"),
     createdAt: integer("created_at", { mode: "timestamp_ms" }).$defaultFn(() => new Date()).notNull(),
     updatedAt: integer("updated_at", { mode: "timestamp_ms" }).$defaultFn(() => new Date()).notNull(),
+    // #219 P2-3：API key 创建地点时记录来源 key
+    actorApiKeyId: text("actor_api_key_id"),
   },
   (table) => ({
     slugIdx: uniqueIndex("locations_slug_idx").on(table.slug),
@@ -225,6 +227,8 @@ export const teams = sqliteTable(
     checklist: text("checklist", { mode: "json" }).$type<TeamChecklist>(),
     createdAt: integer("created_at", { mode: "timestamp_ms" }).$defaultFn(() => new Date()).notNull(),
     updatedAt: integer("updated_at", { mode: "timestamp_ms" }).$defaultFn(() => new Date()).notNull(),
+    // #219 P2-3：API key 创建/加入时记录来源 key（nullable，session 用户无 key）
+    actorApiKeyId: text("actor_api_key_id"),
   },
   (table) => ({
     locationIdx: index("teams_location_idx").on(table.locationId),
@@ -249,6 +253,8 @@ export const teamMembers = sqliteTable(
     statusUpdatedAt: integer("status_updated_at", { mode: "timestamp_ms" }),
     extra: text("extra"),
     createdAt: integer("created_at", { mode: "timestamp_ms" }).$defaultFn(() => new Date()).notNull(),
+    // #219 P2-3：API key 申请加入时记录来源 key
+    actorApiKeyId: text("actor_api_key_id"),
   },
   (table) => ({
     teamIdx: index("team_members_team_idx").on(table.teamId),
@@ -502,6 +508,8 @@ export const stories = sqliteTable(
     likeCount: integer("like_count").default(0),
     createdAt: integer("created_at", { mode: "timestamp_ms" }).$defaultFn(() => new Date()).notNull(),
     updatedAt: integer("updated_at", { mode: "timestamp_ms" }).$defaultFn(() => new Date()).notNull(),
+    // #219 P2-3：API key 发故事时记录来源 key
+    actorApiKeyId: text("actor_api_key_id"),
   },
   (table) => ({
     authorIdx: index("stories_author_idx").on(table.authorId),

--- a/api/src/routes/v1/index.ts
+++ b/api/src/routes/v1/index.ts
@@ -4,6 +4,10 @@ import { teamsRoute } from "./teams";
 import { locationsRoute } from "./locations";
 import { enumsRoute } from "./enums";
 import { storiesRoute } from "./stories";
+import { writeTeams } from "./write/teams";
+import { writeMembers } from "./write/members";
+import { writeLocations } from "./write/locations";
+import { writeStories } from "./write/stories";
 
 const v1 = new Hono<{ Bindings: Env }>();
 
@@ -11,9 +15,16 @@ const v1 = new Hono<{ Bindings: Env }>();
 import openapiSpec from "./openapi.json";
 v1.get("/openapi.json", (c) => c.json(openapiSpec));
 
+// Read routes
 v1.route("/teams", teamsRoute);
 v1.route("/locations", locationsRoute);
 v1.route("/enums", enumsRoute);
 v1.route("/stories", storiesRoute);
+
+// Write routes (#217 P2-1)
+v1.route("/teams", writeTeams); // POST /v1/teams
+v1.route("/teams", writeMembers); // POST /v1/teams/:teamId/members
+v1.route("/locations", writeLocations); // POST /v1/locations
+v1.route("/stories", writeStories); // POST /v1/stories
 
 export { v1 as v1Route };

--- a/api/src/routes/v1/openapi.json
+++ b/api/src/routes/v1/openapi.json
@@ -6,8 +6,14 @@
     "version": "1.0.0"
   },
   "servers": [
-    { "url": "https://api.gomate.live", "description": "生产环境" },
-    { "url": "https://api-staging.gomate.live", "description": "Staging 环境" }
+    {
+      "url": "https://api.gomate.live",
+      "description": "生产环境"
+    },
+    {
+      "url": "https://api-staging.gomate.live",
+      "description": "Staging 环境"
+    }
   ],
   "components": {
     "securitySchemes": {
@@ -21,49 +27,112 @@
         "type": "http",
         "scheme": "bearer",
         "description": "Web 端 session cookie（登录后自动携带）"
+      },
+      "apiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-api-key"
+      },
+      "sessionCookie": {
+        "type": "http",
+        "scheme": "bearer"
       }
     },
     "schemas": {
       "Error": {
         "type": "object",
         "properties": {
-          "success": { "type": "boolean", "example": false },
-          "error": { "type": "string" },
-          "message": { "type": "string" }
+          "success": {
+            "type": "boolean",
+            "example": false
+          },
+          "error": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
         }
       },
       "Pagination": {
         "type": "object",
         "properties": {
-          "page": { "type": "integer" },
-          "pageSize": { "type": "integer" },
-          "total": { "type": "integer" },
-          "totalPages": { "type": "integer" },
-          "hasMore": { "type": "boolean" }
+          "page": {
+            "type": "integer"
+          },
+          "pageSize": {
+            "type": "integer"
+          },
+          "total": {
+            "type": "integer"
+          },
+          "totalPages": {
+            "type": "integer"
+          },
+          "hasMore": {
+            "type": "boolean"
+          }
         }
       },
       "TeamCard": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "locationId": { "type": "string" },
-          "leaderId": { "type": "string" },
-          "title": { "type": "string" },
-          "description": { "type": "string", "nullable": true },
-          "startTime": { "type": "string", "format": "date-time" },
-          "endTime": { "type": "string", "format": "date-time" },
-          "durationMin": { "type": "integer", "nullable": true },
-          "maxMembers": { "type": "integer" },
-          "requirements": { "type": "string", "nullable": true },
-          "icon": { "type": "string" },
+          "id": {
+            "type": "string"
+          },
+          "locationId": {
+            "type": "string"
+          },
+          "leaderId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "startTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "durationMin": {
+            "type": "integer",
+            "nullable": true
+          },
+          "maxMembers": {
+            "type": "integer"
+          },
+          "requirements": {
+            "type": "string",
+            "nullable": true
+          },
+          "icon": {
+            "type": "string"
+          },
           "status": {
             "type": "string",
             "enum": ["recruiting", "ongoing", "completed", "cancelled"]
           },
-          "createdAt": { "type": "string", "format": "date-time" },
-          "updatedAt": { "type": "string", "format": "date-time" },
-          "currentMembers": { "type": "integer" },
-          "leader": { "$ref": "#/components/schemas/Leader" },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "currentMembers": {
+            "type": "integer"
+          },
+          "leader": {
+            "$ref": "#/components/schemas/Leader"
+          },
           "location": {
             "$ref": "#/components/schemas/LocationSummary",
             "nullable": true
@@ -72,7 +141,9 @@
       },
       "TeamDetail": {
         "allOf": [
-          { "$ref": "#/components/schemas/TeamCard" },
+          {
+            "$ref": "#/components/schemas/TeamCard"
+          },
           {
             "type": "object",
             "properties": {
@@ -80,7 +151,9 @@
                 "type": "string",
                 "enum": ["none", "pending", "approved", "rejected", "member"]
               },
-              "currentMembers": { "type": "integer" }
+              "currentMembers": {
+                "type": "integer"
+              }
             }
           }
         ]
@@ -88,119 +161,251 @@
       "Leader": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "name": { "type": "string" },
-          "nickname": { "type": "string", "nullable": true },
-          "level": { "type": "string", "nullable": true },
-          "image": { "type": "string", "nullable": true }
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "nickname": {
+            "type": "string",
+            "nullable": true
+          },
+          "level": {
+            "type": "string",
+            "nullable": true
+          },
+          "image": {
+            "type": "string",
+            "nullable": true
+          }
         }
       },
       "LocationSummary": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "name": { "type": "string", "nullable": true },
-          "coverImage": { "type": "string", "nullable": true },
-          "difficulty": { "type": "string", "nullable": true }
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "coverImage": {
+            "type": "string",
+            "nullable": true
+          },
+          "difficulty": {
+            "type": "string",
+            "nullable": true
+          }
         }
       },
       "LocationDetail": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "name": { "type": "string" },
-          "slug": { "type": "string", "nullable": true },
-          "coverImage": { "type": "string", "nullable": true },
-          "cityId": { "type": "string", "nullable": true },
-          "difficulty": { "type": "string", "nullable": true },
-          "durationMin": { "type": "integer", "nullable": true },
-          "description": { "type": "string", "nullable": true },
-          "images": { "type": "array", "items": { "type": "string" } },
-          "bestSeason": { "type": "array", "items": { "type": "string" } },
-          "coordinates": { "$ref": "#/components/schemas/Coordinates" },
-          "gearEssential": { "type": "array", "items": { "type": "string" } },
-          "gearOptional": { "type": "array", "items": { "type": "string" } },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string",
+            "nullable": true
+          },
+          "coverImage": {
+            "type": "string",
+            "nullable": true
+          },
+          "cityId": {
+            "type": "string",
+            "nullable": true
+          },
+          "difficulty": {
+            "type": "string",
+            "nullable": true
+          },
+          "durationMin": {
+            "type": "integer",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "images": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "bestSeason": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "coordinates": {
+            "$ref": "#/components/schemas/Coordinates"
+          },
+          "gearEssential": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "gearOptional": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "tags": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Tag" }
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
           }
         }
       },
       "Coordinates": {
         "type": "object",
         "properties": {
-          "lat": { "type": "number" },
-          "lng": { "type": "number" }
+          "lat": {
+            "type": "number"
+          },
+          "lng": {
+            "type": "number"
+          }
         }
       },
       "Tag": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "name": { "type": "string" },
-          "type": { "type": "string", "nullable": true }
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          }
         }
       },
       "City": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "name": { "type": "string" }
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
         }
       },
       "Duration": {
         "type": "object",
         "properties": {
-          "value": { "type": "integer", "description": "分钟数" },
-          "label": { "type": "string" }
+          "value": {
+            "type": "integer",
+            "description": "分钟数"
+          },
+          "label": {
+            "type": "string"
+          }
         }
       },
       "Difficulty": {
         "type": "object",
         "properties": {
-          "value": { "type": "string" },
-          "label": { "type": "string" }
+          "value": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          }
         }
       },
       "TeamStatus": {
         "type": "object",
         "properties": {
-          "value": { "type": "string" },
-          "label": { "type": "string" }
+          "value": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          }
         }
       },
       "StoryCard": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "title": { "type": "string" },
-          "coverImage": { "type": "string", "nullable": true },
-          "summary": { "type": "string" },
-          "content": { "type": "string" },
-          "viewCount": { "type": "integer" },
-          "likeCount": { "type": "integer" },
-          "status": { "type": "string" },
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "coverImage": {
+            "type": "string",
+            "nullable": true
+          },
+          "summary": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "viewCount": {
+            "type": "integer"
+          },
+          "likeCount": {
+            "type": "integer"
+          },
+          "status": {
+            "type": "string"
+          },
           "publishedAt": {
             "type": "string",
             "format": "date-time",
             "nullable": true
           },
-          "createdAt": { "type": "string", "format": "date-time" },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
           "author": {
             "type": "object",
             "properties": {
-              "id": { "type": "string" },
-              "name": { "type": "string" },
-              "image": { "type": "string", "nullable": true }
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "image": {
+                "type": "string",
+                "nullable": true
+              }
             },
             "nullable": true
           },
           "location": {
             "type": "object",
             "properties": {
-              "id": { "type": "string" },
-              "name": { "type": "string" },
-              "slug": { "type": "string", "nullable": true }
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "slug": {
+                "type": "string",
+                "nullable": true
+              }
             },
             "nullable": true
           }
@@ -208,14 +413,20 @@
       },
       "StoryDetail": {
         "allOf": [
-          { "$ref": "#/components/schemas/StoryCard" },
+          {
+            "$ref": "#/components/schemas/StoryCard"
+          },
           {
             "type": "object",
             "properties": {
-              "isLiked": { "type": "boolean" },
+              "isLiked": {
+                "type": "boolean"
+              },
               "tags": {
                 "type": "array",
-                "items": { "$ref": "#/components/schemas/Tag" }
+                "items": {
+                  "$ref": "#/components/schemas/Tag"
+                }
               }
             }
           }
@@ -233,37 +444,52 @@
           {
             "name": "page",
             "in": "query",
-            "schema": { "type": "integer", "default": 1 },
+            "schema": {
+              "type": "integer",
+              "default": 1
+            },
             "description": "页码（从 1 开始）"
           },
           {
             "name": "pageSize",
             "in": "query",
-            "schema": { "type": "integer", "default": 12, "maximum": 100 },
+            "schema": {
+              "type": "integer",
+              "default": 12,
+              "maximum": 100
+            },
             "description": "每页条数"
           },
           {
             "name": "cityId",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "按城市 ID 过滤"
           },
           {
             "name": "tagId",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "按标签 ID 过滤"
           },
           {
             "name": "status",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "状态过滤（recruiting/ongoing/completed/cancelled），逗号分隔多个"
           },
           {
             "name": "keyword",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "标题/描述关键词搜索"
           }
         ],
@@ -275,16 +501,98 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "teams": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/TeamCard" }
+                      "items": {
+                        "$ref": "#/components/schemas/TeamCard"
+                      }
                     },
-                    "pagination": { "$ref": "#/components/schemas/Pagination" }
+                    "pagination": {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
                   }
                 }
               }
             }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createTeam",
+        "summary": "创建队伍",
+        "description": "认证端点（session 或 x-api-key），需要 Idempotency-Key header。返回 201 创建成功，400 缺少 Idempotency-Key，401 未认证。",
+        "security": [
+          {
+            "apiKeyAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "locationId": {
+                    "type": "string",
+                    "description": "地点ID"
+                  },
+                  "title": {
+                    "type": "string",
+                    "description": "队伍名称",
+                    "maxLength": 100
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "描述",
+                    "maxLength": 2000
+                  },
+                  "startTime": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "开始时间 ISO8601"
+                  },
+                  "durationMin": {
+                    "type": "integer",
+                    "description": "时长（分钟）"
+                  },
+                  "maxMembers": {
+                    "type": "integer",
+                    "description": "最大成员数",
+                    "minimum": 2,
+                    "maximum": 50
+                  },
+                  "requirements": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "要求清单"
+                  }
+                },
+                "required": ["locationId", "title", "startTime"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "队伍创建成功"
+          },
+          "400": {
+            "description": "缺少 Idempotency-Key 或输入无效"
+          },
+          "401": {
+            "description": "未认证"
+          },
+          "404": {
+            "description": "地点不存在"
           }
         }
       }
@@ -294,13 +602,22 @@
         "operationId": "getTeamDetail",
         "summary": "获取队伍详情",
         "description": "公开读端点。认证后可获取当前用户的 myStatus。",
-        "security": [{ "ApiKeyAuth": [] }, { "SessionCookie": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "SessionCookie": []
+          }
+        ],
         "parameters": [
           {
             "name": "id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "队伍 ID"
           }
         ],
@@ -312,8 +629,12 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
-                    "team": { "$ref": "#/components/schemas/TeamDetail" }
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "team": {
+                      "$ref": "#/components/schemas/TeamDetail"
+                    }
                   }
                 }
               }
@@ -323,7 +644,9 @@
             "description": "队伍不存在",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Error" }
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
               }
             }
           }
@@ -335,13 +658,22 @@
         "operationId": "getMyTeamStatus",
         "summary": "获取当前用户在本队伍的身份",
         "description": "需认证。未加入返回 {status:\"none\"}；pending 时返回 pollAfterSeconds=300（5分钟轮询建议）。",
-        "security": [{ "ApiKeyAuth": [] }, { "SessionCookie": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "SessionCookie": []
+          }
+        ],
         "parameters": [
           {
             "name": "id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "队伍 ID"
           }
         ],
@@ -384,23 +716,34 @@
           {
             "name": "page",
             "in": "query",
-            "schema": { "type": "integer", "default": 1 }
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
           },
           {
             "name": "pageSize",
             "in": "query",
-            "schema": { "type": "integer", "default": 12, "maximum": 100 }
+            "schema": {
+              "type": "integer",
+              "default": 12,
+              "maximum": 100
+            }
           },
           {
             "name": "keyword",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "地点名称搜索"
           },
           {
             "name": "cityId",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "按城市 ID 过滤"
           }
         ],
@@ -412,16 +755,131 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "locations": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/LocationDetail" }
+                      "items": {
+                        "$ref": "#/components/schemas/LocationDetail"
+                      }
                     },
-                    "pagination": { "$ref": "#/components/schemas/Pagination" }
+                    "pagination": {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
                   }
                 }
               }
             }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createLocation",
+        "summary": "创建地点",
+        "description": "认证端点（session 或 x-api-key），需要 Idempotency-Key header。",
+        "security": [
+          {
+            "apiKeyAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "地点名称"
+                  },
+                  "slug": {
+                    "type": "string",
+                    "description": "slug（可选）"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "subtitle": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "描述"
+                  },
+                  "address": {
+                    "type": "string"
+                  },
+                  "cityId": {
+                    "type": "string",
+                    "description": "城市ID"
+                  },
+                  "cityName": {
+                    "type": "string"
+                  },
+                  "coverImage": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "封面图 URL"
+                  },
+                  "images": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  },
+                  "coordinates": {
+                    "type": "object",
+                    "properties": {
+                      "lat": {
+                        "type": "number"
+                      },
+                      "lng": {
+                        "type": "number"
+                      }
+                    }
+                  },
+                  "bestSeason": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "gearEssential": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "gearOptional": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": ["name", "description", "cityId", "coverImage"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "地点创建成功"
+          },
+          "400": {
+            "description": "缺少 Idempotency-Key 或输入无效"
+          },
+          "401": {
+            "description": "未认证"
+          },
+          "404": {
+            "description": "城市不存在"
           }
         }
       }
@@ -436,7 +894,9 @@
             "name": "id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "地点 ID 或 slug"
           }
         ],
@@ -448,7 +908,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "location": {
                       "$ref": "#/components/schemas/LocationDetail"
                     }
@@ -461,7 +923,9 @@
             "description": "地点不存在",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Error" }
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
               }
             }
           }
@@ -481,29 +945,41 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "enums": {
                       "type": "object",
                       "properties": {
                         "cities": {
                           "type": "array",
-                          "items": { "$ref": "#/components/schemas/City" }
+                          "items": {
+                            "$ref": "#/components/schemas/City"
+                          }
                         },
                         "tags": {
                           "type": "array",
-                          "items": { "$ref": "#/components/schemas/Tag" }
+                          "items": {
+                            "$ref": "#/components/schemas/Tag"
+                          }
                         },
                         "durations": {
                           "type": "array",
-                          "items": { "$ref": "#/components/schemas/Duration" }
+                          "items": {
+                            "$ref": "#/components/schemas/Duration"
+                          }
                         },
                         "difficulties": {
                           "type": "array",
-                          "items": { "$ref": "#/components/schemas/Difficulty" }
+                          "items": {
+                            "$ref": "#/components/schemas/Difficulty"
+                          }
                         },
                         "teamStatuses": {
                           "type": "array",
-                          "items": { "$ref": "#/components/schemas/TeamStatus" }
+                          "items": {
+                            "$ref": "#/components/schemas/TeamStatus"
+                          }
                         }
                       }
                     }
@@ -524,17 +1000,26 @@
           {
             "name": "page",
             "in": "query",
-            "schema": { "type": "integer", "default": 1 }
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
           },
           {
             "name": "pageSize",
             "in": "query",
-            "schema": { "type": "integer", "default": 10, "maximum": 20 }
+            "schema": {
+              "type": "integer",
+              "default": 10,
+              "maximum": 20
+            }
           },
           {
             "name": "locationId",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "按地点 ID 过滤"
           }
         ],
@@ -546,16 +1031,92 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "stories": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/StoryCard" }
+                      "items": {
+                        "$ref": "#/components/schemas/StoryCard"
+                      }
                     },
-                    "pagination": { "$ref": "#/components/schemas/Pagination" }
+                    "pagination": {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
                   }
                 }
               }
             }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createStory",
+        "summary": "发布故事",
+        "description": "认证端点（session 或 x-api-key），需要 Idempotency-Key header。",
+        "security": [
+          {
+            "apiKeyAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "description": "标题",
+                    "maxLength": 100
+                  },
+                  "summary": {
+                    "type": "string",
+                    "description": "摘要",
+                    "maxLength": 150
+                  },
+                  "content": {
+                    "type": "string",
+                    "description": "内容",
+                    "maxLength": 10000
+                  },
+                  "coverImage": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "locationId": {
+                    "type": "string",
+                    "description": "关联地点ID"
+                  },
+                  "tags": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 10
+                  }
+                },
+                "required": ["title", "summary", "content", "locationId"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "故事发布成功"
+          },
+          "400": {
+            "description": "缺少 Idempotency-Key 或输入无效"
+          },
+          "401": {
+            "description": "未认证"
+          },
+          "404": {
+            "description": "地点不存在"
           }
         }
       }
@@ -565,13 +1126,22 @@
         "operationId": "getStoryDetail",
         "summary": "获取故事详情",
         "description": "公开读端点。认证用户可看到 isLiked 状态；draft/hidden 仅对作者本人或 admin 可见。",
-        "security": [{ "ApiKeyAuth": [] }, { "SessionCookie": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "SessionCookie": []
+          }
+        ],
         "parameters": [
           {
             "name": "id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "故事 ID"
           }
         ],
@@ -583,8 +1153,12 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
-                    "story": { "$ref": "#/components/schemas/StoryDetail" }
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "story": {
+                      "$ref": "#/components/schemas/StoryDetail"
+                    }
                   }
                 }
               }
@@ -594,7 +1168,9 @@
             "description": "故事不存在",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Error" }
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
               }
             }
           }
@@ -606,7 +1182,14 @@
         "operationId": "createApiKey",
         "summary": "创建 API Key",
         "description": "需认证。每位用户最多 10 个 Key，超额返回 403。",
-        "security": [{ "ApiKeyAuth": [] }, { "SessionCookie": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "SessionCookie": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -634,20 +1217,32 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
-                    "name": { "type": "string", "nullable": true },
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string",
+                      "nullable": true
+                    },
                     "key": {
                       "type": "string",
                       "description": "明文 Key，仅此次返回，请妥善保存"
                     },
-                    "prefix": { "type": "string" },
-                    "startsAt": { "type": "string", "format": "date-time" },
+                    "prefix": {
+                      "type": "string"
+                    },
+                    "startsAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
                     "expiresAt": {
                       "type": "string",
                       "format": "date-time",
                       "nullable": true
                     },
-                    "enabled": { "type": "boolean" }
+                    "enabled": {
+                      "type": "boolean"
+                    }
                   }
                 }
               }
@@ -657,7 +1252,9 @@
             "description": "未认证",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Error" }
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
               }
             }
           },
@@ -668,16 +1265,64 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean", "example": false },
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
                     "error": {
                       "type": "string",
                       "example": "MAX_API_KEYS_EXCEEDED"
                     },
-                    "message": { "type": "string" }
+                    "message": {
+                      "type": "string"
+                    }
                   }
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/v1/teams/{teamId}/members": {
+      "post": {
+        "operationId": "joinTeam",
+        "summary": "申请加入队伍",
+        "description": "认证端点（session 或 x-api-key），需要 Idempotency-Key header。",
+        "security": [
+          {
+            "apiKeyAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "teamId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "队伍ID"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "申请已提交"
+          },
+          "200": {
+            "description": "重新申请成功"
+          },
+          "400": {
+            "description": "缺少 Idempotency-Key 或已在队伍中"
+          },
+          "401": {
+            "description": "未认证"
+          },
+          "404": {
+            "description": "队伍不存在"
           }
         }
       }

--- a/api/src/routes/v1/write/locations.ts
+++ b/api/src/routes/v1/write/locations.ts
@@ -1,0 +1,106 @@
+/**
+ * POST /v1/locations — Create a new location.
+ *
+ * Auth: session cookie or x-api-key.
+ * Idempotency-Key: required (400 if missing). Uses Bob's idempotencyMiddleware.
+ * Actor: session.user.id, actorApiKeyId set if via API key (#219).
+ */
+import { Hono } from "hono";
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+import { createAuth } from "../../../lib/auth";
+import { createDb } from "../../../db";
+import * as schema from "../../../db/schema";
+import type { Env } from "../../../lib/auth";
+import { APIErrors } from "../../../lib/api-errors";
+import { generateId } from "../../../lib/id";
+import { idempotencyMiddleware } from "../../../lib/idempotency";
+
+const writeLocations = new Hono<{ Bindings: Env }>();
+
+const createLocationSchema = z.object({
+  name: z.string().min(1, "地点名称不能为空").max(200),
+  slug: z.string().max(200).optional(),
+  type: z.string().max(50).optional(),
+  subtitle: z.string().max(500).optional(),
+  description: z.string().min(1, "地点描述不能为空").max(5000),
+  address: z.string().max(500).optional(),
+  cityId: z.string().min(1, "城市ID不能为空"),
+  cityName: z.string().max(100).optional(),
+  bestSeason: z.array(z.string()).optional(),
+  coverImage: z.string().url("封面图片必须是有效URL"),
+  images: z.array(z.string().url()).optional(),
+  coordinates: z.object({ lat: z.number().min(-90).max(90), lng: z.number().min(-180).max(180) }).optional(),
+  extra: z.record(z.unknown()).nullable().optional(),
+  parkingAvailable: z.boolean().nullable().optional(),
+  parkingInfo: z.string().max(100).optional(),
+  gearEssential: z.array(z.string().min(1).max(20)).max(10).optional(),
+  gearOptional: z.array(z.string().min(1).max(20)).max(10).optional(),
+});
+
+writeLocations.post("/", idempotencyMiddleware, async (c) => {
+  try {
+    // 1. Authenticate
+    const auth = createAuth(c.env);
+    const session = await auth.api.getSession({ headers: c.req.raw.headers }).catch(() => null);
+    if (!session) {
+      return c.json(APIErrors.unauthorized("请先登录"), 401);
+    }
+    const actorApiKeyId = null; // TODO #219
+
+    // 2. Parse body
+    const body = await c.req.json().catch(() => null);
+    if (!body) {
+      return c.json(APIErrors.validationError("请求体无效"), 400);
+    }
+    const parsed = createLocationSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json(APIErrors.validationError("输入无效", parsed.error.errors), 400);
+    }
+    const data = parsed.data;
+
+    const db = createDb(c.env.DB);
+
+    // 3. Verify city exists
+    const city = await db.query.cities.findFirst({ where: eq(schema.cities.id, data.cityId) });
+    if (!city) {
+      return c.json(APIErrors.notFound("城市不存在"), 404);
+    }
+
+    // 4. Create location
+    const id = generateId();
+    const slug = data.slug ?? data.name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+    const now = new Date();
+
+    await db.insert(schema.locations).values({
+      id,
+      name: data.name,
+      slug,
+      type: data.type ?? null,
+      subtitle: data.subtitle ?? null,
+      description: data.description,
+      address: data.address ?? null,
+      cityId: data.cityId,
+      cityName: data.cityName ?? city.name,
+      bestSeason: JSON.stringify(data.bestSeason ?? []),
+      coverImage: data.coverImage,
+      images: JSON.stringify(data.images ?? []),
+      coordinates: JSON.stringify(data.coordinates ?? { lat: 0, lng: 0 }),
+      extra: data.extra ? JSON.stringify(data.extra) : null,
+      parkingAvailable: data.parkingAvailable ?? null,
+      parkingInfo: data.parkingInfo ?? null,
+      gearEssential: data.gearEssential?.join(",") ?? null,
+      gearOptional: data.gearOptional?.join(",") ?? null,
+      createdAt: now,
+      updatedAt: now,
+      actorApiKeyId: actorApiKeyId ?? null,
+    });
+
+    return c.json({ success: true, location: { id, slug } }, 201);
+  } catch (error) {
+    console.error("[v1/locations POST] error:", error);
+    return c.json(APIErrors.internalError("创建地点失败"), 500);
+  }
+});
+
+export { writeLocations };

--- a/api/src/routes/v1/write/members.ts
+++ b/api/src/routes/v1/write/members.ts
@@ -1,0 +1,109 @@
+/**
+ * POST /v1/teams/:teamId/members — Apply to join a team.
+ *
+ * Auth: session cookie or x-api-key.
+ * Idempotency-Key: required (400 if missing). Uses Bob's idempotencyMiddleware.
+ * Actor: session.user.id, actorApiKeyId set if via API key (#219).
+ */
+import { Hono } from "hono";
+import { eq, and } from "drizzle-orm";
+import { createAuth } from "../../../lib/auth";
+import { createDb } from "../../../db";
+import * as schema from "../../../db/schema";
+import type { Env } from "../../../lib/auth";
+import { APIErrors } from "../../../lib/api-errors";
+import { generateId } from "../../../lib/id";
+import { idempotencyMiddleware } from "../../../lib/idempotency";
+
+const writeMembers = new Hono<{ Bindings: Env }>();
+
+writeMembers.post("/:teamId/members", idempotencyMiddleware, async (c) => {
+  try {
+    // 1. Authenticate
+    const auth = createAuth(c.env);
+    const session = await auth.api.getSession({ headers: c.req.raw.headers }).catch(() => null);
+    if (!session) {
+      return c.json(APIErrors.unauthorized("请先登录"), 401);
+    }
+    const actorId = session.user.id;
+    const actorApiKeyId = null; // TODO #219
+
+    const teamId = c.req.param("teamId");
+    if (!teamId) {
+      return c.json(APIErrors.validationError("缺少队伍ID"), 400);
+    }
+
+    const db = createDb(c.env.DB);
+
+    // 2. Verify user has wechat
+    const userRecord = await db
+      .select({ wechat: schema.users.wechat })
+      .from(schema.users)
+      .where(eq(schema.users.id, actorId))
+      .then((rows) => rows[0]);
+    if (!userRecord?.wechat) {
+      return c.json(APIErrors.badRequest("请先填写微信号才能加入队伍"), 400);
+    }
+
+    // 3. Verify team exists and is recruiting
+    const team = await db.query.teams.findFirst({ where: eq(schema.teams.id, teamId) });
+    if (!team) {
+      return c.json(APIErrors.notFound("队伍不存在"), 404);
+    }
+    if (team.status !== "recruiting") {
+      return c.json(APIErrors.badRequest("该队伍当前不接受新成员"), 400);
+    }
+
+    // 4. Check member count
+    const { sql } = await import("drizzle-orm");
+    const [{ approvedCount }] = await db
+      .select({ approvedCount: sql<number>`count(*)` })
+      .from(schema.teamMembers)
+      .where(and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.status, "approved")));
+
+    if (approvedCount >= team.maxMembers) {
+      return c.json(APIErrors.badRequest("队伍已满"), 400);
+    }
+
+    // 5. Check existing membership
+    const existingMembers = await db.query.teamMembers.findMany({
+      where: and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.userId, actorId)),
+      limit: 1,
+    });
+    const existing = existingMembers[0];
+
+    if (existing) {
+      if (existing.status === "approved") {
+        return c.json(APIErrors.badRequest("你已经是该队伍的成员"), 400);
+      }
+      if (existing.status === "pending") {
+        return c.json(APIErrors.badRequest("你已经提交了申请，请等待审核"), 400);
+      }
+      // rejected → reapply
+      await db
+        .update(schema.teamMembers)
+        .set({ status: "pending", createdAt: new Date() })
+        .where(eq(schema.teamMembers.id, existing.id));
+
+      return c.json({ success: true, message: "重新申请已提交" });
+    }
+
+    // 6. Create membership application
+    const memberId = generateId();
+    await db.insert(schema.teamMembers).values({
+      id: memberId,
+      teamId,
+      userId: actorId,
+      status: "pending",
+      createdAt: new Date(),
+      actorApiKeyId: actorApiKeyId ?? null,
+    });
+
+    return c.json({ success: true, message: "申请已提交", memberId }, 201);
+  } catch (error) {
+    console.error("[v1/teams/:teamId/members POST] error:", error);
+    return c.json(APIErrors.internalError("申请加入队伍失败"), 500);
+  }
+});
+
+export { writeMembers };

--- a/api/src/routes/v1/write/stories.ts
+++ b/api/src/routes/v1/write/stories.ts
@@ -1,0 +1,132 @@
+/**
+ * POST /v1/stories — Create a new story.
+ *
+ * Auth: session cookie or x-api-key.
+ * Idempotency-Key: required (400 if missing). Uses Bob's idempotencyMiddleware.
+ * Actor: session.user.id, actorApiKeyId set if via API key (#219).
+ */
+import { Hono } from "hono";
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+import { createAuth } from "../../../lib/auth";
+import { createDb } from "../../../db";
+import * as schema from "../../../db/schema";
+import type { Env } from "../../../lib/auth";
+import { APIErrors } from "../../../lib/api-errors";
+import { generateId } from "../../../lib/id";
+import { idempotencyMiddleware } from "../../../lib/idempotency";
+
+const writeStories = new Hono<{ Bindings: Env }>();
+
+const createStorySchema = z.object({
+  title: z.string().min(1, "标题不能为空").max(100),
+  summary: z.string().min(1, "摘要不能为空").max(150),
+  content: z.string().min(1, "内容不能为空").max(10000),
+  coverImage: z.string().url().optional(),
+  locationId: z.string().min(1, "地点ID不能为空"),
+  tags: z.array(z.string()).max(10).optional(),
+});
+
+function normalizeStoryTags(tags: string[] | undefined): string[] {
+  return (tags ?? [])
+    .map((t) => t.trim())
+    .filter(Boolean)
+    .filter((v, i, a) => a.indexOf(v) === i);
+}
+
+writeStories.post("/", idempotencyMiddleware, async (c) => {
+  try {
+    // 1. Authenticate
+    const auth = createAuth(c.env);
+    const session = await auth.api.getSession({ headers: c.req.raw.headers }).catch(() => null);
+    if (!session) {
+      return c.json(APIErrors.unauthorized("请先登录"), 401);
+    }
+    const actorId = session.user.id;
+    const actorApiKeyId = null; // TODO #219
+
+    // 2. Parse body
+    const body = await c.req.json().catch(() => null);
+    if (!body) {
+      return c.json(APIErrors.validationError("请求体无效"), 400);
+    }
+    const parsed = createStorySchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json(APIErrors.validationError("输入无效", parsed.error.errors), 400);
+    }
+    const data = parsed.data;
+
+    const db = createDb(c.env.DB);
+
+    // 3. Verify location exists
+    const location = await db.query.locations.findFirst({
+      where: eq(schema.locations.id, data.locationId),
+    });
+    if (!location) {
+      return c.json(APIErrors.notFound("地点不存在"), 404);
+    }
+
+    // 4. Create story
+    const storyId = generateId();
+    const now = new Date();
+    const normalizedTags = normalizeStoryTags(data.tags);
+
+    await db.insert(schema.stories).values({
+      id: storyId,
+      authorId: actorId,
+      title: data.title.trim(),
+      summary: data.summary.trim(),
+      content: data.content.trim(),
+      coverImage: data.coverImage,
+      locationId: data.locationId,
+      status: "published",
+      viewCount: 0,
+      likeCount: 0,
+      createdAt: now,
+      updatedAt: now,
+      actorApiKeyId: actorApiKeyId ?? null,
+    });
+
+    // 5. Create tags (find-or-create)
+    for (const tagName of normalizedTags) {
+      let tag = await db.query.tags.findFirst({ where: eq(schema.tags.name, tagName) });
+      if (!tag) {
+        const tagId = generateId();
+        await db.insert(schema.tags).values({
+          id: tagId,
+          name: tagName,
+          type: "activity",
+          createdAt: now,
+        });
+        tag = await db.query.tags.findFirst({ where: eq(schema.tags.id, tagId) });
+      }
+      if (tag) {
+        await db.insert(schema.entityToTags).values({
+          id: generateId(),
+          entityId: storyId,
+          entityType: "activity",
+          tagId: tag.id,
+          createdAt: now,
+        });
+      }
+    }
+
+    return c.json({
+      success: true,
+      story: {
+        id: storyId,
+        authorId: actorId,
+        title: data.title.trim(),
+        summary: data.summary.trim(),
+        locationId: data.locationId,
+        status: "published",
+        createdAt: now.toISOString(),
+      },
+    }, 201);
+  } catch (error) {
+    console.error("[v1/stories POST] error:", error);
+    return c.json(APIErrors.internalError("创建故事失败"), 500);
+  }
+});
+
+export { writeStories };

--- a/api/src/routes/v1/write/teams.ts
+++ b/api/src/routes/v1/write/teams.ts
@@ -1,0 +1,138 @@
+/**
+ * POST /v1/teams — Create a new team.
+ *
+ * Auth: session cookie or x-api-key (via enableSessionForAPIKeys: true).
+ * Idempotency-Key: required (400 if missing). Uses Bob's idempotencyMiddleware.
+ * Actor: session.user.id, actorApiKeyId set if via API key (#219).
+ */
+import { Hono } from "hono";
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+import { createAuth } from "../../../lib/auth";
+import { createDb } from "../../../db";
+import * as schema from "../../../db/schema";
+import type { Env } from "../../../lib/auth";
+import { APIErrors } from "../../../lib/api-errors";
+import { generateId } from "../../../lib/id";
+import { idempotencyMiddleware } from "../../../lib/idempotency";
+
+const writeTeams = new Hono<{ Bindings: Env }>();
+
+const createTeamSchema = z.object({
+  locationId: z.string().min(1, "地点ID不能为空"),
+  title: z.string().min(1, "队伍名称不能为空").max(100, "队伍名称不能超过100字"),
+  description: z.string().max(2000, "描述不能超过2000字").optional(),
+  startTime: z.string().datetime({ offset: true }).or(z.string().regex(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/, "无效的开始时间格式")),
+  durationMin: z.number().int().min(0).max(1440).optional(),
+  maxMembers: z.number().int().min(2).max(50).optional(),
+  requirements: z.array(z.string()).optional(),
+});
+
+writeTeams.post("/", idempotencyMiddleware, async (c) => {
+  try {
+    // 1. Authenticate
+    const auth = createAuth(c.env);
+    const session = await auth.api.getSession({ headers: c.req.raw.headers }).catch(() => null);
+    if (!session) {
+      return c.json(APIErrors.unauthorized("请先登录"), 401);
+    }
+    const actorId = session.user.id;
+    const actorApiKeyId = null; // TODO #219: extract from better-auth session.extra
+
+    // 2. Parse and validate body (idempotencyMiddleware already cloned/read the body)
+    const body = await c.req.json().catch(() => null);
+    if (!body) {
+      return c.json(APIErrors.validationError("请求体无效"), 400);
+    }
+    const parsed = createTeamSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json(APIErrors.validationError("输入无效", parsed.error.errors), 400);
+    }
+    const { locationId, title, description, startTime, durationMin, maxMembers, requirements } = parsed.data;
+
+    const db = createDb(c.env.DB);
+
+    // 3. Verify location exists
+    const location = await db.query.locations.findFirst({ where: eq(schema.locations.id, locationId) });
+    if (!location) {
+      return c.json(APIErrors.notFound("地点不存在"), 404);
+    }
+
+    // 4. Verify user has wechat set
+    const userRecord = await db
+      .select({ wechat: schema.users.wechat })
+      .from(schema.users)
+      .where(eq(schema.users.id, actorId))
+      .then((rows) => rows[0]);
+    if (!userRecord?.wechat) {
+      return c.json(APIErrors.badRequest("请先填写微信号才能创建队伍"), 400);
+    }
+
+    // 5. Compute end time
+    const start = new Date(startTime);
+    if (isNaN(start.getTime())) {
+      return c.json(APIErrors.validationError("无效的开始时间"), 400);
+    }
+    const duration = durationMin ?? 240;
+    const end = new Date(start.getTime() + duration * 60 * 1000);
+
+    // 6. Create team + self-membership (leader auto-approved)
+    const teamId = generateId();
+    const memberId = generateId();
+    const now = new Date();
+    const teamIcon = "⛰️";
+
+    await db.insert(schema.teams).values({
+      id: teamId,
+      locationId,
+      leaderId: actorId,
+      title,
+      description: description ?? null,
+      startTime: start,
+      endTime: end,
+      durationMin: duration,
+      maxMembers: maxMembers ?? 10,
+      requirements: requirements ? JSON.stringify(requirements) : null,
+      icon: teamIcon,
+      status: "recruiting",
+      createdAt: now,
+      updatedAt: now,
+      actorApiKeyId: actorApiKeyId ?? null,
+    });
+
+    await db.insert(schema.teamMembers).values({
+      id: memberId,
+      teamId,
+      userId: actorId,
+      status: "approved",
+      joinedAt: now,
+      createdAt: now,
+      actorApiKeyId: actorApiKeyId ?? null,
+    });
+
+    return c.json({
+      success: true,
+      team: {
+        id: teamId,
+        locationId,
+        leaderId: actorId,
+        title,
+        description: description ?? null,
+        startTime: start.toISOString(),
+        endTime: end.toISOString(),
+        durationMin: duration,
+        maxMembers: maxMembers ?? 10,
+        currentMembers: 1,
+        requirements,
+        icon: teamIcon,
+        status: "recruiting",
+        createdAt: now.toISOString(),
+      },
+    }, 201);
+  } catch (error) {
+    console.error("[v1/teams POST] error:", error);
+    return c.json(APIErrors.internalError("创建队伍失败"), 500);
+  }
+});
+
+export { writeTeams };


### PR DESCRIPTION
## #217 P2-1 实现

### 变更概览

**4 个写端点**（认证：session cookie 或 x-api-key，Idempotency-Key header 必传）：

| 方法 | 路径 | 说明 |
|------|------|------|
| POST | /v1/teams | 创建队伍 |
| POST | /v1/teams/:teamId/members | 申请加入队伍 |
| POST | /v1/locations | 创建地点 |
| POST | /v1/stories | 发布故事 |

### 认证
-  使 API key 自动注入 session
- 未认证 → 401，Idempotency-Key 缺失 → 400（由 idempotencyMiddleware 处理）

### Idempotency
- 使用 Bob 的 （#464 已上 prod，KV-backed）
- UUID 格式校验，KV 存储响应，TTL 2h

### Schema (#219 前置)
- ：teams / team_members / locations / stories 表加  nullable 列
- **幂等说明**：依赖 wrangler d1_migrations 账本跳过重放（账本已记录则不重执行）。D1 migrations journal 按顺序 apply，每条 migration 在账本里就不会重跑。SQL 本身不加 IF NOT EXISTS（SQLite ALTER TABLE 无等价写法）。
- Drizzle schema： 字段（nullable，当前写 null，#219 填入实际值）

### openapi.json
- 新增 4 端点 + requestBody schema + apiKeyAuth / sessionCookie security scheme

### 文件变更

```
api/db/migrations/0018_add_actor_api_key_id.sql     +13
api/db/migrations/meta/_journal.json                  +7
api/src/db/schema.ts                               +8
api/src/routes/v1/index.ts                          +11
api/src/routes/v1/openapi.json                    +911
api/src/routes/v1/write/locations.ts              +106
api/src/routes/v1/write/members.ts               +109
api/src/routes/v1/write/stories.ts               +132
api/src/routes/v1/write/teams.ts                 +138
```

验证：type-check / lint / build 全部 PASS

@Martin CR