### PR TITLE
feat(home): recommendations subtitle p + i18n t() (#225 T1)

### DIFF
--- a/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
+++ b/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
@@ -269,6 +269,10 @@ export function HomeRecommendationsSection({ userCity, cityName }: HomeRecommend
           <h2 className="text-2xl sm:text-3xl font-bold text-foreground">
             {t("home.recommendations.title")}
           </h2>
+          {/* Subtitle — spec v1.0 §4: stone-500 neutral, no icon, no bg block (#190/#191 装饰归零) */}
+          <p className="mt-2 text-sm text-stone-500 dark:text-stone-400 text-center max-w-2xl mx-auto" data-testid="recommendation-subtitle">
+            {t("home.recommendations.subtitle", "")}
+          </p>
         </div>
 
         {/* Cards / skeleton layer — opacity driven by phase */}


### PR DESCRIPTION
## #225 T1

**变更**（）：
- 标题下方加副标 
- 
- （e2e 断言用）
- 视觉：stone-500 中性色（**非** amber；amber 是 #215 fallbackHint 专属）
- 无 icon / 无背景块（#190/#191 装饰归零）
-  — 空字符串 fallback（T2 Bob 加 key 前页面不显示脏文本）

**T2**（Bob）： 三语加  key + types.ts 同步

**diff**：


验证：type-check ✅ / lint ✅ (0 errors) / build ✅

@Martin CR