### PR TITLE
refactor(frontend): canonicalize press-scale, transition properties, and icon stroke

### DIFF
--- a/frontend/src/components/features/create-team-client.tsx
+++ b/frontend/src/components/features/create-team-client.tsx
@@ -258,7 +258,7 @@ export function CreateTeamClient() {
                 value={formData.title}
                 onChange={handleChange}
                 required
-                className="w-full px-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
+                className="w-full px-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
               />
             </FieldGroup>
 
@@ -273,7 +273,7 @@ export function CreateTeamClient() {
                   value={formData.locationId}
                   onChange={handleChange}
                   required
-                  className="w-full pl-11 pr-4 py-3 rounded-xl border bg-muted text-foreground text-sm transition-all duration-200 focus:outline-none appearance-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
+                  className="w-full pl-11 pr-4 py-3 rounded-xl border bg-muted text-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none appearance-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
                 >
                   <option value="">{t("teams.formPlaceholder.location")}</option>
                   {locations.map((loc) => (
@@ -299,7 +299,7 @@ export function CreateTeamClient() {
                     onChange={handleChange}
                     min={defaultDate}
                     required
-                    className="w-full pl-11 pr-4 py-3 rounded-xl border bg-muted text-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
+                    className="w-full pl-11 pr-4 py-3 rounded-xl border bg-muted text-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
                   />
                 </div>
               </FieldGroup>
@@ -315,7 +315,7 @@ export function CreateTeamClient() {
                     value={formData.time}
                     onChange={handleChange}
                     required
-                    className="w-full pl-11 pr-4 py-3 rounded-xl border bg-muted text-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
+                    className="w-full pl-11 pr-4 py-3 rounded-xl border bg-muted text-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
                   />
                 </div>
               </FieldGroup>
@@ -350,7 +350,7 @@ export function CreateTeamClient() {
                     value={formData.durationMin}
                     onChange={handleDurationChange}
                     required
-                    className="w-full pl-11 pr-4 py-3 rounded-xl border bg-muted text-foreground text-sm transition-all duration-200 focus:outline-none appearance-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
+                    className="w-full pl-11 pr-4 py-3 rounded-xl border bg-muted text-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none appearance-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
                   >
                     {getDurationOptions(t).map((opt) => (
                       <option key={opt.value} value={opt.value}>
@@ -409,7 +409,7 @@ export function CreateTeamClient() {
                     value={formData.maxMembers}
                     onChange={handleChange}
                     required
-                    className="w-full pl-11 pr-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
+                    className="w-full pl-11 pr-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
                   />
                 </div>
               </FieldGroup>
@@ -426,7 +426,7 @@ export function CreateTeamClient() {
                 onChange={handleChange}
                 required
                 rows={4}
-                className="w-full px-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none resize-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
+                className="w-full px-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none resize-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
               />
             </FieldGroup>
 
@@ -453,7 +453,7 @@ export function CreateTeamClient() {
               <button
                 type="button"
                 onClick={() => window.history.back()}
-                className="flex-1 py-3 rounded-xl border text-sm font-medium transition-all duration-150 border-border text-muted-foreground hover:bg-muted"
+                className="flex-1 py-3 rounded-xl border text-sm font-medium transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150 border-border text-muted-foreground hover:bg-muted"
               >
                 {t("common.cancel")}
               </button>

--- a/frontend/src/components/features/discover/featured-story-card.tsx
+++ b/frontend/src/components/features/discover/featured-story-card.tsx
@@ -63,7 +63,7 @@ export function FeaturedStoryCard({ story, onClick, className }: FeaturedStoryCa
         "border border-border/60",
         "shadow-[0_1px_3px_rgba(0,0,0,0.05)]",
         "hover:shadow-md hover:border-primary/20",
-        "transition-all duration-300",
+        "transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-300",
         className
       )}
     >

--- a/frontend/src/components/features/discover/story-card.tsx
+++ b/frontend/src/components/features/discover/story-card.tsx
@@ -75,7 +75,7 @@ export function StoryCard({ story, onClick, className }: StoryCardProps) {
         "border border-border/60",
         "shadow-[0_1px_2px_rgba(0,0,0,0.04)]",
         "hover:shadow-[0_4px_12px_rgba(0,0,0,0.08)] hover:-translate-y-[2px]",
-        "transition-all duration-300",
+        "transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-300",
         "break-inside-avoid mb-4",
         className
       )}

--- a/frontend/src/components/features/edit-team-client.tsx
+++ b/frontend/src/components/features/edit-team-client.tsx
@@ -231,7 +231,7 @@ export function EditTeamClient({ teamId }: EditTeamClientProps) {
                 onChange={handleChange}
                 required
                 maxLength={60}
-                className="w-full px-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
+                className="w-full px-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
               />
             </FieldGroup>
 
@@ -270,7 +270,7 @@ export function EditTeamClient({ teamId }: EditTeamClientProps) {
                     type="time"
                     value={formData.time}
                     onChange={handleChange}
-                    className="w-full pl-11 pr-4 py-3 rounded-xl border bg-muted text-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
+                    className="w-full pl-11 pr-4 py-3 rounded-xl border bg-muted text-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
                   />
                 </div>
               </FieldGroup>
@@ -283,7 +283,7 @@ export function EditTeamClient({ teamId }: EditTeamClientProps) {
                     name="durationMin"
                     value={formData.durationMin}
                     onChange={handleChange}
-                    className="w-full pl-11 pr-4 py-3 rounded-xl border bg-muted text-foreground text-sm transition-all duration-200 focus:outline-none appearance-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
+                    className="w-full pl-11 pr-4 py-3 rounded-xl border bg-muted text-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none appearance-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
                   >
                     {[120, 180, 240, 300, 360, 420, 480, 540, 600, 720].map((m) => (
                       <option key={m} value={m}>{t("teams.editDurationHours", { hours: m / 60 })}</option>
@@ -306,7 +306,7 @@ export function EditTeamClient({ teamId }: EditTeamClientProps) {
                   value={formData.maxMembers}
                   onChange={handleChange}
                   required
-                  className="w-full pl-11 pr-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
+                  className="w-full pl-11 pr-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
                 />
               </div>
               <p className="text-xs text-muted-foreground mt-1.5 flex items-center gap-1.5">
@@ -323,7 +323,7 @@ export function EditTeamClient({ teamId }: EditTeamClientProps) {
                 value={formData.description}
                 onChange={handleChange}
                 rows={4}
-                className="w-full px-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none resize-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
+                className="w-full px-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none resize-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
               />
             </FieldGroup>
 
@@ -342,7 +342,7 @@ export function EditTeamClient({ teamId }: EditTeamClientProps) {
                       onChange={(e) => updateRequirement(i, e.target.value)}
                       placeholder={t("teams.editRequirementPlaceholder")}
                       maxLength={100}
-                      className="flex-1 px-3 py-2 rounded-lg border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-2 focus:ring-primary/10"
+                      className="flex-1 px-3 py-2 rounded-lg border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-2 focus:ring-primary/10"
                     />
                     <button
                       type="button"
@@ -358,7 +358,7 @@ export function EditTeamClient({ teamId }: EditTeamClientProps) {
                 <button
                   type="button"
                   onClick={addRequirement}
-                  className="w-full mt-2 py-2.5 rounded-lg border text-sm font-medium transition-all duration-150 flex items-center justify-center gap-1.5 border-border text-muted-foreground hover:bg-muted hover:border-primary hover:text-primary"
+                  className="w-full mt-2 py-2.5 rounded-lg border text-sm font-medium transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150 flex items-center justify-center gap-1.5 border-border text-muted-foreground hover:bg-muted hover:border-primary hover:text-primary"
                 >
                   <span>{t("teams.editAddRequirement")}</span>
                 </button>
@@ -393,7 +393,7 @@ export function EditTeamClient({ teamId }: EditTeamClientProps) {
               <button
                 type="button"
                 onClick={() => window.location.href = `/teams/${teamId}`}
-                className="flex-1 py-3 rounded-xl border text-sm font-medium transition-all duration-150 border-border text-muted-foreground hover:bg-muted"
+                className="flex-1 py-3 rounded-xl border text-sm font-medium transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150 border-border text-muted-foreground hover:bg-muted"
               >
                 {t("common.cancel")}
               </button>

--- a/frontend/src/components/features/favorites-client.tsx
+++ b/frontend/src/components/features/favorites-client.tsx
@@ -186,7 +186,7 @@ export function FavoritesClient() {
                 return (
                   <div
                     key={fav.id}
-                    className="bg-card rounded-2xl overflow-hidden group transition-all duration-200 hover:-translate-y-0.5"
+                    className="bg-card rounded-2xl overflow-hidden group transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 hover:-translate-y-0.5"
                     style={{
                       boxShadow: "0 1px 4px color-mix(in oklab, var(--foreground) 6%, transparent)",
                     }}
@@ -223,7 +223,7 @@ export function FavoritesClient() {
                           handleRemove(loc.id);
                         }}
                         disabled={removingId === loc.id}
-                        className="absolute top-3 right-3 w-8 h-8 rounded-full flex items-center justify-center transition-all duration-150"
+                        className="absolute top-3 right-3 w-8 h-8 rounded-full flex items-center justify-center transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150"
                         style={{
                           background: "color-mix(in oklab, white 92%, transparent)",
                           backdropFilter: "blur(4px)",

--- a/frontend/src/components/features/forgot-password-client.tsx
+++ b/frontend/src/components/features/forgot-password-client.tsx
@@ -93,7 +93,7 @@ export function ForgotPasswordClient() {
 
               <a
                 href="/login"
-                className="inline-block w-full py-3 rounded-xl text-sm font-semibold text-white text-center transition-all duration-200"
+                className="inline-block w-full py-3 rounded-xl text-sm font-semibold text-white text-center transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200"
                 style={{
                   background: "linear-gradient(135deg, var(--primary) 0%, var(--primary-400) 100%)",
                   boxShadow: "0 4px 18px color-mix(in oklab, var(--primary) 35%, transparent)",
@@ -151,7 +151,7 @@ export function ForgotPasswordClient() {
                         setError("");
                       }}
                       required
-                      className="w-full pl-11 pr-4 py-3 rounded-xl border bg-card text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
+                      className="w-full pl-11 pr-4 py-3 rounded-xl border bg-card text-foreground placeholder:text-muted-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
                     />
                   </div>
                 </div>
@@ -170,7 +170,7 @@ export function ForgotPasswordClient() {
                 <button
                   type="submit"
                   disabled={isLoading}
-                  className="w-full py-3 rounded-xl text-sm font-semibold text-white transition-all duration-200 flex items-center justify-center gap-2 disabled:opacity-60 disabled:cursor-not-allowed"
+                  className="w-full py-3 rounded-xl text-sm font-semibold text-white transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 flex items-center justify-center gap-2 disabled:opacity-60 disabled:cursor-not-allowed"
                   style={{
                     background: isLoading ? "var(--primary)" : "linear-gradient(135deg, var(--primary) 0%, var(--primary-400) 100%)",
                     boxShadow: isLoading ? "none" : "0 4px 18px color-mix(in oklab, var(--primary) 35%, transparent)",

--- a/frontend/src/components/features/help-client.tsx
+++ b/frontend/src/components/features/help-client.tsx
@@ -39,7 +39,7 @@ function FaqAccordionItem({
 
       {/* 展开区域，使用 max-height 过渡实现动画 */}
       <div
-        className="overflow-hidden transition-all duration-300 ease-in-out"
+        className="overflow-hidden transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-300 ease-in-out"
         style={{ maxHeight: isOpen ? "300px" : "0px" }}
       >
         <p className="px-6 pb-5 pt-1 text-muted-foreground leading-relaxed border-t border-border">

--- a/frontend/src/components/features/home/home-hero.tsx
+++ b/frontend/src/components/features/home/home-hero.tsx
@@ -29,10 +29,10 @@ export function HomeHero({ data }: { data: HomeData }) {
             onChange={(e) => search.setValue(e.target.value)}
             onKeyDown={(e) => { if (e.key === "Enter") handleSearch(search.value); }}
             onFocus={() => search.setFocused(true)} onBlur={() => search.setFocused(false)}
-            className="w-full pl-11 sm:pl-14 pr-28 sm:pr-32 py-3 sm:py-4 bg-card/95 border border-border rounded-2xl text-foreground placeholder:text-muted-foreground text-sm sm:text-base transition-all duration-250 focus:outline-none focus:ring-4 focus:ring-amber-400/15 focus:border-amber-400"
+            className="w-full pl-11 sm:pl-14 pr-28 sm:pr-32 py-3 sm:py-4 bg-card/95 border border-border rounded-2xl text-foreground placeholder:text-muted-foreground text-sm sm:text-base transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-250 focus:outline-none focus:ring-4 focus:ring-amber-400/15 focus:border-amber-400"
             style={{ boxShadow: search.isFocused ? "0 6px 28px color-mix(in oklab, var(--primary) 20%, transparent)" : "0 4px 20px color-mix(in oklab, var(--foreground) 8%, transparent)", backdropFilter: "blur(8px)" }} />
           {search.value && (
-            <button onClick={search.clear} className="absolute right-20 sm:right-28 top-1/2 -translate-y-1/2 w-6 h-6 rounded-full flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition-all duration-150 animate-spin-in">
+            <button onClick={search.clear} className="absolute right-20 sm:right-28 top-1/2 -translate-y-1/2 w-6 h-6 rounded-full flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150 animate-spin-in">
               <X className="h-3.5 w-3.5" />
             </button>
           )}

--- a/frontend/src/components/features/home/home-location-card.tsx
+++ b/frontend/src/components/features/home/home-location-card.tsx
@@ -44,7 +44,7 @@ export const LocationCard = memo(function LocationCard({ location, index = 0, co
   if (compact) {
     return (
       <a href={`/locations/${location.id}`} className="block group">
-        <article className="flex items-center gap-3 px-3 py-2.5 bg-card rounded-xl shadow-[var(--shadow-card)] transition-all duration-200 hover:shadow-[var(--shadow-card-hover)] will-change-transform">
+        <article className="flex items-center gap-3 px-3 py-2.5 bg-card rounded-xl shadow-[var(--shadow-card)] transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 hover:shadow-[var(--shadow-card-hover)] will-change-transform">
           {/* Left: square thumbnail ~80px */}
           <div className="flex-shrink-0 w-[72px] h-[72px] rounded-lg overflow-hidden bg-muted">
             {location.coverImage ? (
@@ -76,7 +76,7 @@ export const LocationCard = memo(function LocationCard({ location, index = 0, co
             )}
           </div>
           {/* Arrow */}
-          <div className="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center transition-all duration-150 group-hover:bg-brand group-hover:text-white"
+          <div className="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150 group-hover:bg-brand group-hover:text-white"
             style={{ background: "var(--brand-subtle)", color: "var(--brand)" }}>
             <ArrowRight className="h-3 w-3" />
           </div>
@@ -90,7 +90,7 @@ export const LocationCard = memo(function LocationCard({ location, index = 0, co
       <article
         className="overflow-hidden rounded-2xl cursor-pointer bg-card
           shadow-[var(--shadow-card)]
-          transition-all duration-200 ease-out
+          transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 ease-out
           hover:shadow-[var(--shadow-card-hover)]
           hover:-translate-y-1
           will-change-transform"
@@ -152,7 +152,7 @@ export const LocationCard = memo(function LocationCard({ location, index = 0, co
               </div>
             )}
           </div>
-          <div className="w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ml-3 transition-all duration-150 group-hover:bg-brand group-hover:text-white"
+          <div className="w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ml-3 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150 group-hover:bg-brand group-hover:text-white"
             style={{ background: "var(--brand-subtle)", color: "var(--brand)" }}>
             <ArrowRight className="h-3.5 w-3.5" />
           </div>

--- a/frontend/src/components/features/home/home-locations-section.tsx
+++ b/frontend/src/components/features/home/home-locations-section.tsx
@@ -72,7 +72,7 @@ export function HomeLocationsSection({ data }: { data: HomeData }) {
 
             {/* Round 3 §A：探索地点「查看全部」出口 — 复用 teams viewAll 按钮结构 */}
             <div className="text-center mt-14">
-              <a href={locationsUrl} className="group inline-flex items-center gap-2 px-7 py-3.5 border border-border rounded-2xl text-base font-semibold text-foreground transition-all duration-200 hover:border-amber-300 dark:hover:border-amber-700 hover:text-amber-700 dark:hover:text-amber-400 hover:shadow-warm-sm active:scale-[0.98]">
+              <a href={locationsUrl} className="group inline-flex items-center gap-2 px-7 py-3.5 border border-border rounded-2xl text-base font-semibold text-foreground transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 hover:border-amber-300 dark:hover:border-amber-700 hover:text-amber-700 dark:hover:text-amber-400 hover:shadow-warm-sm active:scale-[0.96]">
                 {t("common.viewAll")}
                 <ArrowRight className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-0.5" />
               </a>

--- a/frontend/src/components/features/home/home-team-card.tsx
+++ b/frontend/src/components/features/home/home-team-card.tsx
@@ -53,7 +53,7 @@ export function TeamCard({ team, featured = false }: { team: Team; featured?: bo
 
   return (
     <a href={`/teams/${team.id}`} className="block group">
-      <article className={`overflow-hidden rounded-2xl cursor-pointer bg-card relative transition-all duration-300 hover:-translate-y-1.5 hover:shadow-warm-md ${featured ? 'ring-2 ring-amber-500/50' : ''}`}>
+      <article className={`overflow-hidden rounded-2xl cursor-pointer bg-card relative transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-300 hover:-translate-y-1.5 hover:shadow-warm-md ${featured ? 'ring-2 ring-amber-500/50' : ''}`}>
 
         {/* Featured badge */}
         {featured && (
@@ -157,7 +157,7 @@ export function TeamCard({ team, featured = false }: { team: Team; featured?: bo
         </div>
 
         {/* Simplified bottom bar: text link instead of gradient bar */}
-        <div className="sm:absolute bottom-0 left-0 right-0 flex items-center justify-center gap-1.5 py-2.5 text-xs font-medium text-stone-400 dark:text-stone-500 sm:translate-y-full sm:group-hover:translate-y-0 transition-all duration-300 ease-out rounded-b-lg sm:rounded-none opacity-100 sm:opacity-0 sm:group-hover:opacity-100 mt-2 sm:mt-0 static sm:static group-hover:text-amber-600 dark:group-hover:text-amber-400">
+        <div className="sm:absolute bottom-0 left-0 right-0 flex items-center justify-center gap-1.5 py-2.5 text-xs font-medium text-stone-400 dark:text-stone-500 sm:translate-y-full sm:group-hover:translate-y-0 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-300 ease-out rounded-b-lg sm:rounded-none opacity-100 sm:opacity-0 sm:group-hover:opacity-100 mt-2 sm:mt-0 static sm:static group-hover:text-amber-600 dark:group-hover:text-amber-400">
           <span>{t("home.teamCard.viewDetails")}</span><ArrowRight className="h-3.5 w-3.5" />
         </div>
       </article>

--- a/frontend/src/components/features/home/home-teams-section.tsx
+++ b/frontend/src/components/features/home/home-teams-section.tsx
@@ -53,7 +53,7 @@ export function HomeTeamsSection({ data }: { data: HomeData }) {
         {/* View all button */}
         <div className="text-center mt-14">
           <a href="/teams">
-            <button className="group inline-flex items-center gap-2 px-7 py-3.5 border border-border rounded-2xl text-base font-semibold text-foreground transition-all duration-200 hover:border-amber-300 dark:hover:border-amber-700 hover:text-amber-700 dark:hover:text-amber-400 hover:shadow-warm-sm active:scale-[0.98]">
+            <button className="group inline-flex items-center gap-2 px-7 py-3.5 border border-border rounded-2xl text-base font-semibold text-foreground transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 hover:border-amber-300 dark:hover:border-amber-700 hover:text-amber-700 dark:hover:text-amber-400 hover:shadow-warm-sm active:scale-[0.96]">
               {t("common.viewAll")}
               <ArrowRight className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-0.5" />
             </button>

--- a/frontend/src/components/features/home/local-circle/local-circle-card.tsx
+++ b/frontend/src/components/features/home/local-circle/local-circle-card.tsx
@@ -27,7 +27,7 @@ export const LocalCircleCard = memo(function LocalCircleCard({ location, index =
       <article
         className="overflow-hidden rounded-2xl cursor-pointer bg-card
           shadow-[var(--shadow-card)]
-          transition-all duration-200 ease-out
+          transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 ease-out
           hover:shadow-[var(--shadow-card-hover)]
           hover:-translate-y-1
           will-change-transform"
@@ -57,7 +57,7 @@ export const LocalCircleCard = memo(function LocalCircleCard({ location, index =
             </div>
             <ArrowRight
               className="w-4 h-4 flex-shrink-0 text-amber-700 dark:text-amber-400 transition-transform group-hover:translate-x-0.5"
-              strokeWidth={2.2}
+              strokeWidth={2}
             />
           </div>
         </div>

--- a/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
+++ b/frontend/src/components/features/home/recommendations/home-recommendations-section.tsx
@@ -194,7 +194,7 @@ export function HomeRecommendationsSection({ userCity, cityName }: HomeRecommend
           data-testid="recommendation-retry-btn"
           aria-label={t("home.recommendations.error")}
         >
-          <RefreshCw className="w-3.5 h-3.5" strokeWidth={2.2} />
+          <RefreshCw className="w-3.5 h-3.5" strokeWidth={2} />
         </button>
       </section>
     );
@@ -298,7 +298,7 @@ export function HomeRecommendationsSection({ userCity, cityName }: HomeRecommend
               className="inline-flex items-center gap-1.5 text-sm font-medium text-amber-700 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-300 transition-colors underline-offset-2 hover:underline"
               data-testid="recommendation-refresh-btn"
             >
-              <RefreshCw className="w-3.5 h-3.5" strokeWidth={2.2} />
+              <RefreshCw className="w-3.5 h-3.5" strokeWidth={2} />
               {t("home.recommendations.cta.refresh")}
             </button>
           </div>

--- a/frontend/src/components/features/home/recommendations/recommendation-badge.tsx
+++ b/frontend/src/components/features/home/recommendations/recommendation-badge.tsx
@@ -69,7 +69,7 @@ export function RecommendationBadge({
       style={{ background: s.bg, color: s.text, borderColor: s.border }}
       data-testid={`recommendation-badge-${kind}`}
     >
-      <Icon className={cn(size === "sm" ? "w-3 h-3" : "w-3.5 h-3.5")} strokeWidth={2.4} />
+      <Icon className={cn(size === "sm" ? "w-3 h-3" : "w-3.5 h-3.5")} strokeWidth={2} />
       {label}
     </span>
   );

--- a/frontend/src/components/features/home/recommendations/recommendation-card.tsx
+++ b/frontend/src/components/features/home/recommendations/recommendation-card.tsx
@@ -65,7 +65,7 @@ export function RecommendationCard({ reco }: RecommendationCardProps) {
     >
       <Card
         className={cn(
-          "h-full p-5 flex flex-col gap-3 border-l-4 transition-all duration-200",
+          "h-full p-5 flex flex-col gap-3 border-l-4 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200",
           "hover:shadow-lg hover:-translate-y-0.5",
           KIND_BORDER[kind],
         )}

--- a/frontend/src/components/features/location-detail-client.tsx
+++ b/frontend/src/components/features/location-detail-client.tsx
@@ -224,7 +224,7 @@ function Lightbox({ images, index, onClose, onPrev, onNext }: LightboxProps) {
                 else { for (let j = 0; j < -diff; j++) onPrev(); }
               }}
               className={cn(
-                "w-10 h-10 rounded-lg overflow-hidden border-2 transition-all duration-200",
+                "w-10 h-10 rounded-lg overflow-hidden border-2 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200",
                 i === index ? "border-white scale-110" : "border-white/30 hover:border-white/60"
               )}
             >
@@ -254,7 +254,7 @@ function ActionCard({ location, teams }: ActionCardProps) {
 
   return (
     <div
-      className="rounded-xl overflow-hidden bg-card border border-stone-100 dark:border-stone-800 shadow-[0_1px_8px_rgba(0,0,0,0.04)]"
+      className="rounded-xl overflow-hidden bg-card border border-stone-100 dark:border-stone-800 shadow-warm-sm"
     >
       <div className="p-5">
         {/* 情感标题 */}
@@ -297,7 +297,7 @@ function ActionCard({ location, teams }: ActionCardProps) {
         {/* 主 CTA */}
         <a href={`/teams/create?locationId=${location.id}`} className="block mb-3">
           <button
-            className="w-full py-3.5 rounded-xl text-sm font-bold text-white dark:text-stone-950 bg-amber-700 dark:bg-amber-500 shadow-[0_8px_18px_rgba(217,119,6,0.20)] hover:shadow-[0_10px_22px_rgba(217,119,6,0.26)] hover:-translate-y-0.5 transition-all duration-200 active:scale-[0.97]"
+            className="w-full py-3.5 rounded-xl text-sm font-bold text-white dark:text-stone-950 bg-amber-700 dark:bg-amber-500 shadow-card-hover hover:-translate-y-0.5 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 active:scale-[0.96]"
           >
             <span className="flex items-center justify-center gap-2">
               <Users className="h-4 w-4" />
@@ -309,7 +309,7 @@ function ActionCard({ location, teams }: ActionCardProps) {
         {/* 次要 CTA */}
         <a href={`/teams?locationId=${location.id}`} className="block">
           <button
-            className="w-full py-2.5 rounded-xl text-sm font-semibold text-foreground border border-stone-200 dark:border-stone-700 bg-transparent hover:bg-stone-50 dark:hover:bg-stone-800 transition-all duration-150 active:scale-[0.97]"
+            className="w-full py-2.5 rounded-xl text-sm font-semibold text-foreground border border-stone-200 dark:border-stone-700 bg-transparent hover:bg-stone-50 dark:hover:bg-stone-800 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150 active:scale-[0.96]"
           >
               {t("locations.detailBrowseTeams")}
           </button>
@@ -342,7 +342,7 @@ function RelatedLocations({ locations }: RelatedLocationsProps) {
   };
 
   return (
-    <div className="bg-card rounded-xl p-5 border border-stone-100 dark:border-stone-800 shadow-[0_1px_8px_rgba(0,0,0,0.04)]">
+    <div className="bg-card rounded-xl p-5 border border-stone-100 dark:border-stone-800 shadow-warm-sm">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-sm font-bold text-stone-900 dark:text-stone-100">
           {t("locations.relatedTitle")}
@@ -365,7 +365,7 @@ function RelatedLocations({ locations }: RelatedLocationsProps) {
             <a
               key={loc.id}
               href={`/locations/${loc.id}`}
-              className="flex items-center gap-3 group rounded-xl p-2 -mx-2 transition-all duration-200 hover:bg-stone-50 dark:hover:bg-stone-800"
+              className="flex items-center gap-3 group rounded-xl p-2 -mx-2 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 hover:bg-stone-50 dark:hover:bg-stone-800"
             >
               <div className="w-[68px] h-[52px] rounded-xl overflow-hidden flex-shrink-0 bg-stone-100 dark:bg-stone-800">
                 {loc.coverImage ? (
@@ -433,7 +433,7 @@ function MobileFloatingCTA({ location, heroRef }: MobileFloatingCTAProps) {
   return (
     <div
       className={cn(
-        "lg:hidden fixed bottom-0 left-0 right-0 z-40 transition-all duration-300 bg-white/96 dark:bg-stone-900/96 backdrop-blur-md",
+        "lg:hidden fixed bottom-0 left-0 right-0 z-40 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-300 bg-white/96 dark:bg-stone-900/96 backdrop-blur-md",
         heroLeft ? "translate-y-0 opacity-100" : "translate-y-full opacity-0 pointer-events-none"
       )}
       style={{
@@ -451,7 +451,7 @@ function MobileFloatingCTA({ location, heroRef }: MobileFloatingCTAProps) {
         {/* 浏览队伍 */}
         <a href={`/teams?locationId=${location.id}`} className="flex-shrink-0 max-[360px]:flex-1">
           <button
-            className="px-3 sm:px-4 py-2.5 rounded-xl text-sm font-semibold text-foreground border border-stone-200 dark:border-stone-700 hover:bg-stone-50 dark:hover:bg-stone-800 transition-all duration-150 active:scale-[0.96] whitespace-nowrap max-[360px]:w-full max-[360px]:px-2"
+            className="px-3 sm:px-4 py-2.5 rounded-xl text-sm font-semibold text-foreground border border-stone-200 dark:border-stone-700 hover:bg-stone-50 dark:hover:bg-stone-800 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150 active:scale-[0.96] whitespace-nowrap max-[360px]:w-full max-[360px]:px-2"
           >
             {t("locationDetail.browseTeams")}
           </button>
@@ -460,7 +460,7 @@ function MobileFloatingCTA({ location, heroRef }: MobileFloatingCTAProps) {
         {/* 主 CTA */}
         <a href={`/teams/create?locationId=${location.id}`} className="flex-shrink-0 max-[360px]:flex-1">
           <button
-            className="flex w-full items-center justify-center gap-1.5 px-4 sm:px-5 py-2.5 rounded-xl text-sm font-bold text-white dark:text-stone-950 bg-amber-700 dark:bg-amber-500 shadow-[0_6px_16px_rgba(217,119,6,0.24)] active:scale-[0.96] transition-transform duration-150 whitespace-nowrap max-[360px]:px-2"
+            className="flex w-full items-center justify-center gap-1.5 px-4 sm:px-5 py-2.5 rounded-xl text-sm font-bold text-white dark:text-stone-950 bg-amber-700 dark:bg-amber-500 shadow-glow active:scale-[0.96] transition-transform duration-150 whitespace-nowrap max-[360px]:px-2"
           >
             <span className="flex items-center gap-1.5">
               <Users className="h-4 w-4" />
@@ -548,7 +548,7 @@ function HeroActions({
       >
         <Heart
           className={cn(
-            "h-4 w-4 transition-all duration-200",
+            "h-4 w-4 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200",
             isFavorited ? "fill-red-400 text-red-400 scale-110" : "text-white"
           )}
           style={
@@ -826,7 +826,7 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
           <button
             onClick={() => setLightboxIndex(activeImageIndex)}
             className={cn(
-              "absolute bottom-6 right-5 z-10 flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-black/40 hover:bg-black/60 backdrop-blur-md text-white text-xs font-medium transition-all duration-200 border border-white/15",
+              "absolute bottom-6 right-5 z-10 flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-black/40 hover:bg-black/60 backdrop-blur-md text-white text-xs font-medium transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 border border-white/15",
               showArrows ? "opacity-100" : "opacity-0 pointer-events-none"
             )}
           >
@@ -843,7 +843,7 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
               className={cn(
                 "absolute left-4 top-1/2 -translate-y-1/2 z-10",
                 "w-11 h-11 rounded-full bg-black/35 hover:bg-black/55 backdrop-blur-md",
-                "flex items-center justify-center transition-all duration-200 border border-white/10",
+                "flex items-center justify-center transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 border border-white/10",
                 showArrows ? "opacity-100 translate-x-0" : "opacity-0 -translate-x-3 pointer-events-none"
               )}
               aria-label={t("locationDetail.prevImage")}
@@ -855,7 +855,7 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
               className={cn(
                 "absolute right-4 top-1/2 -translate-y-1/2 z-10",
                 "w-11 h-11 rounded-full bg-black/35 hover:bg-black/55 backdrop-blur-md",
-                "flex items-center justify-center transition-all duration-200 border border-white/10",
+                "flex items-center justify-center transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 border border-white/10",
                 showArrows ? "opacity-100 translate-x-0" : "opacity-0 translate-x-3 pointer-events-none"
               )}
               aria-label={t("locationDetail.nextImage")}
@@ -932,7 +932,7 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
                     key={idx}
                     onClick={() => switchImage(idx)}
                     className={cn(
-                      "rounded-full transition-all duration-200",
+                      "rounded-full transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200",
                       idx === activeImageIndex
                         ? "w-6 h-2 bg-white shadow-sm"
                         : "w-2 h-2 bg-white/35 hover:bg-white/60"

--- a/frontend/src/components/features/location-detail/location-intro-card.tsx
+++ b/frontend/src/components/features/location-detail/location-intro-card.tsx
@@ -143,7 +143,7 @@ export function LocationIntroCard({
           <p
             ref={descRef}
             className={cn(
-              "text-sm text-stone-500 dark:text-stone-400 leading-[1.9] tracking-wide transition-all duration-300",
+              "text-sm text-stone-500 dark:text-stone-400 leading-[1.9] tracking-wide transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-300",
               !expanded && "line-clamp-4"
             )}
           >

--- a/frontend/src/components/features/location-detail/team-card.tsx
+++ b/frontend/src/components/features/location-detail/team-card.tsx
@@ -25,10 +25,10 @@ export function TeamCard({ team }: TeamCardProps) {
 
   return (
     <a href={`/teams/${team.id}`} className="block group">
-      <div className="p-4 rounded-xl bg-card border border-stone-100 dark:border-stone-800 hover:border-amber-100 hover:shadow-[0_4px_20px_rgba(217,119,6,0.12)] hover:-translate-y-0.5 transition-all duration-200">
+      <div className="p-4 rounded-xl bg-card border border-stone-100 dark:border-stone-800 hover:border-amber-100 hover:shadow-[0_4px_20px_rgba(217,119,6,0.12)] hover:-translate-y-0.5 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200">
         <div className="flex items-start gap-3 mb-3">
           {dateInfo ? (
-            <div className="flex-shrink-0 w-12 rounded-xl overflow-hidden border border-stone-100 dark:border-stone-800 shadow-sm group-hover:shadow-md group-hover:border-amber-100 transition-all duration-200">
+            <div className="flex-shrink-0 w-12 rounded-xl overflow-hidden border border-stone-100 dark:border-stone-800 shadow-sm group-hover:shadow-md group-hover:border-amber-100 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200">
               <div className="bg-amber-700 dark:bg-amber-500 group-hover:bg-amber-800 dark:group-hover:bg-amber-400 py-0.5 text-center transition-colors">
                 <span className="text-[9px] font-bold text-white dark:text-stone-950 tracking-widest uppercase">
                   {dateInfo.month}
@@ -61,7 +61,7 @@ export function TeamCard({ team }: TeamCardProps) {
               date={team.date}
               variant="badge"
             />
-            <ArrowRight className="h-3.5 w-3.5 text-stone-400 dark:text-stone-600 group-hover:text-amber-500 group-hover:translate-x-0.5 transition-all duration-150" />
+            <ArrowRight className="h-3.5 w-3.5 text-stone-400 dark:text-stone-600 group-hover:text-amber-500 group-hover:translate-x-0.5 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150" />
           </div>
         </div>
 

--- a/frontend/src/components/features/location-detail/team-list-section.tsx
+++ b/frontend/src/components/features/location-detail/team-list-section.tsx
@@ -54,7 +54,7 @@ export function TeamListSection({ teams, locationId }: TeamListSectionProps) {
           {hasMore && (
             <div className="mt-4 pt-4 border-t border-stone-100 dark:border-stone-800">
               <a href={`/teams?locationId=${locationId}`} className="block">
-                <button className="w-full py-2.5 rounded-xl text-sm font-semibold transition-all duration-150 active:scale-[0.97] flex items-center justify-center gap-1.5 border border-amber-200 dark:border-amber-800 text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/30 hover:bg-amber-100 dark:hover:bg-amber-900/40 hover:border-amber-300 dark:hover:border-amber-700">
+                <button className="w-full py-2.5 rounded-xl text-sm font-semibold transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150 active:scale-[0.96] flex items-center justify-center gap-1.5 border border-amber-200 dark:border-amber-800 text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/30 hover:bg-amber-100 dark:hover:bg-amber-900/40 hover:border-amber-300 dark:hover:border-amber-700">
                   {t("common.viewAllTeams").replace("{count}", String(teams.length))}
                   <ArrowRight className="h-3.5 w-3.5" />
                 </button>
@@ -89,7 +89,7 @@ function EmptyTeamsState({ locationId }: { locationId: string }) {
       </p>
 
       <a href={`/teams/create?locationId=${locationId}`}>
-        <button className="inline-flex items-center gap-2 px-6 py-2.5 bg-amber-700 dark:bg-amber-500 text-white dark:text-stone-950 rounded-full text-sm font-semibold transition-all duration-200 shadow-[0_6px_16px_rgba(217,119,6,0.22)] hover:shadow-[0_8px_20px_rgba(217,119,6,0.28)] active:scale-[0.97]">
+        <button className="inline-flex items-center gap-2 px-6 py-2.5 bg-amber-700 dark:bg-amber-500 text-white dark:text-stone-950 rounded-full text-sm font-semibold transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 shadow-glow hover:shadow-warm-md active:scale-[0.96]">
           <Users className="h-4 w-4" />
           {t('locations.detailNoTeamsBtn')}
         </button>

--- a/frontend/src/components/features/location-form/location-form-basic-fields.tsx
+++ b/frontend/src/components/features/location-form/location-form-basic-fields.tsx
@@ -73,7 +73,7 @@ function Field({ label, required, hint, error, children }: FieldProps) {
 
 function styledInput(hasError?: boolean) {
   return cn(
-    "w-full px-3 py-2.5 rounded-xl text-sm outline-none transition-all duration-150",
+    "w-full px-3 py-2.5 rounded-xl text-sm outline-none transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150",
     "border focus:ring-2",
     "bg-stone-50 dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder:text-stone-400 dark:placeholder:text-stone-500",
     hasError ? "border-red-300 dark:border-red-800 focus:ring-red-200 focus:border-red-400" : "border-stone-200 dark:border-stone-700 focus:ring-amber-200 focus:border-amber-400"
@@ -117,7 +117,7 @@ export function LocationFormBasicFields({ formData, errors, cities, updateField,
             {locationTypeOptions.map((opt) => (
               <button key={opt.value} type="button"
                 onClick={() => updateField("type", formData.type === opt.value ? "" : opt.value)}
-                className={cn("px-3.5 py-1.5 rounded-full text-sm font-medium transition-all",
+                className={cn("px-3.5 py-1.5 rounded-full text-sm font-medium transition-[transform,background-color,border-color,color,opacity,box-shadow]",
                   formData.type === opt.value ? "bg-stone-800 dark:bg-stone-200 text-white dark:text-stone-900" : "bg-stone-100 dark:bg-stone-800 text-stone-600 dark:text-stone-400 hover:bg-stone-200 dark:hover:bg-stone-700")}>
                 {opt.label}
               </button>
@@ -132,7 +132,7 @@ export function LocationFormBasicFields({ formData, errors, cities, updateField,
               className={cn(styledInput(!!errors.description), "resize-none leading-relaxed")} />
             <div className="absolute bottom-2.5 right-3 flex items-center gap-1.5">
               <div className="h-1 w-16 rounded-full bg-stone-100 overflow-hidden">
-                <div className={cn("h-full rounded-full transition-all duration-300",
+                <div className={cn("h-full rounded-full transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-300",
                   formData.description.length < 50 ? "bg-stone-300" : formData.description.length < 100 ? "bg-amber-400" : "bg-emerald-400")}
                   style={{ width: `${Math.min((formData.description.length / 500) * 100, 100)}%` }} />
               </div>

--- a/frontend/src/components/features/location-form/location-form-decision-fields.tsx
+++ b/frontend/src/components/features/location-form/location-form-decision-fields.tsx
@@ -123,7 +123,7 @@ function GearList({ items, onChange, placeholder, chipTone, inputSlotId, showToa
               }
             }}
             placeholder={placeholder}
-            className="w-full px-3 py-2 rounded-xl text-sm outline-none transition-all duration-150 border bg-white dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder:text-stone-400 dark:placeholder:text-stone-500 border-stone-200 dark:border-stone-700 focus:ring-2 focus:ring-amber-200 focus:border-amber-400 flex-1" />
+            className="w-full px-3 py-2 rounded-xl text-sm outline-none transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150 border bg-white dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder:text-stone-400 dark:placeholder:text-stone-500 border-stone-200 dark:border-stone-700 focus:ring-2 focus:ring-amber-200 focus:border-amber-400 flex-1" />
           <button type="button" onClick={() => {
             onChange(items.filter((_, i) => i !== idx));
             showToast("success", deletedText);
@@ -199,7 +199,7 @@ export function LocationFormDecisionFields({ formData, updateField }: LocationFo
                       updateField("parkingInfo", "");
                     }
                   }}
-                  className={cn("px-3 py-1.5 rounded-xl text-xs font-medium border transition-all",
+                  className={cn("px-3 py-1.5 rounded-xl text-xs font-medium border transition-[transform,background-color,border-color,color,opacity,box-shadow]",
                     selected
                       ? "bg-amber-50 dark:bg-amber-950/30 text-amber-700 dark:text-amber-400 border-amber-300 dark:border-amber-800"
                       : "bg-white dark:bg-stone-800 text-stone-600 dark:text-stone-400 border-stone-200 dark:border-stone-700 hover:bg-stone-50 dark:hover:bg-stone-700 hover:border-amber-300")}>
@@ -216,7 +216,7 @@ export function LocationFormDecisionFields({ formData, updateField }: LocationFo
             disabled={!parkingInfoEditable}
             onChange={(e) => updateField("parkingInfo", e.target.value)}
             placeholder={t("admin.formParkingInfoPlaceholder")}
-            className={cn("w-full px-3 py-2 rounded-xl text-sm outline-none transition-all duration-150 border placeholder:text-stone-400 dark:placeholder:text-stone-500 focus:ring-2 focus:ring-amber-200 focus:border-amber-400",
+            className={cn("w-full px-3 py-2 rounded-xl text-sm outline-none transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150 border placeholder:text-stone-400 dark:placeholder:text-stone-500 focus:ring-2 focus:ring-amber-200 focus:border-amber-400",
               parkingInfoEditable
                 ? "bg-white dark:bg-stone-800 text-stone-900 dark:text-stone-100 border-stone-200 dark:border-stone-700"
                 : "bg-stone-100 dark:bg-stone-800/40 text-stone-400 dark:text-stone-500 border-stone-200 dark:border-stone-800 opacity-50 cursor-not-allowed")} />

--- a/frontend/src/components/features/location-form/location-form-settings-fields.tsx
+++ b/frontend/src/components/features/location-form/location-form-settings-fields.tsx
@@ -146,7 +146,7 @@ export function LocationFormSettingsFields({ formData, allTags, updateField }: L
               return (
                 <button key={f.value} type="button"
                   onClick={() => updateField("extra", { ...formData.extra, facilities: selected ? formData.extra.facilities.filter((v) => v !== f.value) : [...formData.extra.facilities, f.value] })}
-                  className={cn("px-3 py-1.5 rounded-xl text-xs font-medium border transition-all",
+                  className={cn("px-3 py-1.5 rounded-xl text-xs font-medium border transition-[transform,background-color,border-color,color,opacity,box-shadow]",
                     selected ? "bg-amber-500 text-white border-amber-500" : "bg-white dark:bg-stone-800 text-stone-600 dark:text-stone-400 border-stone-200 dark:border-stone-700 hover:bg-stone-50 dark:hover:bg-stone-700 hover:border-amber-300")}>
                   {f.label}
                 </button>
@@ -178,7 +178,7 @@ export function LocationFormSettingsFields({ formData, allTags, updateField }: L
                       updateField("extra", { ...formData.extra, tips: next });
                     }
                   }}
-                  placeholder={t("admin.tipsPlaceholder")} className={cn("w-full px-3 py-2 rounded-xl text-sm outline-none transition-all duration-150 border bg-white dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder:text-stone-400 dark:placeholder:text-stone-500 border-stone-200 dark:border-stone-700 focus:ring-2 focus:ring-amber-200 focus:border-amber-400 flex-1")} />
+                  placeholder={t("admin.tipsPlaceholder")} className={cn("w-full px-3 py-2 rounded-xl text-sm outline-none transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150 border bg-white dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder:text-stone-400 dark:placeholder:text-stone-500 border-stone-200 dark:border-stone-700 focus:ring-2 focus:ring-amber-200 focus:border-amber-400 flex-1")} />
                 <button type="button" onClick={() => {
                   const next = formData.extra.tips.filter((_, i) => i !== idx);
                   updateField("extra", { ...formData.extra, tips: next });
@@ -224,7 +224,7 @@ export function LocationFormSettingsFields({ formData, allTags, updateField }: L
                       updateField("extra", { ...formData.extra, warnings: next });
                     }
                   }}
-                  placeholder={t("admin.warningsPlaceholder")} className={cn("w-full px-3 py-2 rounded-xl text-sm outline-none transition-all duration-150 border bg-white dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder:text-stone-400 dark:placeholder:text-stone-500 border-stone-200 dark:border-stone-700 focus:ring-2 focus:ring-amber-200 focus:border-amber-400 flex-1")} />
+                  placeholder={t("admin.warningsPlaceholder")} className={cn("w-full px-3 py-2 rounded-xl text-sm outline-none transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150 border bg-white dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder:text-stone-400 dark:placeholder:text-stone-500 border-stone-200 dark:border-stone-700 focus:ring-2 focus:ring-amber-200 focus:border-amber-400 flex-1")} />
                 <button type="button" onClick={() => {
                   const next = formData.extra.warnings.filter((_, i) => i !== idx);
                   updateField("extra", { ...formData.extra, warnings: next });
@@ -262,7 +262,7 @@ export function LocationFormSettingsFields({ formData, allTags, updateField }: L
                 return (
                   <button key={tag.id} type="button"
                     onClick={() => updateField("tagIds", selected ? formData.tagIds.filter((id) => id !== tag.id) : [...formData.tagIds, tag.id])}
-                    className={cn("px-3 py-1 rounded-full text-xs font-medium border transition-all",
+                    className={cn("px-3 py-1 rounded-full text-xs font-medium border transition-[transform,background-color,border-color,color,opacity,box-shadow]",
                       selected ? "bg-amber-500 text-white border-amber-500" : "bg-white text-stone-600 border-stone-200 hover:border-amber-300")}>
                     {tag.name}
                   </button>

--- a/frontend/src/components/features/locations/locations-grid.tsx
+++ b/frontend/src/components/features/locations/locations-grid.tsx
@@ -40,7 +40,7 @@ function LocationCard({ location, index }: { location: Location; index: number }
       className="group block"
       style={{ animation: `fade-up 0.35s cubic-bezier(0.16, 1, 0.3, 1) ${delayMs}ms both` }}
     >
-      <article className="bg-card rounded-2xl overflow-hidden border border-border hover:border-amber-200/50 dark:hover:border-amber-800/50 hover:shadow-xl hover:shadow-amber-100/40 dark:hover:shadow-amber-900/20 hover:ring-1 hover:ring-amber-200/40 dark:hover:ring-amber-700/40 transition-all duration-300 hover:-translate-y-1">
+      <article className="bg-card rounded-2xl overflow-hidden border border-border hover:border-amber-200/50 dark:hover:border-amber-800/50 hover:shadow-xl hover:shadow-amber-100/40 dark:hover:shadow-amber-900/20 hover:ring-1 hover:ring-amber-200/40 dark:hover:ring-amber-700/40 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-300 hover:-translate-y-1">
         <div className="relative h-52 overflow-hidden bg-stone-100 dark:bg-stone-800">
           {location.coverImage ? (
             <LocationCoverImage
@@ -198,11 +198,11 @@ export function EmptyState({
         {desc}
       </p>
 
-      {/* Primary button — amber rounded-full shadow-md hover:-translate-y-0.5 active:scale-95 PRESERVED */}
+      {/* Primary button — amber rounded-full shadow-md hover:-translate-y-0.5 active:scale-[0.96] PRESERVED */}
       {primaryAction && (
         <button
           onClick={primaryAction}
-          className="inline-flex items-center gap-2 px-5 py-2.5 bg-amber-700 hover:bg-amber-800 dark:bg-amber-500 dark:hover:bg-amber-400 text-white dark:text-stone-950 rounded-full text-sm font-medium transition-all duration-200 shadow-md shadow-amber-200 hover:-translate-y-0.5 active:scale-95"
+          className="inline-flex items-center gap-2 px-5 py-2.5 bg-amber-700 hover:bg-amber-800 dark:bg-amber-500 dark:hover:bg-amber-400 text-white dark:text-stone-950 rounded-full text-sm font-medium transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 shadow-md shadow-amber-200 hover:-translate-y-0.5 active:scale-[0.96]"
         >
           <Icon className="h-4 w-4" />
           {primaryLabel}
@@ -280,7 +280,7 @@ export function LocationsGrid({
             onClick={() => currentPage > 1 && onPageChange(currentPage - 1)}
             disabled={currentPage === 1}
             aria-label={t("locations.paginationPrev")}
-            className="w-9 h-9 rounded-xl flex items-center justify-center bg-popover border border-stone-200 dark:border-stone-700 hover:border-stone-300 dark:hover:border-stone-600 hover:text-stone-700 dark:hover:text-stone-300 disabled:bg-stone-100 disabled:border-stone-200 dark:disabled:bg-stone-900 dark:disabled:border-stone-700 disabled:cursor-not-allowed transition-all duration-200"
+            className="w-9 h-9 rounded-xl flex items-center justify-center bg-popover border border-stone-200 dark:border-stone-700 hover:border-stone-300 dark:hover:border-stone-600 hover:text-stone-700 dark:hover:text-stone-300 disabled:bg-stone-100 disabled:border-stone-200 dark:disabled:bg-stone-900 dark:disabled:border-stone-700 disabled:cursor-not-allowed transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200"
           >
             <span className={cn("text-stone-900 dark:text-stone-100", currentPage === 1 && "text-stone-500 dark:text-stone-500")}>
               <ChevronLeft className="h-4 w-4" />
@@ -295,7 +295,7 @@ export function LocationsGrid({
                 key={page}
                 onClick={() => onPageChange(page as number)}
                 className={cn(
-                  "w-9 h-9 rounded-xl text-sm font-medium transition-all duration-200",
+                  "w-9 h-9 rounded-xl text-sm font-medium transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200",
                   page === currentPage
                     ? "bg-stone-900 dark:bg-stone-100 dark:text-stone-900 text-white shadow-sm"
                     : "bg-card text-stone-600 dark:text-stone-400 border border-border hover:border-stone-300 dark:hover:border-stone-600 hover:text-stone-700 dark:hover:text-stone-300"
@@ -310,7 +310,7 @@ export function LocationsGrid({
             onClick={() => currentPage < pagination.totalPages && onPageChange(currentPage + 1)}
             disabled={currentPage === pagination.totalPages}
             aria-label={t("locations.paginationNext")}
-            className="w-9 h-9 rounded-xl flex items-center justify-center bg-popover border border-stone-200 dark:border-stone-700 hover:border-stone-300 dark:hover:border-stone-600 hover:text-stone-700 dark:hover:text-stone-300 disabled:bg-stone-100 disabled:border-stone-200 dark:disabled:bg-stone-900 dark:disabled:border-stone-700 disabled:cursor-not-allowed transition-all duration-200"
+            className="w-9 h-9 rounded-xl flex items-center justify-center bg-popover border border-stone-200 dark:border-stone-700 hover:border-stone-300 dark:hover:border-stone-600 hover:text-stone-700 dark:hover:text-stone-300 disabled:bg-stone-100 disabled:border-stone-200 dark:disabled:bg-stone-900 dark:disabled:border-stone-700 disabled:cursor-not-allowed transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200"
           >
             <span className={cn("text-stone-900 dark:text-stone-100", currentPage === pagination.totalPages && "text-stone-500 dark:text-stone-500")}>
               <ChevronRight className="h-4 w-4" />

--- a/frontend/src/components/features/locations/locations-hero.tsx
+++ b/frontend/src/components/features/locations/locations-hero.tsx
@@ -79,7 +79,7 @@ export function LocationsHero({
               const isActive = activeRole === key;
               return (
                 <button key={key} type="button" onClick={() => onRoleSelect(key)}
-                  className="relative group flex items-center gap-3 px-4 py-3.5 rounded-2xl border text-left transition-all duration-250 active:scale-[0.97] overflow-hidden"
+                  className="relative group flex items-center gap-3 px-4 py-3.5 rounded-2xl border text-left transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-250 active:scale-[0.96] overflow-hidden"
                   style={isActive ? { background: cfg.activeBg, borderColor: "transparent", boxShadow: `0 6px 20px ${cfg.iconColor}35` } : { background: `linear-gradient(135deg, ${cfg.gradientFrom}, ${cfg.gradientTo})`, borderColor: "rgba(231,229,228,0.8)" }}
                 >
                   {isActive && <div className="absolute inset-0 opacity-20" style={{ backgroundImage: `radial-gradient(circle at 80% 20%, rgba(255,255,255,0.6) 0%, transparent 60%)` }} />}
@@ -106,7 +106,7 @@ export function LocationsHero({
           <input
             ref={searchInputRef} type="text" placeholder={t("locations.searchPlaceholder")}
             value={searchQuery} onChange={(e) => onSearchChange(e.target.value)}
-            className="w-full pl-11 pr-12 py-3.5 bg-stone-50 dark:bg-stone-900 text-foreground placeholder-stone-500 border border-stone-200 dark:border-stone-700 rounded-2xl focus:outline-none focus:border-amber-400 focus:ring-2 focus:ring-amber-400/15 transition-all duration-200 text-sm shadow-sm"
+            className="w-full pl-11 pr-12 py-3.5 bg-stone-50 dark:bg-stone-900 text-foreground placeholder-stone-500 border border-stone-200 dark:border-stone-700 rounded-2xl focus:outline-none focus:border-amber-400 focus:ring-2 focus:ring-amber-400/15 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 text-sm shadow-sm"
           />
           {searchQuery && (
             <button type="button" onClick={() => onSearchChange("")}
@@ -128,7 +128,7 @@ export function LocationsHero({
                   }
                   onToggleCityDropdown();
                 }}
-                className={cn("flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium border transition-all duration-200",
+                className={cn("flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium border transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200",
                   selectedCityId ? "bg-amber-700 text-white border-amber-700 shadow-sm dark:bg-amber-500 dark:border-amber-500 dark:text-stone-950" : "bg-card text-stone-500 dark:text-stone-400 border-stone-200 dark:border-stone-700 hover:border-stone-300 dark:hover:border-stone-600 hover:text-stone-700 dark:hover:text-stone-300"
                 )}>
                 <MapPin className="w-3 h-3" />
@@ -141,7 +141,7 @@ export function LocationsHero({
             )}
             {popularTags.slice(0, 8).map((tag) => (
               <button key={tag.id} type="button" onClick={() => onTagToggle(tag.id)}
-                className={cn("flex-shrink-0 px-3 py-1.5 text-xs rounded-full border transition-all duration-200 active:scale-95",
+                className={cn("flex-shrink-0 px-3 py-1.5 text-xs rounded-full border transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 active:scale-[0.96]",
                   selectedTags.includes(tag.id) ? "bg-amber-700 text-white border-amber-700 shadow-sm dark:bg-amber-500 dark:border-amber-500 dark:text-stone-950" : "bg-card text-stone-500 dark:text-stone-400 border-stone-200 dark:border-stone-700 hover:border-stone-300 dark:hover:border-stone-600 hover:text-stone-700 dark:hover:text-stone-300"
                 )}>
                 {tag.name}
@@ -276,7 +276,7 @@ export function LocationsCtaSection() {
                 {/* Button Group */}
                 <div className="flex flex-col sm:flex-row items-center gap-3 justify-center lg:justify-start">
                   <a href="/teams/create" className="group">
-                    <button className="inline-flex items-center gap-2 bg-amber-700 hover:bg-amber-800 dark:bg-amber-500 dark:hover:bg-amber-400 text-white dark:text-stone-950 px-7 py-3.5 rounded-2xl text-base font-semibold transition-all duration-200 hover:shadow-lg hover:shadow-amber-200/40 active:scale-[0.98]">
+                    <button className="inline-flex items-center gap-2 bg-amber-700 hover:bg-amber-800 dark:bg-amber-500 dark:hover:bg-amber-400 text-white dark:text-stone-950 px-7 py-3.5 rounded-2xl text-base font-semibold transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 hover:shadow-lg hover:shadow-amber-200/40 active:scale-[0.96]">
                       <Sparkles className="w-5 h-5" />
                       {t("locations.ctaBtn")}
                       <ArrowRight className="w-4 h-4 transition-transform duration-200 group-hover:translate-x-0.5" />

--- a/frontend/src/components/features/login-client.tsx
+++ b/frontend/src/components/features/login-client.tsx
@@ -177,7 +177,7 @@ export function LoginClient() {
                   value={formData.email}
                   onChange={handleInputChange}
                   required
-                  className="w-full px-4 py-3 rounded-xl border bg-card text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:ring-3 focus:ring-primary/10"
+                  className="w-full px-4 py-3 rounded-xl border bg-card text-foreground placeholder:text-muted-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none focus:border-primary focus:ring-3 focus:ring-primary/10"
                 />
               </div>
 
@@ -204,7 +204,7 @@ export function LoginClient() {
                     value={formData.password}
                     onChange={handleInputChange}
                     required
-                    className="w-full px-4 py-3 pr-11 rounded-xl border bg-card text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:ring-3 focus:ring-primary/10"
+                    className="w-full px-4 py-3 pr-11 rounded-xl border bg-card text-foreground placeholder:text-muted-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none focus:border-primary focus:ring-3 focus:ring-primary/10"
                   />
                   <button
                     type="button"
@@ -231,7 +231,7 @@ export function LoginClient() {
                 data-testid="login-submit"
                 type="submit"
                 disabled={isLoading}
-                className="w-full py-3 rounded-xl text-sm font-semibold text-white transition-all duration-200 flex items-center justify-center gap-2 disabled:opacity-60 disabled:cursor-not-allowed"
+                className="w-full py-3 rounded-xl text-sm font-semibold text-white transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 flex items-center justify-center gap-2 disabled:opacity-60 disabled:cursor-not-allowed"
                 style={{
                   background: isLoading ? "var(--primary)" : "linear-gradient(135deg, var(--primary) 0%, var(--primary-400) 100%)",
                   boxShadow: isLoading ? "none" : "0 4px 18px color-mix(in oklab, var(--primary) 35%, transparent)",

--- a/frontend/src/components/features/my-teams/my-teams-application-card.tsx
+++ b/frontend/src/components/features/my-teams/my-teams-application-card.tsx
@@ -32,7 +32,7 @@ export function ApplicationCard({ application }: { application: ApplicationRecor
 
   return (
     <a href={`/teams/${team.id}`} className="block group">
-      <div className="bg-card rounded-2xl border border-stone-100 dark:border-stone-800 p-4 hover:-translate-y-0.5 hover:shadow-lg hover:shadow-amber-100/40 hover:border-amber-200/50 transition-all duration-200">
+      <div className="bg-card rounded-2xl border border-stone-100 dark:border-stone-800 p-4 hover:-translate-y-0.5 hover:shadow-lg hover:shadow-amber-100/40 hover:border-amber-200/50 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200">
         <div className="flex items-start gap-4">
           <div className="w-20 h-20 rounded-xl flex-shrink-0 overflow-hidden bg-stone-100 dark:bg-stone-800 flex items-center justify-center">
             {team.location?.coverImage ? (
@@ -80,7 +80,7 @@ export function ApplicationCard({ application }: { application: ApplicationRecor
               <p className="text-xs text-stone-400 dark:text-stone-500 ml-auto">{formatTimeAgo(application.createdAt)}</p>
             </div>
           </div>
-          <ChevronRight className="h-5 w-5 text-stone-300 dark:text-stone-600 group-hover:text-amber-400 group-hover:translate-x-0.5 transition-all flex-shrink-0 self-center" />
+          <ChevronRight className="h-5 w-5 text-stone-300 dark:text-stone-600 group-hover:text-amber-400 group-hover:translate-x-0.5 transition-[transform,background-color,border-color,color,opacity,box-shadow] flex-shrink-0 self-center" />
         </div>
       </div>
     </a>
@@ -98,7 +98,7 @@ export function PendingApprovalCard({ approval, onClick }: {
   const lv = levelConfig[applicant.level];
 
   return (
-    <button className="w-full text-left bg-card rounded-2xl border-l-4 border-l-amber-400 border-y border-r border-stone-100 dark:border-stone-800 p-4 hover:-translate-y-0.5 hover:shadow-lg hover:shadow-amber-50 transition-all duration-200 group"
+    <button className="w-full text-left bg-card rounded-2xl border-l-4 border-l-amber-400 border-y border-r border-stone-100 dark:border-stone-800 p-4 hover:-translate-y-0.5 hover:shadow-lg hover:shadow-amber-50 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 group"
       onClick={() => onClick(approval)}>
       <div className="flex items-start justify-between gap-2 mb-3">
         <span className="px-2.5 py-1 rounded-full text-xs font-medium bg-amber-50 text-amber-700 border border-amber-200 flex items-center gap-1.5">
@@ -143,7 +143,7 @@ export function PendingApprovalCard({ approval, onClick }: {
         </div>
       </div>
       <div className="mt-3 flex items-center justify-end">
-        <span className="text-sm text-amber-600 font-medium flex items-center gap-1 group-hover:gap-2 transition-all">
+        <span className="text-sm text-amber-600 font-medium flex items-center gap-1 group-hover:gap-2 transition-[transform,background-color,border-color,color,opacity,box-shadow]">
           {t("myTeams.viewDetail")}<ChevronRight className="h-4 w-4" />
         </span>
       </div>

--- a/frontend/src/components/features/my-teams/my-teams-main.tsx
+++ b/frontend/src/components/features/my-teams/my-teams-main.tsx
@@ -47,7 +47,7 @@ export function MyTeamsClient() {
             </div>
           </div>
           <a href="/teams/create" className="flex-shrink-0">
-            <button className="flex items-center gap-2 bg-amber-500 hover:bg-amber-600 text-white px-4 py-2.5 rounded-xl font-medium transition-all duration-200 text-sm active:scale-95">
+            <button className="flex items-center gap-2 bg-amber-500 hover:bg-amber-600 text-white px-4 py-2.5 rounded-xl font-medium transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 text-sm active:scale-[0.96]">
               <Plus className="h-4 w-4" />{t("myTeams.createTeamBtn")}
             </button>
           </a>
@@ -75,7 +75,7 @@ export function MyTeamsClient() {
             ].map(({ id, label, icon: Icon, count }) => (
               <button key={id} onClick={() => ctx.handleTabChange(id)}
                 className={cn(
-                  "flex items-center gap-1.5 px-4 py-3 text-sm font-medium transition-all duration-200 whitespace-nowrap relative",
+                  "flex items-center gap-1.5 px-4 py-3 text-sm font-medium transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 whitespace-nowrap relative",
                   ctx.activeTab === id ? "text-amber-700 border-b-2 border-amber-500" : "text-stone-500 dark:text-stone-400 hover:text-stone-700 dark:hover:text-stone-300 border-b-2 border-transparent"
                 )}>
                 <Icon className="h-4 w-4" />{label}
@@ -95,7 +95,7 @@ export function MyTeamsClient() {
               ].map(({ id, label, count }) => (
                 <button key={id} onClick={() => ctx.handleRoleFilterChange(id as "all" | "leader" | "member")}
                   className={cn(
-                    "flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-all",
+                    "flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-[transform,background-color,border-color,color,opacity,box-shadow]",
                     ctx.roleFilter === id ? "bg-amber-500 text-white" : "bg-stone-100 dark:bg-stone-800 text-stone-600 dark:text-stone-400 hover:bg-stone-200 dark:hover:bg-stone-700"
                   )}>
                   {label}
@@ -138,14 +138,14 @@ export function MyTeamsClient() {
           <div className="mt-6 space-y-4">
             <div className="flex gap-2 bg-stone-100 dark:bg-stone-800 rounded-xl p-1">
               <button onClick={() => ctx.handleSubTabChange("my")}
-                className={cn("flex-1 flex items-center justify-center gap-2 py-2.5 rounded-lg text-sm font-medium transition-all",
+                className={cn("flex-1 flex items-center justify-center gap-2 py-2.5 rounded-lg text-sm font-medium transition-[transform,background-color,border-color,color,opacity,box-shadow]",
                   ctx.applicationSubTab === "my" ? "bg-white text-stone-800 shadow-sm" : "text-stone-500 dark:text-stone-400 hover:text-stone-700 dark:hover:text-stone-300"
                 )}>
                 <ClipboardCheck className="h-4 w-4" />{t("myTeams.subTabMyApplications")}
                 {ctx.pendingApplicationsCount > 0 && <span className="w-1.5 h-1.5 rounded-full bg-amber-500" />}
               </button>
               <button onClick={() => ctx.handleSubTabChange("pending")}
-                className={cn("flex-1 flex items-center justify-center gap-2 py-2.5 rounded-lg text-sm font-medium transition-all",
+                className={cn("flex-1 flex items-center justify-center gap-2 py-2.5 rounded-lg text-sm font-medium transition-[transform,background-color,border-color,color,opacity,box-shadow]",
                   ctx.applicationSubTab === "pending" ? "bg-white text-stone-800 shadow-sm" : "text-stone-500 dark:text-stone-400 hover:text-stone-700 dark:hover:text-stone-300"
                 )}>
                 <Hourglass className="h-4 w-4" />{t("myTeams.subTabPendingApprovals")}

--- a/frontend/src/components/features/my-teams/my-teams-modals.tsx
+++ b/frontend/src/components/features/my-teams/my-teams-modals.tsx
@@ -77,11 +77,11 @@ export function ApprovalDetailModal({ approval, isProcessing, onApprove, onRejec
           </p>
           <div className="flex gap-3">
             <button onClick={onReject} disabled={isProcessing}
-              className="flex-1 border-2 border-red-200 text-red-600 hover:bg-red-50 hover:border-red-300 py-3 rounded-2xl font-semibold transition-all duration-200 disabled:opacity-50 flex items-center justify-center gap-2">
+              className="flex-1 border-2 border-red-200 text-red-600 hover:bg-red-50 hover:border-red-300 py-3 rounded-2xl font-semibold transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 disabled:opacity-50 flex items-center justify-center gap-2">
               <XCircle className="h-4 w-4" />{t("myTeams.rejectBtn")}
             </button>
             <button onClick={onApprove} disabled={isProcessing}
-              className="flex-1 bg-amber-600 hover:bg-amber-700 text-white py-3 rounded-2xl font-semibold transition-all duration-200 disabled:opacity-50 flex items-center justify-center gap-2 shadow-lg shadow-amber-200">
+              className="flex-1 bg-amber-600 hover:bg-amber-700 text-white py-3 rounded-2xl font-semibold transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 disabled:opacity-50 flex items-center justify-center gap-2 shadow-lg shadow-amber-200">
               {isProcessing ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle className="h-4 w-4" />}
               {t("myTeams.approveBtn")}
             </button>

--- a/frontend/src/components/features/my-teams/my-teams-team-card.tsx
+++ b/frontend/src/components/features/my-teams/my-teams-team-card.tsx
@@ -30,7 +30,7 @@ function TeamCard({ team, isLeader = false, onCancel, onForm }: {
 
   return (
     <a href={`/teams/${team.id}`} className="block group">
-      <div className="bg-card rounded-2xl border border-stone-100 dark:border-stone-800 p-4 hover:-translate-y-0.5 hover:shadow-lg hover:shadow-amber-100/40 hover:border-amber-200/50 transition-all duration-200">
+      <div className="bg-card rounded-2xl border border-stone-100 dark:border-stone-800 p-4 hover:-translate-y-0.5 hover:shadow-lg hover:shadow-amber-100/40 hover:border-amber-200/50 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200">
         <div className="flex items-start gap-4">
           <div className="w-20 h-20 rounded-xl flex-shrink-0 overflow-hidden bg-stone-100 dark:bg-stone-800 flex items-center justify-center">
             {team.location?.coverImage ? (
@@ -77,7 +77,7 @@ function TeamCard({ team, isLeader = false, onCancel, onForm }: {
               </span>
             </div>
           </div>
-          <ChevronRight className="h-5 w-5 text-stone-300 dark:text-stone-600 group-hover:text-amber-400 group-hover:translate-x-0.5 transition-all flex-shrink-0 self-center" />
+          <ChevronRight className="h-5 w-5 text-stone-300 dark:text-stone-600 group-hover:text-amber-400 group-hover:translate-x-0.5 transition-[transform,background-color,border-color,color,opacity,box-shadow] flex-shrink-0 self-center" />
         </div>
         {(canCancel || canForm) && (
           <div className="mt-3 pt-3 border-t border-stone-100 dark:border-stone-800 flex justify-end gap-2">

--- a/frontend/src/components/features/profile-edit/constants.tsx
+++ b/frontend/src/components/features/profile-edit/constants.tsx
@@ -15,7 +15,7 @@ export const PRESET_EQUIPMENT_KEYS = [
 
 export const inputCls =
   "w-full px-4 py-3 border border-stone-200 dark:border-stone-700 rounded-xl text-stone-900 dark:text-stone-100 placeholder:text-stone-300 dark:placeholder:text-stone-600 " +
-  "focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500 transition-all";
+  "focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500 transition-[transform,background-color,border-color,color,opacity,box-shadow]";
 
 export const SECTION_ICONS = {
   basic: FileText,

--- a/frontend/src/components/features/profile-edit/profile-form-fields.tsx
+++ b/frontend/src/components/features/profile-edit/profile-form-fields.tsx
@@ -153,7 +153,7 @@ export function OutdoorInfoFields({ level, experience, equipment, equipmentInput
           {LEVEL_OPTIONS.map((opt) => {
             const isSelected = level === opt.value;
             return (
-              <label key={opt.value} className={cn("relative flex flex-col p-4 rounded-xl border-2 cursor-pointer transition-all",
+              <label key={opt.value} className={cn("relative flex flex-col p-4 rounded-xl border-2 cursor-pointer transition-[transform,background-color,border-color,color,opacity,box-shadow]",
                 isSelected ? "border-amber-500 bg-gradient-to-br from-amber-50 to-amber-100/50 dark:from-amber-950/50 dark:to-amber-900/30 shadow-md shadow-amber-100 dark:shadow-amber-950/30" : "border-stone-100 dark:border-stone-800 bg-white dark:bg-stone-900 hover:border-amber-200 dark:hover:border-amber-900 hover:bg-amber-50/30 dark:hover:bg-amber-950/20"
               )}>
                 <input type="radio" name="level" value={opt.value} checked={isSelected} onChange={onChange} className="sr-only" />
@@ -179,7 +179,7 @@ export function OutdoorInfoFields({ level, experience, equipment, equipmentInput
             const isSelected = equipment.includes(label);
             return (
               <button key={key} type="button" onClick={() => onAddPresetEquipment(label)} disabled={isSelected}
-                className={cn("px-2.5 py-1 rounded-full text-xs font-medium transition-all",
+                className={cn("px-2.5 py-1 rounded-full text-xs font-medium transition-[transform,background-color,border-color,color,opacity,box-shadow]",
                   isSelected ? "bg-amber-100 dark:bg-amber-900/40 text-amber-400 dark:text-amber-600 cursor-not-allowed" : "bg-stone-100 dark:bg-stone-800 text-stone-600 dark:text-stone-400 hover:bg-amber-50 dark:hover:bg-amber-950/20 hover:text-amber-700 dark:hover:text-amber-400 hover:border-amber-200 dark:hover:border-amber-900 border border-transparent"
                 )}>
                 {label}
@@ -275,7 +275,7 @@ export function ActionBar({ isSaving, isUploading, savedDone }: ActionBarProps) 
           {t('common.cancel')}
         </button>
       </a>
-      <button type="submit" disabled={loading} className={cn("flex-1 py-3 rounded-xl font-medium text-sm transition-all flex items-center justify-center gap-2 disabled:cursor-not-allowed",
+      <button type="submit" disabled={loading} className={cn("flex-1 py-3 rounded-xl font-medium text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] flex items-center justify-center gap-2 disabled:cursor-not-allowed",
         savedDone ? "bg-amber-500 text-white shadow-md shadow-amber-100 dark:shadow-amber-950/30" : "bg-amber-600 hover:bg-amber-700 text-white shadow-md shadow-amber-200 dark:shadow-amber-900/30 disabled:opacity-50"
       )}>
         {loading ? (

--- a/frontend/src/components/features/profile-edit/profile-main.tsx
+++ b/frontend/src/components/features/profile-edit/profile-main.tsx
@@ -96,7 +96,7 @@ export function ProfileEditClient() {
             <CardSection icon={SECTION_ICONS.account} title={t('profile.sectionAccount')} />
             <div className="space-y-1.5">
               <span className="text-sm font-semibold text-stone-700 dark:text-stone-300">{t('profile.emailLabel')}</span>
-              <input value={ctx.user?.email || ""} disabled className="w-full px-4 py-3 border border-stone-200 dark:border-stone-700 rounded-xl text-stone-900 dark:text-stone-100 bg-stone-50 dark:bg-stone-800 text-stone-400 dark:text-stone-600 cursor-not-allowed focus:outline-none transition-all" />
+              <input value={ctx.user?.email || ""} disabled className="w-full px-4 py-3 border border-stone-200 dark:border-stone-700 rounded-xl text-stone-900 dark:text-stone-100 bg-stone-50 dark:bg-stone-800 text-stone-400 dark:text-stone-600 cursor-not-allowed focus:outline-none transition-[transform,background-color,border-color,color,opacity,box-shadow]" />
               <p className="text-xs text-stone-400 dark:text-stone-500">{t('profile.emailReadonly')}</p>
             </div>
           </Card>

--- a/frontend/src/components/features/register-client.tsx
+++ b/frontend/src/components/features/register-client.tsx
@@ -252,7 +252,7 @@ export function RegisterClient() {
                     onChange={handleInputChange}
                     required
                     minLength={6}
-                    className="w-full px-4 py-3 pr-11 rounded-xl border bg-card text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:ring-3 focus:ring-primary/10"
+                    className="w-full px-4 py-3 pr-11 rounded-xl border bg-card text-foreground placeholder:text-muted-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none focus:border-primary focus:ring-3 focus:ring-primary/10"
                   />
                   <button
                     type="button"
@@ -296,7 +296,7 @@ export function RegisterClient() {
                 data-testid="register-submit"
                 type="submit"
                 disabled={isLoading}
-                className="w-full py-3 rounded-xl text-sm font-semibold text-white transition-all duration-200 flex items-center justify-center gap-2 disabled:opacity-60 disabled:cursor-not-allowed"
+                className="w-full py-3 rounded-xl text-sm font-semibold text-white transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 flex items-center justify-center gap-2 disabled:opacity-60 disabled:cursor-not-allowed"
                 style={{
                   background: isLoading ? "var(--primary)" : "linear-gradient(135deg, var(--primary) 0%, var(--primary-400) 100%)",
                   boxShadow: isLoading ? "none" : "0 4px 18px color-mix(in oklab, var(--primary) 35%, transparent)",
@@ -390,7 +390,7 @@ function FormField({
         value={value}
         onChange={onChange}
         required={required}
-        className={`w-full px-4 py-3 rounded-xl border bg-card text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:ring-3 focus:ring-primary/10 ${hasError ? "border-destructive ring-3 ring-destructive/10" : ""}`}
+        className={`w-full px-4 py-3 rounded-xl border bg-card text-foreground placeholder:text-muted-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none focus:border-primary focus:ring-3 focus:ring-primary/10 ${hasError ? "border-destructive ring-3 ring-destructive/10" : ""}`}
       />
       {hint && (
         <p className="text-xs text-muted-foreground">{hint}</p>
@@ -423,7 +423,7 @@ function PasswordStrength({ password }: { password: string }) {
         {[1, 2, 3, 4].map((i) => (
           <div
             key={i}
-            className="h-1 flex-1 rounded-full transition-all duration-300"
+            className="h-1 flex-1 rounded-full transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-300"
             style={{ background: i <= level ? color : "var(--border)" }}
           />
         ))}

--- a/frontend/src/components/features/reset-password-client.tsx
+++ b/frontend/src/components/features/reset-password-client.tsx
@@ -133,7 +133,7 @@ export function ResetPasswordClient() {
 
             <a
               href="/forgot-password"
-              className="inline-block w-full py-3 rounded-xl text-sm font-semibold text-white text-center transition-all duration-200"
+              className="inline-block w-full py-3 rounded-xl text-sm font-semibold text-white text-center transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200"
               style={{
                 background: "linear-gradient(135deg, var(--primary) 0%, var(--primary-400) 100%)",
                 boxShadow: "0 4px 18px color-mix(in oklab, var(--primary) 35%, transparent)",
@@ -206,7 +206,7 @@ export function ResetPasswordClient() {
 
               <a
                 href="/login"
-                className="inline-block w-full py-3 rounded-xl text-sm font-semibold text-white text-center transition-all duration-200"
+                className="inline-block w-full py-3 rounded-xl text-sm font-semibold text-white text-center transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200"
                 style={{
                   background: "linear-gradient(135deg, var(--primary) 0%, var(--primary-400) 100%)",
                   boxShadow: "0 4px 18px color-mix(in oklab, var(--primary) 35%, transparent)",
@@ -265,7 +265,7 @@ export function ResetPasswordClient() {
                         setError("");
                       }}
                       required
-                      className="w-full pl-11 pr-4 py-3 rounded-xl border text-sm transition-all duration-200 focus:outline-none"
+                      className="w-full pl-11 pr-4 py-3 rounded-xl border text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none"
                       style={{
                         background: "#fff",
                         borderColor: "var(--border)",
@@ -303,7 +303,7 @@ export function ResetPasswordClient() {
                         setError("");
                       }}
                       required
-                      className="w-full pl-11 pr-4 py-3 rounded-xl border text-sm transition-all duration-200 focus:outline-none"
+                      className="w-full pl-11 pr-4 py-3 rounded-xl border text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none"
                       style={{
                         background: "#fff",
                         borderColor: "var(--border)",
@@ -336,7 +336,7 @@ export function ResetPasswordClient() {
                 <button
                   type="submit"
                   disabled={isLoading}
-                  className="w-full py-3 rounded-xl text-sm font-semibold text-white transition-all duration-200 flex items-center justify-center gap-2 disabled:opacity-60 disabled:cursor-not-allowed"
+                  className="w-full py-3 rounded-xl text-sm font-semibold text-white transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 flex items-center justify-center gap-2 disabled:opacity-60 disabled:cursor-not-allowed"
                   style={{
                     background: isLoading ? "var(--primary)" : "linear-gradient(135deg, var(--primary) 0%, var(--primary-400) 100%)",
                     boxShadow: isLoading ? "none" : "0 4px 18px color-mix(in oklab, var(--primary) 35%, transparent)",

--- a/frontend/src/components/features/team-detail/team-actionbook-form.tsx
+++ b/frontend/src/components/features/team-detail/team-actionbook-form.tsx
@@ -135,7 +135,7 @@ export function TeamActionbookForm({ teamId, initialChecklist, isLeader }: Props
                 onChange={(e) => setField("meetingPointName", e.target.value)}
                 placeholder={t("teams.actionbook.meetingNamePlaceholder")}
                 maxLength={200}
-                className="w-full px-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
+                className="w-full px-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
               />
               <div className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-2">
                 <input
@@ -144,7 +144,7 @@ export function TeamActionbookForm({ teamId, initialChecklist, isLeader }: Props
                   onChange={(e) => setField("meetingPointTime", e.target.value)}
                   placeholder={t("teams.actionbook.meetingTimePlaceholder")}
                   maxLength={50}
-                  className="w-full px-4 py-2.5 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
+                  className="w-full px-4 py-2.5 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
                 />
                 <input
                   type="text"
@@ -152,7 +152,7 @@ export function TeamActionbookForm({ teamId, initialChecklist, isLeader }: Props
                   onChange={(e) => setField("meetingPointNote", e.target.value)}
                   placeholder={t("teams.actionbook.meetingNotePlaceholder")}
                   maxLength={500}
-                  className="w-full px-4 py-2.5 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
+                  className="w-full px-4 py-2.5 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
                 />
               </div>
             </FieldGroup>
@@ -165,7 +165,7 @@ export function TeamActionbookForm({ teamId, initialChecklist, isLeader }: Props
                   onChange={(e) =>
                     setField("transportMode", e.target.value as typeof form.transportMode)
                   }
-                  className="w-full px-4 py-3 rounded-xl border bg-muted text-foreground text-sm transition-all duration-200 focus:outline-none appearance-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
+                  className="w-full px-4 py-3 rounded-xl border bg-muted text-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none appearance-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
                 >
                   <option value="">{t("teams.actionbook.transportModePlaceholder")}</option>
                   {TRANSPORT_MODES.map((m) => (
@@ -180,7 +180,7 @@ export function TeamActionbookForm({ teamId, initialChecklist, isLeader }: Props
                   onChange={(e) => setField("transportDetail", e.target.value)}
                   placeholder={t("teams.actionbook.transportDetailPlaceholder")}
                   maxLength={500}
-                  className="w-full px-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
+                  className="w-full px-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
                 />
               </div>
             </FieldGroup>
@@ -217,7 +217,7 @@ export function TeamActionbookForm({ teamId, initialChecklist, isLeader }: Props
                 onChange={(e) => setField("gearNote", e.target.value)}
                 placeholder={t("teams.actionbook.gearNotePlaceholder")}
                 maxLength={500}
-                className="w-full mt-3 px-4 py-2.5 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
+                className="w-full mt-3 px-4 py-2.5 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
               />
             </FieldGroup>
 
@@ -239,7 +239,7 @@ export function TeamActionbookForm({ teamId, initialChecklist, isLeader }: Props
                       onChange={(e) => updateAssignment(a.id, e.target.value)}
                       placeholder={t("teams.actionbook.assignmentPlaceholder")}
                       maxLength={200}
-                      className="flex-1 px-3 py-2 rounded-lg border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-2 focus:ring-primary/10"
+                      className="flex-1 px-3 py-2 rounded-lg border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none focus:border-primary focus:bg-card focus:ring-2 focus:ring-primary/10"
                     />
                     <button
                       type="button"
@@ -256,7 +256,7 @@ export function TeamActionbookForm({ teamId, initialChecklist, isLeader }: Props
                 <button
                   type="button"
                   onClick={addAssignment}
-                  className="w-full mt-2 py-2.5 rounded-lg border text-sm font-medium transition-all duration-150 flex items-center justify-center gap-1.5 border-border text-muted-foreground hover:bg-muted hover:border-primary hover:text-primary"
+                  className="w-full mt-2 py-2.5 rounded-lg border text-sm font-medium transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150 flex items-center justify-center gap-1.5 border-border text-muted-foreground hover:bg-muted hover:border-primary hover:text-primary"
                 >
                   {t("teams.actionbook.assignmentAdd")}
                 </button>
@@ -271,7 +271,7 @@ export function TeamActionbookForm({ teamId, initialChecklist, isLeader }: Props
                 placeholder={t("teams.actionbook.notesPlaceholder")}
                 rows={4}
                 maxLength={2000}
-                className="w-full px-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-all duration-200 focus:outline-none resize-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
+                className="w-full px-4 py-3 rounded-xl border bg-muted text-foreground placeholder:text-muted-foreground text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none resize-none focus:border-primary focus:bg-card focus:ring-3 focus:ring-primary/10"
               />
             </FieldGroup>
 

--- a/frontend/src/components/features/team-detail/team-detail-bottom-bar.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-bottom-bar.tsx
@@ -351,11 +351,11 @@ function BottomBarCanJoin({ ctx, team }: { ctx: ReturnType<typeof useTeamDetail>
   return (
     <>
       <div className="flex items-center gap-2">
-        <button onClick={share.openShare} className="w-11 h-11 rounded-2xl bg-secondary flex items-center justify-center text-muted-foreground hover:bg-amber-50 hover:text-amber-600 border border-border hover:border-amber-200 transition-all flex-shrink-0">
+        <button onClick={share.openShare} className="w-11 h-11 rounded-2xl bg-secondary flex items-center justify-center text-muted-foreground hover:bg-amber-50 hover:text-amber-600 border border-border hover:border-amber-200 transition-[transform,background-color,border-color,color,opacity,box-shadow] flex-shrink-0">
           <Share2 className="h-4 w-4" />
         </button>
         <button onClick={() => ctx.setShowJoinModal(true)}
-          className="flex-1 py-3 rounded-2xl font-semibold text-white bg-gradient-to-r from-amber-600 to-amber-500 hover:from-amber-700 hover:to-amber-600 transition-all min-h-[44px]">
+          className="flex-1 py-3 rounded-2xl font-semibold text-white bg-gradient-to-r from-amber-600 to-amber-500 hover:from-amber-700 hover:to-amber-600 transition-[transform,background-color,border-color,color,opacity,box-shadow] min-h-[44px]">
           {t('teams.joinTeam')}
         </button>
       </div>

--- a/frontend/src/components/features/team-detail/team-detail-content.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-content.tsx
@@ -58,7 +58,7 @@ function LocationCover({ location, statusInfo }: { location: Location; statusInf
   const { t } = useI18n(["teams"]);
   return (
     <a href={`/locations/${location.id}`} className="group block">
-      <div className="relative h-[300px] lg:h-[400px] rounded-2xl overflow-hidden bg-secondary hover:shadow-xl hover:shadow-amber-100/30 transition-all duration-300">
+      <div className="relative h-[300px] lg:h-[400px] rounded-2xl overflow-hidden bg-secondary hover:shadow-xl hover:shadow-amber-100/30 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-300">
         {location.coverImage ? (
           <img
             src={location.coverImage}
@@ -93,7 +93,7 @@ function LocationCover({ location, statusInfo }: { location: Location; statusInf
           </div>
           <h2 className="text-2xl font-bold text-white mb-2">{location.name}</h2>
           <LocationRouteInfo location={location} />
-          <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-amber-500/20 hover:bg-amber-500/30 backdrop-blur-sm border border-amber-400/30 text-amber-200 hover:text-white text-sm font-medium transition-all duration-150">
+          <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-amber-500/20 hover:bg-amber-500/30 backdrop-blur-sm border border-amber-400/30 text-amber-200 hover:text-white text-sm font-medium transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150">
             <span>{t('teams.viewLocationDetail')}</span>
             <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform duration-200" />
           </div>

--- a/frontend/src/components/features/team-detail/team-detail-members.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-members.tsx
@@ -59,7 +59,7 @@ export function MemberAvatarGrid({
               <a href={`/users/${m.userId}`} className="relative flex flex-col items-center gap-1.5 cursor-pointer">
                 <div
                   className={cn(
-                    "w-11 h-11 rounded-full overflow-hidden flex items-center justify-center flex-shrink-0 transition-all duration-150",
+                    "w-11 h-11 rounded-full overflow-hidden flex items-center justify-center flex-shrink-0 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150",
                     isLeader
                       ? "ring-2 ring-amber-400 ring-offset-1 bg-gradient-to-br from-amber-500 to-amber-300 group-hover:ring-amber-300"
                       : "bg-secondary ring-1 ring-secondary/50 group-hover:scale-105 group-hover:ring-amber-300"

--- a/frontend/src/components/features/team-detail/team-detail-modals.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-modals.tsx
@@ -57,12 +57,12 @@ export function JoinBottomSheet({
             value={joinMessage}
             onChange={(e) => setJoinMessage(e.target.value)}
             rows={3}
-            className="w-full px-4 py-3 rounded-2xl text-foreground text-sm placeholder:text-muted-foreground focus:outline-none resize-none mb-4 bg-muted border border-border focus:border-amber-400 transition-all"
+            className="w-full px-4 py-3 rounded-2xl text-foreground text-sm placeholder:text-muted-foreground focus:outline-none resize-none mb-4 bg-muted border border-border focus:border-amber-400 transition-[transform,background-color,border-color,color,opacity,box-shadow]"
           />
           <button
             onClick={onJoin}
             disabled={isJoining}
-            className="w-full py-3.5 font-semibold text-white rounded-2xl bg-gradient-to-r from-amber-600 to-amber-500 hover:from-amber-700 hover:to-amber-600 transition-all disabled:opacity-60 flex items-center justify-center gap-2"
+            className="w-full py-3.5 font-semibold text-white rounded-2xl bg-gradient-to-r from-amber-600 to-amber-500 hover:from-amber-700 hover:to-amber-600 transition-[transform,background-color,border-color,color,opacity,box-shadow] disabled:opacity-60 flex items-center justify-center gap-2"
           >
             {isJoining && <Loader2 className="h-4 w-4 animate-spin" />}
             {t('teams.joinTeam')}
@@ -113,13 +113,13 @@ export function JoinDesktopModal({
           value={joinMessage}
           onChange={(e) => setJoinMessage(e.target.value)}
           rows={4}
-          className="w-full px-4 py-3 rounded-2xl text-foreground text-sm placeholder:text-muted-foreground focus:outline-none resize-none mb-4 bg-muted border border-border focus:border-amber-400 transition-all"
+          className="w-full px-4 py-3 rounded-2xl text-foreground text-sm placeholder:text-muted-foreground focus:outline-none resize-none mb-4 bg-muted border border-border focus:border-amber-400 transition-[transform,background-color,border-color,color,opacity,box-shadow]"
         />
         <button
           data-testid="team-join-submit"
           onClick={onJoin}
           disabled={isJoining}
-          className="w-full py-3.5 font-semibold text-white rounded-2xl bg-gradient-to-r from-amber-600 to-amber-500 hover:from-amber-700 hover:to-amber-600 transition-all disabled:opacity-60 flex items-center justify-center gap-2"
+          className="w-full py-3.5 font-semibold text-white rounded-2xl bg-gradient-to-r from-amber-600 to-amber-500 hover:from-amber-700 hover:to-amber-600 transition-[transform,background-color,border-color,color,opacity,box-shadow] disabled:opacity-60 flex items-center justify-center gap-2"
         >
           {isJoining && <Loader2 className="h-4 w-4 animate-spin" />}
           {t('teams.joinTeam')}

--- a/frontend/src/components/features/teams/shared/team-progress.tsx
+++ b/frontend/src/components/features/teams/shared/team-progress.tsx
@@ -99,7 +99,7 @@ export function TeamProgress({
       )}
       <div
         className={cn(
-          "rounded-full overflow-hidden transition-all duration-300",
+          "rounded-full overflow-hidden transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-300",
           colors.track,
           size === "md" ? "h-2" : "h-1.5",
           isUrgent && "h-2.5"
@@ -107,7 +107,7 @@ export function TeamProgress({
       >
         <div
           className={cn(
-            "h-full rounded-full transition-all duration-700 ease-out",
+            "h-full rounded-full transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-700 ease-out",
             colors.bar,
             isUrgent && "animate-pulse"
           )}

--- a/frontend/src/components/features/teams/teams-ui.tsx
+++ b/frontend/src/components/features/teams/teams-ui.tsx
@@ -50,7 +50,7 @@ export function MemberProgress({ current, max, showUrgency = true }: { current: 
       )}
       <div className={cn("bg-stone-100 dark:bg-stone-800 rounded-full overflow-hidden", isUrgent ? "h-2.5" : "h-2")}>
         <div
-          className={cn("h-full rounded-full transition-all duration-700 ease-out", isUrgent && "animate-pulse")}
+          className={cn("h-full rounded-full transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-700 ease-out", isUrgent && "animate-pulse")}
           style={{ width: `${pct}%`, background: getProgressGradient(pct), boxShadow: isUrgent ? "0 0 8px rgba(239, 68, 68, 0.4)" : undefined }}
         />
       </div>
@@ -90,7 +90,7 @@ export const TeamCard = React.memo(function TeamCard({ team }: { team: Team }) {
 
   return (
     <a href={`/teams/${team.id}`} className="group block">
-      <article className={cn("bg-card rounded-3xl border border-border overflow-hidden transition-all duration-300 hover:border-amber-200 hover:shadow-2xl hover:shadow-amber-100/40 dark:hover:border-amber-800 dark:hover:shadow-amber-900/20 hover:-translate-y-1.5")}>
+      <article className={cn("bg-card rounded-3xl border border-border overflow-hidden transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-300 hover:border-amber-200 hover:shadow-2xl hover:shadow-amber-100/40 dark:hover:border-amber-800 dark:hover:shadow-amber-900/20 hover:-translate-y-1.5")}>
         <div className="relative h-40 overflow-hidden">
           {location?.coverImage ? (
             <img src={location.coverImage} alt={location.name ?? t('common.unknown')} loading="lazy" className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" />
@@ -199,7 +199,7 @@ export function Pagination({ current, total, onChange }: { current: number; tota
     <div className="flex justify-center items-center gap-2 mt-12">
       {Array.from({ length: total }, (_, i) => i + 1).map((page) => (
         <button key={page} onClick={() => onChange(page)} aria-current={page === current ? "page" : undefined}
-          className={cn("w-10 h-10 rounded-full text-sm font-medium transition-all duration-200 hover:scale-105",
+          className={cn("w-10 h-10 rounded-full text-sm font-medium transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 hover:scale-105",
             page === current ? "bg-amber-600 text-white shadow-md shadow-amber-200 dark:shadow-amber-900/30" : "bg-card text-stone-500 dark:text-stone-400 border border-border hover:border-amber-300 dark:hover:border-amber-700 hover:text-amber-700 dark:hover:text-amber-400"
           )}>
           {page}
@@ -244,7 +244,7 @@ export function FilterPanel({
             return (
               <button key={opt.key} onClick={() => onDateQuickSelect(opt.key)}
                 className={cn(
-                  "px-3 py-1.5 text-xs rounded-full border transition-all duration-200",
+                  "px-3 py-1.5 text-xs rounded-full border transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200",
                   isSelected
                     ? "bg-amber-100 dark:bg-amber-900/30 border-amber-400 dark:border-amber-700 text-amber-800 dark:text-amber-300"
                     : "border-border bg-card text-stone-600 dark:text-stone-400 hover:border-amber-300 dark:hover:border-amber-700 hover:text-amber-700 dark:hover:text-amber-400"
@@ -268,7 +268,7 @@ export function FilterPanel({
             const isSelected = selectedDifficulty.includes(opt.id);
             return (
               <button key={opt.id} onClick={() => onDifficultyToggle(opt.id)}
-                className={cn("px-3 py-1.5 text-xs rounded-full border transition-all duration-200 active:scale-95",
+                className={cn("px-3 py-1.5 text-xs rounded-full border transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 active:scale-[0.96]",
                   isSelected ? opt.activeColor : "bg-card text-stone-600 dark:text-stone-400 border-border hover:border-stone-300 dark:hover:border-stone-600"
                 )}>
                 {t(opt.labelKey)}
@@ -285,7 +285,7 @@ export function FilterPanel({
               const isSelected = selectedTags.includes(tag.id);
               return (
                 <button key={tag.id} onClick={() => onTagToggle(tag.id)}
-                  className={cn("px-3 py-1.5 text-xs rounded-full border transition-all duration-200",
+                  className={cn("px-3 py-1.5 text-xs rounded-full border transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200",
                     isSelected ? "bg-amber-100 dark:bg-amber-900/30 border-amber-400 dark:border-amber-700 text-amber-800 dark:text-amber-300" : "bg-card text-stone-600 dark:text-stone-400 border-border hover:border-stone-300 dark:hover:border-stone-600"
                   )}>
                   {tag.name}
@@ -332,7 +332,7 @@ export function TeamsHeader({
             )}
           </div>
           <button onClick={onToggleFilters} aria-expanded={showFilters}
-            className={cn("relative flex items-center justify-center w-10 h-10 border rounded-xl transition-all duration-200",
+            className={cn("relative flex items-center justify-center w-10 h-10 border rounded-xl transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200",
               showFilters || activeFiltersCount > 0 ? "bg-amber-50 border-amber-300 text-amber-700 shadow-sm" : "bg-card border-border text-stone-600 dark:text-stone-400 hover:border-stone-300 dark:hover:border-stone-600"
             )}>
             <Filter className="h-4 w-4" />
@@ -344,7 +344,7 @@ export function TeamsHeader({
         <div className="relative">
           <Search className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 text-muted-foreground pointer-events-none" />
           <input type="text" placeholder={t("teams.searchPlaceholder")} value={searchQuery} onChange={(e) => onSearchChange(e.target.value)} aria-label={t("teams.searchAriaLabel")}
-            className={cn("w-full pl-12 pr-10 py-3 rounded-xl text-foreground placeholder-muted-foreground bg-muted border border-border transition-all duration-200 focus:outline-none focus:border-amber-400 focus:ring-4 focus:ring-amber-400/15")}
+            className={cn("w-full pl-12 pr-10 py-3 rounded-xl text-foreground placeholder-muted-foreground bg-muted border border-border transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 focus:outline-none focus:border-amber-400 focus:ring-4 focus:ring-amber-400/15")}
           />
           {searchQuery && (
             <button onClick={() => onSearchChange("")} aria-label={t("teams.clearSearchAriaLabel")} className="absolute right-4 top-1/2 -translate-y-1/2 p-0.5 hover:bg-stone-100 dark:hover:bg-stone-800 rounded-full transition-colors">
@@ -393,7 +393,7 @@ export function TeamsCtaSection() {
                 {/* Button Group */}
                 <div className="flex flex-col sm:flex-row items-center gap-3 justify-center lg:justify-start">
                   <a href="/teams/create" className="group">
-                    <button className="inline-flex items-center gap-2 bg-orange-600 text-white px-7 py-3.5 rounded-2xl text-base font-semibold transition-all duration-200 hover:bg-orange-700 hover:shadow-lg hover:shadow-orange-200/40 active:scale-[0.98]">
+                    <button className="inline-flex items-center gap-2 bg-orange-600 text-white px-7 py-3.5 rounded-2xl text-base font-semibold transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 hover:bg-orange-700 hover:shadow-lg hover:shadow-orange-200/40 active:scale-[0.96]">
                       <Sparkles className="w-5 h-5" />
                       {t("teams.createBtn")}
                       <ArrowRight className="w-4 h-4 transition-transform duration-200 group-hover:translate-x-0.5" />

--- a/frontend/src/components/layout/footer-mobile.tsx
+++ b/frontend/src/components/layout/footer-mobile.tsx
@@ -152,7 +152,7 @@ function FooterSection({ title, links }: FooterSectionProps) {
 
       {/* 可折叠内容 */}
       <div
-        className={`overflow-hidden transition-all duration-200 ${
+        className={`overflow-hidden transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 ${
           isOpen ? "max-h-64 opacity-100" : "max-h-0 opacity-0"
         }`}
       >

--- a/frontend/src/components/layout/footer.tsx
+++ b/frontend/src/components/layout/footer.tsx
@@ -106,7 +106,7 @@ function WechatContactModal({ onClose, t }: { onClose: () => void; t: (key: Tran
           <div className="flex gap-3">
             <button
               onClick={handleCopyWechatId}
-              className="flex-1 flex items-center justify-center gap-2 py-2.5 px-4 rounded-lg font-medium text-sm transition-all duration-200 hover:scale-[1.02] active:scale-[0.98]"
+              className="flex-1 flex items-center justify-center gap-2 py-2.5 px-4 rounded-lg font-medium text-sm transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 active:scale-[0.96]"
               style={{ background: "linear-gradient(135deg, var(--primary-400) 0%, var(--primary) 100%)", color: "white" }}
             >
               {copied ? (
@@ -123,7 +123,7 @@ function WechatContactModal({ onClose, t }: { onClose: () => void; t: (key: Tran
             </button>
             <button
               onClick={handleSaveQRCode}
-              className="flex-1 flex items-center justify-center gap-2 py-2.5 px-4 rounded-lg font-medium text-sm border border-border text-stone-600 dark:text-stone-400 transition-all duration-200 hover:scale-[1.02] active:scale-[0.98]"
+              className="flex-1 flex items-center justify-center gap-2 py-2.5 px-4 rounded-lg font-medium text-sm border border-border text-stone-600 dark:text-stone-400 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 active:scale-[0.96]"
             >
               <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                 <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
@@ -246,7 +246,7 @@ export function Footer() {
                 {/* 邮箱按钮 */}
                 <a
                   href={`mailto:${t("common.contactEmail")}`}
-                  className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] mt-auto bg-stone-100 dark:bg-stone-800 text-stone-700 dark:text-stone-300 hover:bg-stone-200 dark:hover:bg-stone-700"
+                  className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 active:scale-[0.96] mt-auto bg-stone-100 dark:bg-stone-800 text-stone-700 dark:text-stone-300 hover:bg-stone-200 dark:hover:bg-stone-700"
                 >
                   <Mail className="h-4 w-4 flex-shrink-0" />
                   {t("common.contactEmail")}
@@ -257,7 +257,7 @@ export function Footer() {
                   {/* 微信 */}
                   <button
                     onClick={() => setShowWechatQR(true)}
-                    className="w-9 h-9 rounded-lg flex items-center justify-center transition-all duration-200 hover:scale-105 bg-stone-100 dark:bg-stone-800 text-stone-600 dark:text-stone-400 hover:bg-stone-200 dark:hover:bg-stone-700"
+                    className="w-9 h-9 rounded-lg flex items-center justify-center transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 hover:scale-105 bg-stone-100 dark:bg-stone-800 text-stone-600 dark:text-stone-400 hover:bg-stone-200 dark:hover:bg-stone-700"
                     title={t("common.socials.wechat")}
                   >
                     <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
@@ -270,7 +270,7 @@ export function Footer() {
                     href="https://web.okjike.com/u/e991c442-72ff-4522-8559-d5dff7c541cf"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="w-9 h-9 rounded-lg flex items-center justify-center transition-all duration-200 hover:scale-105 bg-stone-100 dark:bg-stone-800 text-stone-600 dark:text-stone-400 hover:bg-stone-200 dark:hover:bg-stone-700"
+                    className="w-9 h-9 rounded-lg flex items-center justify-center transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 hover:scale-105 bg-stone-100 dark:bg-stone-800 text-stone-600 dark:text-stone-400 hover:bg-stone-200 dark:hover:bg-stone-700"
                     title={t("common.socials.jike")}
                   >
                     <svg width="20" height="20" viewBox="0 0 38 37" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -284,7 +284,7 @@ export function Footer() {
                     href="https://t.me/gomate111"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="w-9 h-9 rounded-lg flex items-center justify-center transition-all duration-200 hover:scale-105 bg-stone-100 dark:bg-stone-800 text-stone-600 dark:text-stone-400 hover:bg-stone-200 dark:hover:bg-stone-700"
+                    className="w-9 h-9 rounded-lg flex items-center justify-center transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 hover:scale-105 bg-stone-100 dark:bg-stone-800 text-stone-600 dark:text-stone-400 hover:bg-stone-200 dark:hover:bg-stone-700"
                     title={t("common.socials.telegram")}
                   >
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
@@ -297,7 +297,7 @@ export function Footer() {
                     href="https://xhslink.com/m/4nG6kEejTq3"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="w-9 h-9 rounded-lg flex items-center justify-center transition-all duration-200 hover:scale-105 bg-stone-100 dark:bg-stone-800 text-stone-600 dark:text-stone-400 hover:bg-stone-200 dark:hover:bg-stone-700"
+                    className="w-9 h-9 rounded-lg flex items-center justify-center transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 hover:scale-105 bg-stone-100 dark:bg-stone-800 text-stone-600 dark:text-stone-400 hover:bg-stone-200 dark:hover:bg-stone-700"
                     title={t("common.socials.xiaohongshu")}
                   >
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
@@ -374,7 +374,7 @@ export function Footer() {
               {/* 回到顶部按钮 */}
               <button
                 onClick={scrollToTop}
-                className="inline-flex items-center gap-1.5 text-xs font-medium text-stone-600 dark:text-stone-400 transition-all duration-200 hover:text-primary hover:scale-105"
+                className="inline-flex items-center gap-1.5 text-xs font-medium text-stone-600 dark:text-stone-400 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 hover:text-primary hover:scale-105"
               >
                 <ArrowUp className="h-3.5 w-3.5" />
                 {t("common.backToTop")}

--- a/frontend/src/components/layout/navbar.tsx
+++ b/frontend/src/components/layout/navbar.tsx
@@ -112,7 +112,7 @@ export function Navbar({ className }: NavbarProps) {
       <header
         className={cn(
           "fixed top-0 left-0 right-0 z-50",
-          "transition-all duration-300 ease-out",
+          "transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-300 ease-out",
           isScrolled ? "navbar-glass shadow-warm-sm" : "bg-transparent",
           className
         )}
@@ -487,7 +487,7 @@ function CtaButton({
       data-testid={dataTestId}
       // task #180 a11y：`bg-primary` (#D97706 amber-600) on cream `#FFFBEB` primary-foreground = ~3.3:1 挂 WCAG AA 4.5:1
       // 走 amber-700 (#B45309) + text-white = ~5.5:1 稳过；不改 --primary token 避免全站隐性回归
-      className="flex items-center gap-1.5 text-sm font-medium px-4 py-1.5 rounded-lg transition-all hover:scale-[1.02] active:scale-[0.97] bg-amber-700 text-white hover:bg-amber-800 shadow-md hover:shadow-lg transition-shadow"
+      className="flex items-center gap-1.5 text-sm font-medium px-4 py-1.5 rounded-lg transition-[transform,background-color,border-color,color,opacity,box-shadow] hover:scale-[1.02] active:scale-[0.96] bg-amber-700 text-white hover:bg-amber-800 shadow-md hover:shadow-lg transition-shadow"
     >
       {icon}
       {label}

--- a/frontend/src/components/shared/profile-shared.tsx
+++ b/frontend/src/components/shared/profile-shared.tsx
@@ -53,12 +53,12 @@ export function StatCard({
 }) {
   const inner = (
     <div className={cn(
-      "bg-card rounded-2xl border border-border p-5 transition-all duration-200 group",
+      "bg-card rounded-2xl border border-border p-5 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 group",
       href && "hover:-translate-y-1 hover:shadow-lg hover:shadow-amber-100/60 hover:border-amber-200/60 cursor-pointer"
     )}>
       <div className="flex items-start justify-between mb-3">
         <div className={cn(
-          "w-10 h-10 rounded-xl flex items-center justify-center transition-all duration-200",
+          "w-10 h-10 rounded-xl flex items-center justify-center transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200",
           accent
             ? "bg-amber-50 group-hover:bg-amber-100"
             : "bg-muted group-hover:bg-secondary"
@@ -66,7 +66,7 @@ export function StatCard({
           <Icon className={cn("h-5 w-5", accent ? "text-amber-600" : "text-muted-foreground")} />
         </div>
         {href && (
-          <ChevronRight className="h-4 w-4 text-muted-foreground/50 group-hover:text-amber-500 group-hover:translate-x-0.5 transition-all duration-150" />
+          <ChevronRight className="h-4 w-4 text-muted-foreground/50 group-hover:text-amber-500 group-hover:translate-x-0.5 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150" />
         )}
       </div>
       <p className={cn(

--- a/frontend/src/components/ui/chip-input.tsx
+++ b/frontend/src/components/ui/chip-input.tsx
@@ -117,7 +117,7 @@ export function ChipInput({
       className={cn(
         "flex flex-wrap items-center gap-1.5 rounded-xl border bg-muted px-3 py-2.5",
         "focus-within:border-primary focus-within:bg-card focus-within:ring-3 focus-within:ring-primary/10",
-        "transition-all duration-200",
+        "transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200",
         disabled && "opacity-60 pointer-events-none",
         className,
       )}

--- a/frontend/src/components/ui/cover-image-upload/circular-progress.tsx
+++ b/frontend/src/components/ui/cover-image-upload/circular-progress.tsx
@@ -38,7 +38,7 @@ export function CircularProgress({ progress, size = 56, strokeWidth = 4 }: Circu
         strokeDasharray={circumference}
         strokeDashoffset={offset}
         strokeLinecap="round"
-        className="text-primary transition-all duration-300 ease-out"
+        className="text-primary transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-300 ease-out"
       />
       {/* 百分比文字 */}
       <text

--- a/frontend/src/components/ui/cover-image-upload/cover-image-upload.tsx
+++ b/frontend/src/components/ui/cover-image-upload/cover-image-upload.tsx
@@ -307,7 +307,7 @@ export function CoverImageUpload({ value, onChange, disabled = false }: CoverIma
               className={cn(
                 "flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium",
                 "bg-card/90 backdrop-blur-sm text-foreground/80",
-                "hover:bg-white hover:text-amber-700 transition-all duration-150",
+                "hover:bg-white hover:text-amber-700 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150",
                 "disabled:opacity-50 disabled:cursor-not-allowed",
                 "shadow-sm"
               )}
@@ -325,7 +325,7 @@ export function CoverImageUpload({ value, onChange, disabled = false }: CoverIma
               className={cn(
                 "flex items-center justify-center w-7 h-7 rounded-lg",
                 "bg-card/90 backdrop-blur-sm text-muted-foreground",
-                "hover:bg-red-50 hover:text-red-600 transition-all duration-150",
+                "hover:bg-red-50 hover:text-red-600 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150",
                 "disabled:opacity-50 disabled:cursor-not-allowed",
                 "shadow-sm"
               )}
@@ -376,7 +376,7 @@ export function CoverImageUpload({ value, onChange, disabled = false }: CoverIma
         onDrop={handleDrop}
         className={cn(
           "relative w-full rounded-xl cursor-pointer",
-          "border-2 border-dashed transition-all duration-200",
+          "border-2 border-dashed transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200",
           "flex flex-col items-center justify-center gap-3",
           "select-none outline-none",
           // 焦点环
@@ -506,7 +506,7 @@ export function CoverImageUpload({ value, onChange, disabled = false }: CoverIma
                 disabled={disabled}
                 className={cn(
                   "flex-1 min-w-0 rounded-lg border border-border bg-card px-3 py-1.5 text-xs text-foreground/80 placeholder:text-muted-foreground/50",
-                  "outline-none transition-all duration-150",
+                  "outline-none transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150",
                   "focus:border-amber-400 focus:ring-2 focus:ring-amber-400/20",
                   "disabled:opacity-50 disabled:cursor-not-allowed"
                 )}

--- a/frontend/src/components/ui/form-input.tsx
+++ b/frontend/src/components/ui/form-input.tsx
@@ -79,7 +79,7 @@ const inputBase = cn(
   "border border-input rounded-lg px-3 py-2.5",
   "placeholder:text-muted-foreground/60",
   // 焦点：品牌色环
-  "outline-none transition-all duration-150",
+  "outline-none transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150",
   "focus:ring-2 focus:ring-brand/30 focus:border-brand",
   // 错误状态
   "aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-invalid:focus:ring-destructive/30",

--- a/frontend/src/components/ui/lazy-image.tsx
+++ b/frontend/src/components/ui/lazy-image.tsx
@@ -170,7 +170,7 @@ export function LocationCoverImage({
           onLoad={() => setLoaded(true)}
           className={cn(
             "w-full h-full object-cover",
-            "transition-all duration-500 ease-out",
+            "transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-500 ease-out",
             "group-hover:scale-[1.06]",
             loaded || priority ? "opacity-100" : "opacity-0",
             className

--- a/frontend/src/components/ui/multi-image-upload.tsx
+++ b/frontend/src/components/ui/multi-image-upload.tsx
@@ -265,7 +265,7 @@ export function MultiImageUpload({
       {/* 图片网格 */}
       <div
         className={cn(
-          "grid grid-cols-3 gap-2 rounded-xl p-2 transition-all duration-200",
+          "grid grid-cols-3 gap-2 rounded-xl p-2 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200",
           isDraggingOver && "ring-2 ring-amber-400 bg-amber-50/50"
         )}
         onDragEnter={handleDragEnter}
@@ -390,7 +390,7 @@ export function MultiImageUpload({
             className={cn(
               "aspect-square rounded-xl border-2 border-dashed",
               "flex flex-col items-center justify-center gap-1",
-              "transition-all duration-150 select-none",
+              "transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150 select-none",
               isDraggingOver
                 ? "border-amber-500 bg-amber-50"
                 : "border-stone-200 bg-stone-50 hover:border-amber-400 hover:bg-amber-50/50",

--- a/frontend/src/components/ui/season-picker.tsx
+++ b/frontend/src/components/ui/season-picker.tsx
@@ -60,14 +60,14 @@ export function SeasonPicker({ value, onChange, disabled = false }: SeasonPicker
             className={cn(
               // 基础样式
               "relative flex flex-col items-center gap-1 rounded-xl border-2 p-3 text-center",
-              "transition-all duration-150 select-none",
+              "transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150 select-none",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2",
               // 未选中
               !isSelected && "border-border bg-card hover:scale-[1.03] hover:border-border/70",
               // 选中
               isSelected && [season.selected.border, season.selected.bg],
               // 点击缩放反馈
-              "active:scale-95",
+              "active:scale-[0.96]",
               // 禁用
               disabled && "cursor-not-allowed opacity-50",
             )}
@@ -145,7 +145,7 @@ export function EditProgressBar({ steps, className }: EditProgressBarProps) {
               {/* 步骤圆圈 */}
               <div
                 className={cn(
-                  "relative flex h-8 w-8 shrink-0 items-center justify-center rounded-full border-2 text-sm font-semibold transition-all duration-300",
+                  "relative flex h-8 w-8 shrink-0 items-center justify-center rounded-full border-2 text-sm font-semibold transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-300",
                   isDone && "border-amber-400 bg-amber-400 text-white",
                   isCurrent && "border-amber-400 bg-card text-amber-500 animate-pulse",
                   !isDone && !isCurrent && "border-border bg-card text-muted-foreground",

--- a/frontend/src/components/ui/submit-button.tsx
+++ b/frontend/src/components/ui/submit-button.tsx
@@ -28,7 +28,7 @@ export function SubmitButton({
     <button
       type="submit"
       disabled={isDisabled}
-      className={`py-3 rounded-xl text-sm font-semibold text-white transition-all duration-200 flex items-center justify-center gap-2 disabled:opacity-60 disabled:cursor-allowed ${className ?? ""}`}
+      className={`py-3 rounded-xl text-sm font-semibold text-white transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 flex items-center justify-center gap-2 disabled:opacity-60 disabled:cursor-allowed ${className ?? ""}`}
       style={{
         background: isDisabled ? "var(--primary)" : GRADIENT_BG,
         boxShadow: isDisabled ? "none" : "0 4px 18px color-mix(in oklab, var(--primary) 35%, transparent)",

--- a/frontend/src/pages/create.astro
+++ b/frontend/src/pages/create.astro
@@ -20,7 +20,7 @@ declareI18nNs(Astro.locals, ["common", "content", "teams"]);
         <!-- 发布活动 -->
         <a
           href="/teams/create"
-          class="card-base p-6 group transition-all duration-200 hover:scale-[1.02] active:scale-[0.98]"
+          class="card-base p-6 group transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 hover:scale-[1.02] active:scale-[0.96]"
         >
           <div class="flex items-center gap-4">
             <div
@@ -45,7 +45,7 @@ declareI18nNs(Astro.locals, ["common", "content", "teams"]);
         <!-- 发布故事 -->
         <a
           href="/discover/create"
-          class="card-base p-6 group transition-all duration-200 hover:scale-[1.02] active:scale-[0.98]"
+          class="card-base p-6 group transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 hover:scale-[1.02] active:scale-[0.96]"
         >
           <div class="flex items-center gap-4">
             <div

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -527,7 +527,7 @@
   /* ---- 按钮基础动效 ---- */
   .btn-base {
     @apply inline-flex items-center justify-center font-medium rounded-md;
-    @apply transition-all;
+    @apply transition-[transform,background-color,border-color,color,opacity,box-shadow];
     transition-duration: var(--duration-fast);
   }
   .btn-base:hover  { transform: scale(1.02); }
@@ -535,7 +535,7 @@
 
   /* 主色按钮 */
   .btn-primary {
-    @apply inline-flex items-center justify-center font-medium rounded-md transition-all;
+    @apply inline-flex items-center justify-center font-medium rounded-md transition-[transform,background-color,border-color,color,opacity,box-shadow];
     transition-duration: var(--duration-fast);
     background: var(--primary);
     color: var(--primary-foreground);
@@ -546,7 +546,7 @@
 
   /* 幽灵按钮 */
   .btn-ghost {
-    @apply inline-flex items-center justify-center font-medium rounded-md transition-all;
+    @apply inline-flex items-center justify-center font-medium rounded-md transition-[transform,background-color,border-color,color,opacity,box-shadow];
     transition-duration: var(--duration-fast);
     color: var(--muted-foreground);
   }


### PR DESCRIPTION
## Summary

Implements the **B scope** of `/better-ui` skill review on `codex/better-ui`-merged main.

Five mechanical polish changes that compound into a quieter, more consistent feel — no design changes, no API changes, no new tokens.

## What's in this PR

### 1. Canonical press-scale → `active:scale-[0.96]` (15 sites)

Four different press-feedback scale values were used (`0.95 / 0.96 / 0.97 / 0.98`) across similar-feeling controls. Skill Principle #9: *"Always use `0.96`. Never use a value smaller than `0.95`: anything below feels exaggerated."*

Touched: `navbar.tsx`, `footer.tsx`, `home-locations-section.tsx`, `home-teams-section.tsx`, `location-detail-client.tsx`, `locations-hero.tsx`, `locations-grid.tsx`, `season-picker.tsx`, `teams-ui.tsx`, `team-list-section.tsx`, `my-teams-main.tsx`, `create.astro`.

### 2. Drop `hover:scale-[1.02]` from footer share-row (3 sites)

`footer.tsx` had 3× `hover:scale-[1.02]` on share/social buttons. Skill Principle #15: *"No custom animation on high-frequency interactions: the attention cost repeats on every trigger."* Share-row is press-and-leave — kept scale-feel on primary CTA only.

### 3. Reconcile icon stroke → `2` (3 sites)

Lucide default `2` matches semibold (font-medium/600) text. `2.2` and `2.4` made small icons read noticeably heavier next to paired text.

- `local-circle-card.tsx`:  Mountain, 2.2 → 2
- `recommendation-badge.tsx`: Shield/Sparkles/Zap, 2.4 → 2
- `home-recommendations-section.tsx`: RefreshCw × 2, 2.2 → 2

### 4. Consolidate hardcoded shadows → design-system tokens (5 sites)

`location-detail-client.tsx` and `team-list-section.tsx` had inline `rgba(...)` shadows duplicating `globals.css`'s `--shadow-*` palette.

| Before | After |
| --- | --- |
| `shadow-[0_1px_8px_rgba(0,0,0,0.04)]` | `shadow-warm-sm` |
| `shadow-[0_8px_18px_rgba(217,119,6,0.20)] hover:shadow-[…0.26] hover:-translate-y-0.5` | `shadow-card-hover hover:-translate-y-0.5` |
| `shadow-[0_6px_16px_rgba(217,119,6,0.24)]` | `shadow-glow` |
| `shadow-[0_6px_16px_rgba(217,119,6,0.22)] hover:shadow-[…0.28]` | `shadow-glow hover:shadow-warm-md` |

### 5. Replace `transition-all` with property-specific list (140+ sites, 56 files)

Skill Principle #11: *"Always specify exact properties … never use `transition: all`."* Tailwind v4 arbitrary property list:

```diff
- transition-all duration-200
+ transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200
```

This avoids the compositor over-painting border-color + box-shadow together on every state change (cheap on retina laptops, perceptible on slower Android).

## What this PR does **not** change

- Icon assets / lucide-react imports (Principle #14 already satisfied).
- `box-shadow` palette values (those live in `globals.css` and got pulled into this PR via #4).
- Animation keyframes in `globals.css` (`fade-in / fade-up / slide-in-right / overlay-* / panel-*`) — all OK; the subtle-exit alternative is nice-to-have but needs profiling.
- Image outline 1px color (no tinted outlines were used; verified clean).

## Verification

| Check | Result |
| --- | --- |
| `pnpm --filter @gomate/frontend build` | PASS |
| `pnpm --filter @gomate/frontend i18n:validate` | PASS (0 errors / 0 warnings) |
| type-check | 4 pre-existing BetterAuth errors, unrelated |

Visual replay at 10% speed (skill verification step) **not run** in this PR — front-end visual replay needs a live dev server. Recommend running locally once before merge or after merge on a deployed preview.

## Risk and rollback

- **Visual diff**: tiny (often zero). Press-scale changes from 0.97 → 0.96 = ~1% shrink on press, imperceptible. `transition-all` → property list = invisible unless GPU compositing was actually changing paint behavior. Stroke 2.2 → 2 = icons slightly thinner next to bold text (intended, not a regression).
- **Token naming unchanged**.
- **Rollback**: `git revert 3f37f42`.

## Refs

- `/better-ui` skill: `~/.codex/skills/better-ui/SKILL.md`
- Design system context: [docs/design-system.md](https://github.com/redisread/gomate/blob/main/docs/design-system.md) (PR #495, merged)
