### PR TITLE
test(e2e): 读端点 600/min rate limit 429 契约测试 (#236)

### DIFF
--- a/e2e/v1-rate-limit.spec.ts
+++ b/e2e/v1-rate-limit.spec.ts
@@ -1,5 +1,5 @@
 /**
- * e2e: /v1/* P2-4 rate limit contract (#220)
+ * e2e: /v1/* P2-4 rate limit contract (#220 + #236)
  *
  * Targets: api-staging.gomate.live
  * Spec: read=600/min, write=30/min per actor (apiKey or user). Anonymous → no limit.
@@ -8,7 +8,8 @@
  * 约束：
  * - 不写 idempotency-key 测试（#218 单独覆盖）
  * - 不跨用例 actorId（每用例自建 fixture 隔离）
- * - 仅验证写端点（30/min）— 读端点 #220 没挂 middleware 暂不测
+ * - 写端点 30/min 实际触发 429（4 用例覆盖）
+ * - 读端点 600/min 不实际触发 429（用 5 次循环验证 X-RateLimit 头 + 计数机制），避免 600+ 次循环拖垮 staging
  */
 
 import { test, expect, request as pwRequest } from "@playwright/test";
@@ -49,6 +50,36 @@ async function apiPost(
     headers,
     body: JSON.stringify(body),
   });
+  let data: Record<string, unknown>;
+  try {
+    data = (await res.json()) as Record<string, unknown>;
+  } catch {
+    data = {};
+  }
+  const limit = res.headers.get("x-ratelimit-limit");
+  const remaining = res.headers.get("x-ratelimit-remaining");
+  const reset = res.headers.get("x-ratelimit-reset");
+  const retryAfter = res.headers.get("retry-after");
+  return {
+    status: res.status,
+    body: data,
+    rateLimitHeaders: {
+      limit: limit === null ? null : parseInt(limit, 10),
+      remaining: remaining === null ? null : parseInt(remaining, 10),
+      reset: reset === null ? null : parseInt(reset, 10),
+      retryAfter: retryAfter === null ? null : parseInt(retryAfter, 10),
+    },
+  };
+}
+
+async function apiGet(path: string, cookie?: string): Promise<ApiResult> {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    Origin: FRONTEND_ORIGIN,
+  };
+  if (cookie) headers.Cookie = cookie;
+
+  const res = await fetch(`${API_BASE}${path}`, { method: "GET", headers });
   let data: Record<string, unknown>;
   try {
     data = (await res.json()) as Record<string, unknown>;
@@ -232,4 +263,76 @@ test.describe("P2-4 rate limit (write 30/min)", () => {
       expect(r.rateLimitHeaders.remaining).toBe(29);
     });
   }, { timeout: 90_000 });
+});
+
+// ─── Read endpoints 600/min (#236) ─────────────────────────────────────────
+
+test.describe("P2-4 rate limit (read 600/min)", () => {
+  test("read endpoints include X-RateLimit-Limit=600 + X-RateLimit-Remaining decrements", async () => {
+    const RUN_ID = `rl-read-${Date.now()}`;
+    const cookie = await signUp(`${RUN_ID}@gomate.test`, "TestPass123", `RL read ${RUN_ID}`);
+
+    // 抽样 4 个读端点
+    const endpoints = [
+      "/v1/teams?pageSize=1",
+      "/v1/locations?pageSize=1",
+      "/v1/enums",
+      "/v1/stories?pageSize=1",
+    ];
+
+    await test.step("first 5 GETs per endpoint: X-RateLimit-Limit=600 + Remaining 递减", async () => {
+      // 单 actor 共享一个 read 计数器（key: rl:user:<userId>:read），4 端点 × 5 次 = 20 次都计入同一 read 计数
+      for (let i = 1; i <= 5; i++) {
+        for (let j = 0; j < endpoints.length; j++) {
+          const ep = endpoints[j];
+          const r = await apiGet(ep, cookie);
+          expect(r.status, `${ep} #${i} 应 200, 实际 ${r.status} body=${JSON.stringify(r.body)}`).toBe(200);
+          expect(r.rateLimitHeaders.limit, `${ep} #${i} 应带 X-RateLimit-Limit=600`).toBe(600);
+          // i=1 时 5 端点 × 4 = 第 1/2/3/4 次请求，remaining = 600-1, 600-2, 600-3, 600-4
+          const expectedRemaining = 600 - ((i - 1) * endpoints.length + j + 1);
+          expect(r.rateLimitHeaders.remaining, `${ep} #${i} expected Remaining=${expectedRemaining}`).toBe(expectedRemaining);
+        }
+      }
+    });
+  }, { timeout: 30_000 });
+
+  test("read and write counters are independent for same actor", async () => {
+    const RUN_ID = `rl-iso-rw-${Date.now()}`;
+    const cookie = await signUp(`${RUN_ID}@gomate.test`, "TestPass123", `RL iso RW ${RUN_ID}`);
+    const userId = await getSessionUserId(cookie);
+    await setWechat(cookie, userId, `wx_${RUN_ID}`);
+    const locationId = await getFirstLocationId(cookie);
+
+    await test.step("用户已写 5 次（write counter=5），读端点计数器独立从 1 开始", async () => {
+      for (let i = 1; i <= 5; i++) {
+        const w = await apiPost(
+          "/v1/teams",
+          { locationId, title: `iso RW ${i}`, startTime: new Date(Date.now() + 86400000).toISOString(), durationMin: 60, maxMembers: 4 },
+          cookie,
+        );
+        if (w.status === 429) throw new Error(`write #${i} 提前 429`);
+        expect(w.rateLimitHeaders.remaining, `write #${i} remaining`).toBe(30 - i);
+      }
+      // 读 1 次 → read counter 应独立 = 600 - 1 = 599
+      const r = await apiGet("/v1/teams?pageSize=1", cookie);
+      expect(r.status).toBe(200);
+      expect(r.rateLimitHeaders.limit).toBe(600);
+      expect(r.rateLimitHeaders.remaining, "read counter 应独立，从 599 起").toBe(599);
+    });
+  }, { timeout: 30_000 });
+
+  test("anonymous read requests NOT rate-limited (5 anon GETs all 200)", async () => {
+    for (let i = 1; i <= 5; i++) {
+      const r = await apiGet("/v1/teams?pageSize=1");
+      expect(r.status, `匿名 read #${i} 应 200`).toBe(200);
+    }
+  });
+
+  test("my-status read endpoint includes X-RateLimit-Limit=600", async () => {
+    const RUN_ID = `rl-mystatus-${Date.now()}`;
+    const cookie = await signUp(`${RUN_ID}@gomate.test`, "TestPass123", `RL mystatus ${RUN_ID}`);
+    const r = await apiGet("/v1/teams/000000000000000000000000/my-status", cookie);
+    expect(r.status, "my-status 应 200 即便队伍不存在").toBe(200);
+    expect(r.rateLimitHeaders.limit, "my-status 应挂 read 600/min middleware").toBe(600);
+  });
 });


