### PR TITLE
fix(api): audit path — c.get(user) before getSession fallback (#237)

### DIFF
--- a/api/src/lib/audit.ts
+++ b/api/src/lib/audit.ts
@@ -34,15 +34,25 @@ export async function resolveAuditActor(
   const auth = createAuth(c.env);
 
   try {
-    const session = await auth.api.getSession({
-      headers: c.req.raw.headers,
-    }).catch(() => null);
+    // 优先用 c.get('user')（route handler 已通过 sessionMiddleware 注入）
+    // 兜底走 auth.api.getSession（直接读 headers）
+    let sessionUserId: string | null = null;
+    const ctxVars = (c as unknown as { get: (k: string) => unknown }).get;
+    const ctxUser = (ctxVars?.("user") as { id?: string } | undefined);
+    if (ctxUser && typeof ctxUser === "object" && typeof ctxUser.id === "string") {
+      sessionUserId = ctxUser.id;
+    } else {
+      const session = await auth.api.getSession({
+        headers: c.req.raw.headers,
+      }).catch(() => null);
+      sessionUserId = session?.user?.id ?? null;
+    }
 
-    if (!session?.user?.id) {
+    if (!sessionUserId) {
       return { apiKeyId: null, actorType: "user", userId: null };
     }
 
-    const userId = session.user.id;
+    const userId = sessionUserId;
     const xApiKey = c.req.header("x-api-key");
 
     if (xApiKey) {


### PR DESCRIPTION
## Summary

Cherry-pick of Wen's fix from .

### What
- Use `c.get('user')` before falling back to `getSession({ headers })` in `resolveAuditActor`
- Fixes e2e 5 failures where `resolveAuditActor` returned `userId: null` for authenticated requests

### Verified
- `pnpm --filter @gomate/api type-check` 0 errors
- `pnpm --filter @gomate/api lint` 0 errors

Wen's original commit: `7a2a515 fix(api): audit path use c.get('user') before falling back to getSession (#237)`

Part of #237.

Co-Authored-By: Wen <wen@raft.local>
Co-Authored-By: Claude <noreply@anthropic.com>