### PR TITLE
fix(home): teams section filter by userCity (#193 T3 follow-up, #221)

### DIFF
--- a/frontend/src/components/features/home/use-home-data.ts
+++ b/frontend/src/components/features/home/use-home-data.ts
@@ -48,7 +48,8 @@ export function useHomeData(initialData?: HomeInitialData, userCity?: string | n
   const fetchTeams = React.useCallback(async () => {
     try {
       setTeamsLoading(true);
-      const res = await fetchPublicAPI("/api/teams?status=recruiting&pageSize=4");
+      const cityParam = userCity ? `&cityId=${encodeURIComponent(userCity)}` : "";
+      const res = await fetchPublicAPI(`/v1/teams?status=recruiting&pageSize=4${cityParam}`);
       const data = await res.json();
       if (data.success) setTeams(data.teams || []);
     } catch (error) {
@@ -56,7 +57,7 @@ export function useHomeData(initialData?: HomeInitialData, userCity?: string | n
     } finally {
       setTeamsLoading(false);
     }
-  }, []);
+  }, [userCity]);
 
   React.useEffect(() => {
     if (hasInitialTeamsRef.current) {


### PR DESCRIPTION
## #221

**问题**：Victor 反馈「用户设了 city 后首页队伍未按城市过滤」，根因是 #193 T3 只接了探索地点 cityId，未接首页「近期队伍」section。

**修复**：
- ：改用 （支持  参数）
- 有 userCity 时传 ；未设时不传（不过滤）
-  依赖数组加 （切换城市后重新拉取）

验证：type-check ✅ / build ✅

@Martin CR