### PR DESCRIPTION
## 验收范围

PR #477 (#220 P2-4 rate limit 调档) 合并后，扩 e2e 覆盖读端点 600/min 契约。

## 实证结果

`pnpm e2e --grep "rate limit"` against staging (api-staging.gomate.live)：

```
✓ P2-4 rate limit (write 30/min) › write endpoint returns 429 after 30 requests in window + Retry-After header (19.6s)
✓ P2-4 rate limit (write 30/min) › anonymous write request NOT rate-limited (5 anon requests all non-429) (194ms)
✓ P2-4 rate limit (write 30/min) › two different users have independent counters (24.1s)
✓ P2-4 rate limit (read 600/min) › read endpoints include X-RateLimit-Limit=600 + X-RateLimit-Remaining decrements (21.6s)
✓ P2-4 rate limit (read 600/min) › read and write counters are independent for same actor (8.0s)
✓ P2-4 rate limit (read 600/min) › anonymous read requests NOT rate-limited (5 anon GETs all 200) (2.3s)
✓ P2-4 rate limit (read 600/min) › my-status read endpoint includes X-RateLimit-Limit=600 (3.5s)

7 passed (1.3m)
```

## 覆盖的契约点（#236 任务书 5 项）

| 契约 | 实证 |
|---|---|
| 读 X-RateLimit-Limit 头 | 4 端点（teams/locations/enums/stories）全返 600 |
| 读 X-RateLimit-Remaining 递减 | 单 actor 共享 read counter，4 端点 × 5 次 = 20 次按序递减（599/598/597/596/595/.../581） |
| 读写端点独立计数 | 写 5 次后读 1 次 → read remaining=599（write counter=5 不影响 read counter） |
| 匿名读不计数 | 5 次匿名 GET 全部 200 |
| my-status 单独挂载 | X-RateLimit-Limit=600 头在认证响应附带 |

## 设计取舍

**不实际触发读端点 600 次 429**：
- 600 次循环会拖垮 staging（实测单端点 600+ 次约 6 分钟）且无新增价值（4 端点 × 5 次已实证 X-RateLimit 头 + 计数器机制）
- 写端点 30 次循环已实证「X-RateLimit-Limit=30 → 第 31 次 429 + Retry-After」完整契约 → 读端点 600/min 同 middleware 实现，机制一致

**单 actor 共享 read counter 的关键发现**：
- 4 端点 × 5 次 = 20 次请求，remaining 按 (i-1)*4 + j + 1 递减（不是每个端点独立从 600 起）
- 这符合 spec v1.1「per actor」—— 一个 key/user 共享一个 read 配额
- 也符合预期（防跨端点 bypass）

## 不在范围

- 1 分钟窗口滑出清零（60s 等待用例超时，未自动化）
- 1 分钟窗口触发 429（600+ 次循环拖垮 staging，未跑）

## 已知与本次任务无关

frontend `astro check` 报 4 errors（`auth-client.ts` 中 `apiKeyClient()` 与 better-auth core 1.6.12/1.6.25 版本冲突，pre-existing from #454）。本 PR 不改 frontend 代码，不受影响。

## E2E 自跑

```
E2E_BASE_URL=https://staging.gomate.live pnpm e2e --grep "rate limit"
```

## git diff

```
e2e/v1-rate-limit.spec.ts | 107 +++++++++++++++++++++++++++++++++++++++----
1 file changed, 105 insertions(+), 2 deletions(-)
```