### PR TITLE
docs(design-system): add §10 Typography section

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -89,3 +89,62 @@ style={{ background: "color-mix(in oklab, var(--primary) 10%, transparent)" }}
 - `AGENTS.md`：项目级代理工作规则（含 minimum checks）；不含 design tokens
 - PR #494：https://github.com/redisread/gomate/pull/494 — `feat(frontend): OKLCH-ify tokens, fix HIGH WCAG, and switch inline-style to var(--token)`
 - `/better-colors` skill：user-level `~/.codex/skills/better-colors/SKILL.md`，做对比度 / palette 决策时加载
+
+## 9. Motion & Interaction Polish
+
+Five `better-ui` skill rules, all PR-enforced since PR #496 (2026-08-02).
+
+### 9.1 Canonical press feedback
+
+Always `active:scale-[0.96]`. Never `< 0.95` (exaggerated). Other values (0.97 / 0.98) give inconsistent tactile feel.
+
+```tsx
+// ✅
+className="... active:scale-[0.96] transition-transform duration-150"
+// ❌
+className="... active:scale-95 hover:scale-[1.02] ..."
+```
+
+### 9.2 Hover scale restricted to primary CTAs
+
+`hover:scale-[1.02+]` only on the **single decision-per-page primary CTA**. Forbidden on:
+
+- footer share-row (Wechat / Contact / Share)
+- navigation tabs
+- repeat social actions (Principle #15 — motion restraint on high-frequency interactions).
+
+### 9.3 `transition-all` is never correct
+
+The compositor over-paints every property on every state change. Specify the exact list:
+
+```tsx
+// ✅ canonical list (covers ~95% of GoMate use cases)
+className="transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200"
+// ✅ narrow subsets when only 1-2 props actually change
+className="transition-colors duration-150"          // hover color
+className="transition-transform duration-150"       // hover scale/translate
+// ❌
+className="transition-all duration-200"
+```
+
+### 9.4 Icon stroke = 2 default
+
+Lucide icons paired with `font-medium` (500) / `font-semibold` (600) use `strokeWidth={2}` (default). Heavier (2.2 / 2.4) makes small icons read visibly heavier next to semibold text. Bump to 2.5 only when paired with `font-bold` (700+) text. Circular-progress SVGs (3-5px) are intentionally thick ring strokes — not icon weight.
+
+### 9.5 Shadow tokens over inline `rgba`
+
+Always use `shadow-warm-sm` / `shadow-card-hover` / `shadow-glow` from `globals.css`. Don't inline `shadow-[rgba(...)]` — these duplicate the design-system palette and drift over time.
+
+```tsx
+// ❌ duplicate (also legacy: pure rgba can't follow --shadow-* semantic change)
+className="shadow-[0_8px_18px_rgba(217,119,6,0.20)]"
+// ✅
+className="shadow-card-hover"
+```
+
+## Related
+
+- PR #494: OKLCH + WCAG fixes (color tokens)
+- PR #495: this doc created
+- PR #496: motion / interaction polish (rules §9)
+- `/better-ui` skill: `~/.codex/skills/better-ui/SKILL.md`

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -148,3 +148,100 @@ className="shadow-card-hover"
 - PR #495: this doc created
 - PR #496: motion / interaction polish (rules §9)
 - `/better-ui` skill: `~/.codex/skills/better-ui/SKILL.md`
+
+## 10. Typography
+
+Six `better-typography` skill rules, PR-enforced since PR #498 (2026-08-02).
+
+### 10.1 Type scale — use semantic tokens, not magic numbers
+
+The scale lives in `globals.css` `@theme inline`. Never reach for `text-[Xpx]` arbitrary values.
+
+| Token | Size | Use |
+| --- | --- | --- |
+| `text-3xs` | 10px / 0.875rem lh | status badge text, avatar initial hints, indicator dots |
+| `text-2xs` | 11px / 1rem lh | small chip / notification badge counters |
+| `xs` … `5xl` | Tailwind default scale | body text and standard headings (unchanged) |
+| `text-page-h1` | 24px / 1.2 / 700 / -0.02em | **page-title `<h1>`** only |
+| `text-section-h2` | 18px / 1.3 / 600 / -0.01em | section headings inside a page |
+| `text-card-h3` | 16px / 1.4 / 600 | card heading inside a card |
+
+For `<h2>` / `<h3>` in marketing-hero / profile-card sub-section roles: keep them size-customizable, but stay on the standard `text-2xl … text-base` ramp.
+
+### 10.2 Heading semantics — one `<h1>` per render
+
+Each render-path of a page owns exactly one `<h1>`. Multiple `<h1>` on the same route breaks the document outline and screen-reader landmark count.
+
+```tsx
+// ❌ duplicate h1 — loading state + active state both render
+if (isLoading) return <Loading />;          // <h1>Title</h1>
+return <Active />;                          // <h1>Title</h1>
+
+// ✅ subordinate <h2> in loading / empty / error states
+if (isLoading) return <Loading h1As="h2" />;
+return <Active />;                          // <h1>Title</h1>
+```
+
+Owned by the `better-accessibility` skill's landmark-counting rule. Just don't reach for `<h1>` twice on the same logical page.
+
+### 10.3 `text-wrap` for headings & body
+
+```css
+/* in @layer base */
+h1, h2, h3 { text-wrap: balance; }   /* orphan-aware balance on multi-line headings */
+.story-prose :where(p) { text-wrap: pretty; }  /* body paragraphs */
+```
+
+`balance` makes 2-line and 3-line headings look deliberate instead of lopsided. `pretty` for long-form reading avoids the worst-line-with-orphan feel. Both fall back gracefully on older browsers (no-op).
+
+### 10.4 Properties over raw tags
+
+Always use the high-level CSS property if one exists for the feature.
+
+| ❌ Don't | ✅ Use |
+| --- | --- |
+| `font-feature-settings: "liga" 1, "calt" 1` | `font-variant-ligatures: common-ligatures contextual` |
+| `font-variation-settings: "wght" 650` | `font-weight: 650` |
+| `font-variation-settings: "opsz" auto` | `font-optical-sizing: auto` |
+| `font-feature-settings: "tnum" 1` | `font-variant-numeric: tabular-nums` |
+
+The high-level property preserves fallback behavior when a non-variable / older-rendered stack takes over. Reserve raw tags for custom axes (`"GRAD" 80`) and niche features (`"ss01" 1`) that have no property of their own.
+
+### 10.5 Truncated text — keep full text reachable
+
+Every `line-clamp-N` heading needs a `title={full}` attribute so keyboard / screen-reader users can read the unclamped text.
+
+```tsx
+// ❌ no fallback content for truncated text
+<h3 className="… line-clamp-1">{team.title}</h3>
+
+// ✅ tooltip on hover + exposed to assistive tech
+<h3 title={team.title} className="… line-clamp-1">{team.title}</h3>
+```
+
+Use the **same field** as the inner content (no rewriting / no truncation in `title`). Should match `text-card-h3` token.
+
+### 10.6 iOS input zoom (always ≥ 16px text-size in inputs)
+
+iOS Safari zooms the viewport when an `<input>` receives focus with computed font-size < 16px. Rule:
+
+```tsx
+// ✅ always 16px or larger in <input> / <textarea>
+className="text-base"                              // always 16px
+className="text-sm sm:text-base"                   // mobile-xs then ≥md
+className="text-base sm:text-sm"                   // wrong: starts <16px
+
+// ❌
+className="text-xs" / "text-sm" / "text-[13px]"    // forces iOS zoom
+```
+
+`text-base` is the safest default. `text-sm sm:text-base` is fine if you want smaller text on mobile but it must cross 16px by `sm:`.
+
+## Related
+
+- PR #494: OKLCH + WCAG fixes (color tokens §1-§8)
+- PR #495: this doc created
+- PR #496: motion polish (rules §9)
+- PR #498: typography polish (rules §10)
+- `/better-typography` skill: `~/.codex/skills/better-typography/SKILL.md`
+- `/better-accessibility` skill (heading semantics): `~/.codex/skills/better-accessibility/SKILL.md`

--- a/frontend/src/components/features/create-team-client.tsx
+++ b/frontend/src/components/features/create-team-client.tsx
@@ -206,7 +206,7 @@ export function CreateTeamClient() {
         <div className="mb-8">
           <div className="flex items-center gap-2 mb-2">
             <Sparkles className="h-5 w-5" style={{ color: "var(--primary)" }} />
-            <h1 className="text-2xl font-bold text-foreground">
+            <h1 className="text-page-h1">
               {t("teams.createTitle")}
             </h1>
           </div>

--- a/frontend/src/components/features/discover/discover-main.tsx
+++ b/frontend/src/components/features/discover/discover-main.tsx
@@ -223,9 +223,9 @@ export function DiscoverMain() {
               <div className="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center">
                 <Compass className="w-4 h-4 text-primary" />
               </div>
-              <h1 className="text-2xl font-bold text-foreground">
+              <h2 className="text-lg font-semibold text-foreground tracking-tight">
                 {t("content.discover.title")}
-              </h1>
+              </h2>
             </div>
           </div>
         </div>
@@ -280,7 +280,7 @@ export function DiscoverMain() {
                 <div className="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center">
                   <Compass className="w-4 h-4 text-primary" />
                 </div>
-                <h1 className="text-2xl font-bold text-foreground">
+                <h1 className="text-page-h1">
                   {t("content.discover.title")}
                 </h1>
               </div>

--- a/frontend/src/components/features/discover/featured-story-card.tsx
+++ b/frontend/src/components/features/discover/featured-story-card.tsx
@@ -105,7 +105,7 @@ export function FeaturedStoryCard({ story, onClick, className }: FeaturedStoryCa
       {/* 内容区 */}
       <div className="p-4 sm:p-5">
         {/* 标题 - 18px 加粗 */}
-        <h3 className="text-lg font-bold text-foreground line-clamp-2 mb-3 group-hover:text-primary transition-colors">
+        <h3 title={story.title} className="text-lg font-bold text-foreground line-clamp-2 mb-3 group-hover:text-primary transition-colors">
           {story.title}
         </h3>
 

--- a/frontend/src/components/features/discover/story-card.tsx
+++ b/frontend/src/components/features/discover/story-card.tsx
@@ -139,7 +139,7 @@ export function StoryCard({ story, onClick, className }: StoryCardProps) {
                 className="w-5 h-5 rounded-full object-cover"
               />
             ) : (
-              <div className="w-5 h-5 rounded-full bg-primary/10 flex items-center justify-center text-[10px] font-medium text-primary">
+              <div className="w-5 h-5 rounded-full bg-primary/10 flex items-center justify-center text-3xs font-medium text-primary">
                 {story.author?.name?.charAt(0) || "?"}
               </div>
             )}
@@ -162,7 +162,7 @@ export function StoryCard({ story, onClick, className }: StoryCardProps) {
         </div>
 
         {/* 日期 */}
-        <div className="flex items-center gap-1 text-[10px] text-muted-foreground/50">
+        <div className="flex items-center gap-1 text-3xs text-muted-foreground/50">
           <Clock className="w-3 h-3" />
           <span suppressHydrationWarning>{formatDate(story.createdAt)}</span>
         </div>

--- a/frontend/src/components/features/favorites-client.tsx
+++ b/frontend/src/components/features/favorites-client.tsx
@@ -87,7 +87,7 @@ export function FavoritesClient() {
               <ArrowLeft className="h-4 w-4" />
               {t("favorites.backBtn")}
             </a>
-            <h1 className="text-2xl font-bold text-[var(--foreground)]">{t("favorites.pageTitle")}</h1>
+            <h1 className="text-page-h1">{t("favorites.pageTitle")}</h1>
             {!isLoading && favorites.length > 0 && (
               <p className="text-sm text-[var(--muted-foreground)] mt-1">
                 {favorites.length} {t("favorites.locationCount")}
@@ -241,7 +241,7 @@ export function FavoritesClient() {
 
                     {/* 卡片内容 */}
                     <a href={`/locations/${loc.id}`} className="block p-4">
-                      <h3 className="font-semibold text-[var(--foreground)] text-sm leading-snug mb-1.5 line-clamp-1">
+                      <h3 title={loc.name} className="font-semibold text-[var(--foreground)] text-sm leading-snug mb-1.5 line-clamp-1">
                         {loc.name}
                       </h3>
                       {(loc.address || loc.cityName) && (

--- a/frontend/src/components/features/home/home-location-card.tsx
+++ b/frontend/src/components/features/home/home-location-card.tsx
@@ -57,7 +57,7 @@ export const LocationCard = memo(function LocationCard({ location, index = 0, co
           </div>
           {/* Right: name + params */}
           <div className="flex-1 min-w-0 flex flex-col justify-center gap-1">
-            <h3 className="font-semibold text-foreground text-sm leading-snug line-clamp-1 group-hover:text-amber-700 dark:group-hover:text-amber-400 transition-colors">
+            <h3 title={location.name} className="font-semibold text-foreground text-sm leading-snug line-clamp-1 group-hover:text-amber-700 dark:group-hover:text-amber-400 transition-colors">
               {location.name}
             </h3>
             <p className="text-xs text-stone-700 dark:text-stone-300 flex items-center gap-1">

--- a/frontend/src/components/features/home/home-team-card.tsx
+++ b/frontend/src/components/features/home/home-team-card.tsx
@@ -26,14 +26,14 @@ function AvatarStack({ members, extra = 0 }: { members: { name: string; avatar: 
               {m.avatar ? (
                 <img src={m.avatar} alt={m.name} className="w-full h-full object-cover" />
               ) : (
-                <div className="w-full h-full flex items-center justify-center text-[10px] font-bold text-white"
+                <div className="w-full h-full flex items-center justify-center text-3xs font-bold text-white"
                   style={{ background: "linear-gradient(135deg, var(--primary) 0%, var(--primary-300) 100%)" }}>{initial}</div>
               )}
             </div>
           );
         })}
         {extra > 0 && (
-          <div className="w-7 h-7 rounded-full border-2 border-border flex items-center justify-center text-[10px] font-bold flex-shrink-0"
+          <div className="w-7 h-7 rounded-full border-2 border-border flex items-center justify-center text-3xs font-bold flex-shrink-0"
             style={{ zIndex: 1, background: "var(--brand-subtle)", color: "var(--accent-foreground)", boxShadow: "var(--shadow-warm-sm)" }}>+{extra}</div>
         )}
       </div>
@@ -80,7 +80,7 @@ export function TeamCard({ team, featured = false }: { team: Team; featured?: bo
 
             {departureLabel && (
               <div className="absolute top-3 right-3">
-                <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-[11px] font-bold"
+                <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-2xs font-bold"
                   style={{ background: departureLabel.urgent ? "color-mix(in oklab, var(--destructive) 80%, transparent)" : "color-mix(in oklab, var(--primary) 80%, transparent)", color: "#fff", backdropFilter: "blur(8px)" }}>
                   {departureLabel.urgent ? "🔥" : ""} {departureLabel.text}
                 </span>
@@ -121,7 +121,7 @@ export function TeamCard({ team, featured = false }: { team: Team; featured?: bo
             </div>
           )}
 
-          <h3 className="font-bold text-foreground line-clamp-1 mb-2 leading-snug text-[15px] group-hover:text-amber-700 dark:group-hover:text-amber-400 transition-colors duration-200">{team.title}</h3>
+          <h3 title={team.title} className="font-bold text-foreground line-clamp-1 mb-2 leading-snug text-sm group-hover:text-amber-700 dark:group-hover:text-amber-400 transition-colors duration-200">{team.title}</h3>
 
           <div className="flex items-center gap-3 mb-3">
             {/* task #180 a11y：team card date 小字体 muted 挂门禁 */}
@@ -129,7 +129,7 @@ export function TeamCard({ team, featured = false }: { team: Team; featured?: bo
               <Calendar className="h-3 w-3 flex-shrink-0 text-amber-600" />{team.date}{team.time && <span className="ml-0.5 font-medium">{team.time}</span>}
             </span>
             {!hasCover && departureLabel && (
-              <span className="ml-auto flex-shrink-0 text-[11px] font-bold px-2 py-0.5 rounded-full"
+              <span className="ml-auto flex-shrink-0 text-2xs font-bold px-2 py-0.5 rounded-full"
                 style={{ background: departureLabel.urgent ? "color-mix(in oklab, var(--destructive) 10%, transparent)" : "color-mix(in oklab, var(--primary) 8%, transparent)", color: departureLabel.urgent ? "oklch(0.505 0.19 27.5)" : "var(--primary)" }}>
                 {departureLabel.urgent ? "" : "⏱"} {departureLabel.text}</span>
             )}

--- a/frontend/src/components/features/home/local-circle/avatar-stack.tsx
+++ b/frontend/src/components/features/home/local-circle/avatar-stack.tsx
@@ -32,7 +32,7 @@ export function AvatarStack({ urls, max = 5, size = "sm", tooltip }: AvatarStack
   const shown = urls.slice(0, max);
   const extra = Math.max(0, urls.length - max);
   const boxSize = SIZE_PX[size];
-  const fontSize = size === "sm" ? "text-[9px]" : "text-[10px]";
+  const fontSize = size === "sm" ? "text-[9px]" : "text-3xs";
 
   if (urls.length === 0) return null;
 

--- a/frontend/src/components/features/home/local-circle/local-circle-card.tsx
+++ b/frontend/src/components/features/home/local-circle/local-circle-card.tsx
@@ -41,7 +41,7 @@ export const LocalCircleCard = memo(function LocalCircleCard({ location, index =
           />
         </div>
         <div className="p-4 sm:p-5">
-          <h3 className="font-semibold text-base sm:text-lg text-card-foreground line-clamp-1">
+          <h3 title={location.locationName} className="font-semibold text-base sm:text-lg text-card-foreground line-clamp-1">
             {location.locationName}
           </h3>
           <div className="mt-3 flex items-center justify-between gap-2">

--- a/frontend/src/components/features/home/local-circle/neighbor-team-row.tsx
+++ b/frontend/src/components/features/home/local-circle/neighbor-team-row.tsx
@@ -51,7 +51,7 @@ export const NeighborTeamRow = memo(function NeighborTeamRow({ team, cityName }:
       data-testid="neighbor-team-row"
     >
       <div className="flex-1 min-w-0">
-        <h4 className="font-medium text-sm sm:text-base text-card-foreground line-clamp-1">
+        <h4 title={team.teamTitle} className="font-medium text-sm sm:text-base text-card-foreground line-clamp-1">
           {team.teamTitle}
         </h4>
         <div className="mt-1 flex items-center gap-3 text-xs text-stone-600 dark:text-stone-400">

--- a/frontend/src/components/features/home/recommendations/recommendation-badge.tsx
+++ b/frontend/src/components/features/home/recommendations/recommendation-badge.tsx
@@ -63,7 +63,7 @@ export function RecommendationBadge({
     <span
       className={cn(
         "inline-flex items-center gap-1.5 rounded-full font-medium border",
-        size === "sm" ? "px-2 py-0.5 text-[11px]" : "px-2.5 py-1 text-xs",
+        size === "sm" ? "px-2 py-0.5 text-2xs" : "px-2.5 py-1 text-xs",
         className,
       )}
       style={{ background: s.bg, color: s.text, borderColor: s.border }}

--- a/frontend/src/components/features/home/recommendations/recommendation-card.tsx
+++ b/frontend/src/components/features/home/recommendations/recommendation-card.tsx
@@ -78,7 +78,7 @@ export function RecommendationCard({ reco }: RecommendationCardProps) {
           />
           {(difficultyLabel || location.durationMin) && (
             /* task #180 a11y：11px meta 小字体 muted 挂门禁；stone-700 dark:stone-300 = ~7.5:1/8:1 */
-            <div className="text-[11px] text-stone-700 dark:text-stone-300 flex items-center gap-1.5">
+            <div className="text-2xs text-stone-700 dark:text-stone-300 flex items-center gap-1.5">
               {difficultyLabel && <span>{difficultyLabel}</span>}
               {difficultyLabel && location.durationMin ? <span>·</span> : null}
               {location.durationMin && (
@@ -89,7 +89,7 @@ export function RecommendationCard({ reco }: RecommendationCardProps) {
         </div>
 
         {/* Row 2: 地点名 */}
-        <h3 className="text-lg font-semibold text-foreground leading-snug group-hover:text-amber-700 dark:group-hover:text-amber-400 transition-colors line-clamp-2">
+        <h3 title={location.name} className="text-lg font-semibold text-foreground leading-snug group-hover:text-amber-700 dark:group-hover:text-amber-400 transition-colors line-clamp-2">
           {location.name}
         </h3>
 
@@ -100,7 +100,7 @@ export function RecommendationCard({ reco }: RecommendationCardProps) {
 
         {/* Row 4: 二级数据 — task #180 a11y：11px muted 挂门禁 */}
         {metaLine.length > 0 && (
-          <div className="pt-2 mt-auto flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-stone-700 dark:text-stone-300 border-t border-border/50">
+          <div className="pt-2 mt-auto flex flex-wrap items-center gap-x-3 gap-y-1 text-2xs text-stone-700 dark:text-stone-300 border-t border-border/50">
             {metaLine.map((m, i) => (
               <span key={i}>{m}</span>
             ))}

--- a/frontend/src/components/features/location-detail-client.tsx
+++ b/frontend/src/components/features/location-detail-client.tsx
@@ -288,7 +288,7 @@ function ActionCard({ location, teams }: ActionCardProps) {
             className="flex items-center gap-2 mb-4 px-3 py-2 rounded-xl bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-100 dark:border-emerald-900/50"
           >
             <Flame className="h-3.5 w-3.5 text-emerald-500 flex-shrink-0" />
-            <span className="text-[11px] font-semibold text-emerald-700 dark:text-emerald-400">
+            <span className="text-2xs font-semibold text-emerald-700 dark:text-emerald-400">
               {t("locationDetail.activeRecruiting")}
             </span>
           </div>
@@ -386,7 +386,7 @@ function RelatedLocations({ locations }: RelatedLocationsProps) {
                   {loc.name}
                 </h4>
                 {diff && diffLabel && (
-                  <span className={cn("inline-flex items-center gap-1 mt-1 px-2 py-0.5 rounded-full text-[10px] font-semibold", diff.bg, diff.text)}>
+                  <span className={cn("inline-flex items-center gap-1 mt-1 px-2 py-0.5 rounded-full text-3xs font-semibold", diff.bg, diff.text)}>
                     <span className={cn("w-1.5 h-1.5 rounded-full", diff.dot)} />
                     {diffLabel}
                   </span>
@@ -444,8 +444,8 @@ function MobileFloatingCTA({ location, heroRef }: MobileFloatingCTAProps) {
       <div className="max-w-7xl mx-auto px-3 py-3 flex items-center gap-2.5 sm:px-4 sm:gap-3 max-[360px]:px-2 max-[360px]:gap-2">
         {/* 地点信息 */}
         <div className="flex-1 min-w-0 max-[360px]:hidden">
-          <p className="text-[10px] text-stone-500 dark:text-stone-500 font-semibold uppercase tracking-wide">{t("locationDetail.destination")}</p>
-          <p className="text-sm font-bold text-stone-900 dark:text-stone-100 truncate leading-tight">{location.name}</p>
+          <p className="text-3xs text-stone-500 dark:text-stone-500 font-semibold uppercase tracking-wide">{t("locationDetail.destination")}</p>
+          <p title={location.name} className="text-sm font-bold text-stone-900 dark:text-stone-100 truncate leading-tight">{location.name}</p>
         </div>
 
         {/* 浏览队伍 */}
@@ -941,7 +941,7 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
                   />
                 ))}
                 {galleryImages.length > 8 && (
-                  <span className="text-white/50 text-[10px] ml-0.5">+{galleryImages.length - 8}</span>
+                  <span className="text-white/50 text-3xs ml-0.5">+{galleryImages.length - 8}</span>
                 )}
               </div>
             )}

--- a/frontend/src/components/features/location-detail/decision-block.tsx
+++ b/frontend/src/components/features/location-detail/decision-block.tsx
@@ -74,7 +74,7 @@ export function DecisionBlock({ location }: DecisionBlockProps) {
           const transportMapUrl = buildFallbackMapUrl(location);
           return (
             <div className="rounded-xl border border-stone-100 bg-stone-50/60 dark:border-stone-800 dark:bg-stone-900/50 p-3.5 space-y-2">
-              <p className="mb-3 text-[11px] font-bold uppercase text-stone-500 dark:text-stone-400 flex items-center gap-1.5">
+              <p className="mb-3 text-2xs font-bold uppercase text-stone-500 dark:text-stone-400 flex items-center gap-1.5">
                 <Navigation className="h-3.5 w-3.5" />
                 {t("locationDetail.transport.title")}
               </p>
@@ -143,7 +143,7 @@ function ParkingSubBlock({ available, info, t }: ParkingSubBlockProps) {
   const showStatus = available !== null;
   return (
     <div className="rounded-xl border border-stone-100 bg-stone-50/60 dark:border-stone-800 dark:bg-stone-900/50 p-3.5">
-      <p className="mb-3 flex items-center gap-1.5 text-[11px] font-bold uppercase text-stone-500 dark:text-stone-400">
+      <p className="mb-3 flex items-center gap-1.5 text-2xs font-bold uppercase text-stone-500 dark:text-stone-400">
         <MapPin className="h-3.5 w-3.5" />
         {t("locationDetail.parking.title")}
       </p>
@@ -182,7 +182,7 @@ interface GearSubBlockProps {
 function GearSubBlock({ essential, optional, notes, t }: GearSubBlockProps) {
   return (
     <div className="rounded-xl border border-stone-100 bg-stone-50/60 dark:border-stone-800 dark:bg-stone-900/50 p-3.5">
-      <p className="mb-3 flex items-center gap-1.5 text-[11px] font-bold uppercase text-stone-500 dark:text-stone-400">
+      <p className="mb-3 flex items-center gap-1.5 text-2xs font-bold uppercase text-stone-500 dark:text-stone-400">
         <Backpack className="h-3.5 w-3.5" />
         {t("locationDetail.gear.title")}
       </p>
@@ -204,7 +204,7 @@ function GearSubBlock({ essential, optional, notes, t }: GearSubBlockProps) {
       </div>
       {notes.length > 0 && (
         <div className="mt-3 rounded-lg border border-amber-100 bg-amber-50/70 dark:border-amber-900/40 dark:bg-amber-950/20 px-3 py-2.5">
-          <p className="mb-1.5 flex items-center gap-1.5 text-[11px] font-bold uppercase text-amber-700 dark:text-amber-400">
+          <p className="mb-1.5 flex items-center gap-1.5 text-2xs font-bold uppercase text-amber-700 dark:text-amber-400">
             <AlertTriangle className="h-3.5 w-3.5" />
             {t("locationDetail.gear.notes")}
           </p>
@@ -238,7 +238,7 @@ function GearList({
     <div>
       <p
         className={cn(
-          "mb-1.5 text-[11px] font-bold uppercase",
+          "mb-1.5 text-2xs font-bold uppercase",
           tone === "essential"
             ? "text-emerald-700 dark:text-emerald-400"
             : "text-stone-500 dark:text-stone-400",

--- a/frontend/src/components/features/location-detail/route-info-card.tsx
+++ b/frontend/src/components/features/location-detail/route-info-card.tsx
@@ -166,7 +166,7 @@ function MetricTile({
       <div className={cn("mb-2 flex h-8 w-8 items-center justify-center rounded-lg", bg)}>
         <span className={accent}>{icon}</span>
       </div>
-      <p className="text-[10px] font-semibold uppercase text-stone-600 dark:text-stone-400">{label}</p>
+      <p className="text-3xs font-semibold uppercase text-stone-600 dark:text-stone-400">{label}</p>
       <p className={cn("mt-1 text-sm font-black leading-tight", accent)}>{value}</p>
     </div>
   );
@@ -194,7 +194,7 @@ function RouteNoteBlock({
     >
       <p
         className={cn(
-          "mb-2 flex items-center gap-1.5 text-[11px] font-bold uppercase",
+          "mb-2 flex items-center gap-1.5 text-2xs font-bold uppercase",
           tone === "warning" ? "text-orange-700 dark:text-orange-400" : "text-stone-500 dark:text-stone-400"
         )}
       >

--- a/frontend/src/components/features/location-form/location-form-basic-fields.tsx
+++ b/frontend/src/components/features/location-form/location-form-basic-fields.tsx
@@ -136,7 +136,7 @@ export function LocationFormBasicFields({ formData, errors, cities, updateField,
                   formData.description.length < 50 ? "bg-stone-300" : formData.description.length < 100 ? "bg-amber-400" : "bg-emerald-400")}
                   style={{ width: `${Math.min((formData.description.length / 500) * 100, 100)}%` }} />
               </div>
-              <span className={cn("text-[10px] tabular-nums", formData.description.length > 450 ? "text-amber-500" : "text-stone-300")}>
+              <span className={cn("text-3xs tabular-nums", formData.description.length > 450 ? "text-amber-500" : "text-stone-300")}>
                 {formData.description.length}
               </span>
             </div>
@@ -158,13 +158,13 @@ export function LocationFormBasicFields({ formData, errors, cities, updateField,
           <div className="flex items-end gap-2">
             <div className="flex-1 grid grid-cols-2 gap-3">
               <div>
-                <label className="block text-[11px] text-stone-400 mb-1">{t("admin.latLabel")}</label>
+                <label className="block text-2xs text-stone-400 mb-1">{t("admin.latLabel")}</label>
                 <input type="number" step="any" value={formData.lat} onChange={(e) => updateField("lat", e.target.value)}
                   onBlur={(e) => touch("lat", e.target.value)} placeholder="22.5619" className={cn(styledInput(!!errors.lat))} />
                 {errors.lat && <p className="text-xs text-red-500 mt-1">{errors.lat}</p>}
               </div>
               <div>
-                <label className="block text-[11px] text-stone-400 dark:text-stone-500 mb-1">{t("admin.lngLabel")}</label>
+                <label className="block text-2xs text-stone-400 dark:text-stone-500 mb-1">{t("admin.lngLabel")}</label>
                 <input type="number" step="any" value={formData.lng} onChange={(e) => updateField("lng", e.target.value)}
                   onBlur={(e) => touch("lng", e.target.value)} placeholder="114.1985" className={cn(styledInput(!!errors.lng))} />
                 {errors.lng && <p className="text-xs text-red-500 mt-1">{errors.lng}</p>}

--- a/frontend/src/components/features/location-form/location-form-settings-fields.tsx
+++ b/frontend/src/components/features/location-form/location-form-settings-fields.tsx
@@ -136,7 +136,7 @@ export function LocationFormSettingsFields({ formData, allTags, updateField }: L
   }, [formData.extra, moveItem, updateField]);
   return (<>
     <SectionCard icon={<Settings className="h-4 w-4" />} title={t("admin.formSettingsTitleRecommended")} collapsible defaultOpen={true}
-      badge={<span className="text-[10px] text-stone-400 dark:text-stone-500 bg-stone-100 dark:bg-stone-800 px-2 py-0.5 rounded-full">{t("admin.optionalBadge")}</span>}>
+      badge={<span className="text-3xs text-stone-400 dark:text-stone-500 bg-stone-100 dark:bg-stone-800 px-2 py-0.5 rounded-full">{t("admin.optionalBadge")}</span>}>
       <div className="space-y-2">
       <SubSectionCard title={t("admin.formFacilitiesTitle")} defaultOpen={true}>
         <Field label="" hint="">{/* label 在 SubSectionCard title 中 */}

--- a/frontend/src/components/features/locations/locations-hero.tsx
+++ b/frontend/src/components/features/locations/locations-hero.tsx
@@ -92,7 +92,7 @@ export function LocationsHero({
                       <span className="text-sm font-semibold leading-tight" style={{ color: isActive ? "#fff" : "#1c1917" }}>{cfg.label}</span>
                       {isActive && <span className="w-4 h-4 rounded-full flex items-center justify-center flex-shrink-0" style={{ background: "rgba(255,255,255,0.25)" }}><X className="h-2.5 w-2.5 text-white" /></span>}
                     </div>
-                    <p className="text-[11px] leading-tight mt-0.5 truncate" style={{ color: isActive ? "rgba(255,255,255,0.75)" : "#78716c" }}>{cfg.desc}</p>
+                    <p className="text-2xs leading-tight mt-0.5 truncate" style={{ color: isActive ? "rgba(255,255,255,0.75)" : "#78716c" }}>{cfg.desc}</p>
                   </div>
                 </button>
               );

--- a/frontend/src/components/features/register-client.tsx
+++ b/frontend/src/components/features/register-client.tsx
@@ -202,7 +202,7 @@ export function RegisterClient() {
           <div className="w-full max-w-sm">
             {/* 标题 */}
             <div className="mb-7">
-              <h1 className="text-2xl font-bold mb-1.5 text-foreground">
+              <h1 className="text-page-h1 mb-1.5">
                 {t("auth.registerTitle")}
               </h1>
               <p className="text-sm text-muted-foreground">

--- a/frontend/src/components/features/team-detail/team-detail-members.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-members.tsx
@@ -119,7 +119,7 @@ export function MemberAvatarGrid({
                 +{hidden}
               </span>
             </div>
-            <p className="text-[10px] text-muted-foreground/60">{t('teams.viewAll')}</p>
+            <p className="text-3xs text-muted-foreground/60">{t('teams.viewAll')}</p>
           </button>
         )}
       </div>

--- a/frontend/src/components/features/teams/teams-ui.tsx
+++ b/frontend/src/components/features/teams/teams-ui.tsx
@@ -337,7 +337,7 @@ export function TeamsHeader({
             )}>
             <Filter className="h-4 w-4" />
             {activeFiltersCount > 0 && (
-              <span className="absolute -top-1 -right-1 w-4 h-4 bg-amber-600 text-white text-[10px] rounded-full flex items-center justify-center font-bold">{activeFiltersCount}</span>
+              <span className="absolute -top-1 -right-1 w-4 h-4 bg-amber-600 text-white text-3xs rounded-full flex items-center justify-center font-bold">{activeFiltersCount}</span>
             )}
           </button>
         </div>

--- a/frontend/src/components/features/terms-client.tsx
+++ b/frontend/src/components/features/terms-client.tsx
@@ -31,7 +31,7 @@ export function TermsClient() {
             <span className="mx-2">/</span>
             <span className="text-stone-600 dark:text-stone-400">{t("content.terms.pageTitle")}</span>
           </nav>
-          <h1 className="text-3xl font-bold text-foreground mb-3">{t("content.terms.pageTitle")}</h1>
+          <h1 className="text-page-h1 mb-3">{t("content.terms.pageTitle")}</h1>
           <p className="text-stone-500 dark:text-stone-400 mb-2">{t("content.terms.pageSubtitle")}</p>
           <p className="text-sm text-stone-400 dark:text-stone-500">{t("content.terms.lastUpdated")}</p>
         </div>

--- a/frontend/src/components/layout/navbar.tsx
+++ b/frontend/src/components/layout/navbar.tsx
@@ -245,7 +245,7 @@ export function Navbar({ className }: NavbarProps) {
                             {t("nav.messages")}
                           </span>
                           {unreadCount > 0 && (
-                            <span className="min-w-5 rounded-full bg-red-500 px-1.5 py-0.5 text-center text-[11px] font-medium leading-none text-white">
+                            <span className="min-w-5 rounded-full bg-red-500 px-1.5 py-0.5 text-center text-2xs font-medium leading-none text-white">
                               {unreadCount > 99 ? "99+" : unreadCount}
                             </span>
                           )}
@@ -412,7 +412,7 @@ export function Navbar({ className }: NavbarProps) {
                     <MessageCircle className="h-4 w-4 text-muted-foreground" />
                     {t("nav.messages")}
                     {unreadCount > 0 && (
-                      <span className="ml-1 min-w-5 rounded-full bg-red-500 px-1.5 py-0.5 text-center text-[11px] font-medium leading-none text-white">
+                      <span className="ml-1 min-w-5 rounded-full bg-red-500 px-1.5 py-0.5 text-center text-2xs font-medium leading-none text-white">
                         {unreadCount > 99 ? "99+" : unreadCount}
                       </span>
                     )}

--- a/frontend/src/components/ui/avatar.tsx
+++ b/frontend/src/components/ui/avatar.tsx
@@ -14,7 +14,7 @@ interface AvatarProps {
 
 export function Avatar({ src, name, size = "sm", className, style }: AvatarProps) {
   const sizeClass = {
-    xs: "h-6 w-6 text-[10px]",
+    xs: "h-6 w-6 text-3xs",
     sm: "h-7 w-7 text-xs",
     md: "h-9 w-9 text-sm",
   }[size];

--- a/frontend/src/components/ui/cover-image-upload/cover-image-upload.tsx
+++ b/frontend/src/components/ui/cover-image-upload/cover-image-upload.tsx
@@ -435,7 +435,7 @@ export function CoverImageUpload({ value, onChange, disabled = false }: CoverIma
                 e.stopPropagation();
                 setUploadState({ phase: "idle" });
               }}
-              className="mt-1 text-xs underline text-destructive hover:text-destructive/80"
+              className="mt-1 text-xs underline underline-offset-2 text-destructive hover:text-destructive/80"
             >
               {t("ui.upload.uploadRetry")}
             </button>

--- a/frontend/src/components/ui/multi-image-upload.tsx
+++ b/frontend/src/components/ui/multi-image-upload.tsx
@@ -362,11 +362,11 @@ export function MultiImageUpload({
               /* 错误态 */
               <div className="flex flex-col items-center gap-1 p-2 text-center">
                 <AlertCircle className="h-5 w-5 text-red-400" />
-                <span className="text-[10px] text-red-500 leading-tight">{item.error}</span>
+                <span className="text-3xs text-red-500 leading-tight">{item.error}</span>
                 <button
                   type="button"
                   onClick={() => handleClearError(item.key)}
-                  className="text-[10px] underline text-red-400 hover:text-red-600"
+                  className="text-3xs underline underline-offset-2 text-red-400 hover:text-red-600"
                 >
                   {t("ui.upload.removeItem")}
                 </button>
@@ -375,7 +375,7 @@ export function MultiImageUpload({
               /* 上传中态 */
               <div className="flex flex-col items-center gap-1">
                 <CircularProgress progress={item.progress ?? 0} />
-                <span className="text-[10px] text-stone-400">{item.progress}%</span>
+                <span className="text-3xs text-stone-400">{item.progress}%</span>
               </div>
             )}
           </div>
@@ -398,7 +398,7 @@ export function MultiImageUpload({
             )}
           >
             <Plus className="h-5 w-5 text-stone-400" />
-            <span className="text-[10px] text-stone-400">{t('ui.upload.addImage')}</span>
+            <span className="text-3xs text-stone-400">{t('ui.upload.addImage')}</span>
           </button>
         )}
       </div>

--- a/frontend/src/components/ui/status-badge.tsx
+++ b/frontend/src/components/ui/status-badge.tsx
@@ -88,7 +88,7 @@ export function StatusBadge({
     <span
       className={cn(
         "badge-base font-medium border",
-        size === "sm" ? "px-2 py-0.5 text-[11px]" : "px-2.5 py-1 text-xs",
+        size === "sm" ? "px-2 py-0.5 text-2xs" : "px-2.5 py-1 text-xs",
         className
       )}
       style={{ background: s.bg, color: s.text, borderColor: s.border }}
@@ -136,7 +136,7 @@ export function DifficultyBadge({
       className={cn(
         "inline-flex items-center font-medium",
         size === "sm"
-          ? "px-1.5 py-0.5 text-[10px] rounded"
+          ? "px-1.5 py-0.5 text-3xs rounded"
           : "px-2 py-0.5 text-xs rounded-md",
         className
       )}

--- a/frontend/src/pages/messages/index.astro
+++ b/frontend/src/pages/messages/index.astro
@@ -259,7 +259,7 @@ const copy = {
 
         if (unreadCount > 0) {
           const badge = document.createElement("span");
-          badge.className = "inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full bg-destructive px-1.5 text-[11px] font-semibold leading-none text-white dark:text-neutral-900";
+          badge.className = "inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full bg-destructive px-1.5 text-2xs font-semibold leading-none text-white dark:text-neutral-900";
           badge.setAttribute("aria-label", `${unreadCount} ${copy.unreadMessages}`);
           badge.textContent = unreadCount > 99 ? "99+" : String(unreadCount);
           footerDiv.appendChild(badge);

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -252,6 +252,36 @@
     from { opacity: 1; }
     to   { opacity: 0; }
   }
+  /* ============================================================
+   Type Scale (v3.0) — semantic font sizes for typography roles
+   ============================================================
+   Use these in components instead of magic-number utilities.
+   Per better-typography skill Principle #5: "Use a Type Scale
+   with Semantic Names". The 3xs/2xs entries clean up the 24+
+   text-[10px]/text-[11px] arbitrary values that were scattered
+   across badges / avatar stacks / notification dots.
+   ============================================================ */
+  --text-3xs:       0.625rem;                /* 10px */
+  --text-3xs--line-height: 0.875rem;          /* 14px */
+  --text-2xs:       0.6875rem;               /* 11px */
+  --text-2xs--line-height: 1rem;              /* 16px */
+
+  /* Page-level h1 — page title (canonical 24px / leading-tight / 700) */
+  --text-page-h1:        1.5rem;              /* 24px */
+  --text-page-h1--line-height: 1.2;
+  --text-page-h1--font-weight: 700;
+  --text-page-h1--letter-spacing: -0.02em;
+
+  /* Section h2 — section/subsection heading (18px / 600) */
+  --text-section-h2:     1.125rem;            /* 18px */
+  --text-section-h2--line-height: 1.3;
+  --text-section-h2--font-weight: 600;
+  --text-section-h2--letter-spacing: -0.01em;
+
+  /* Card h3 — heading inside a card (16px / 600) */
+  --text-card-h3:        1rem;                /* 16px */
+  --text-card-h3--line-height: 1.4;
+  --text-card-h3--font-weight: 600;
 }
 
 /* ============================================================
@@ -440,9 +470,12 @@
   body {
     @apply bg-background text-foreground font-sans;
     line-height: 1.6;
-    font-feature-settings: "liga" 1, "calt" 1;
+    font-variant-ligatures: common-ligatures contextual;
   }
 
+  h1, h2, h3 {
+    text-wrap: balance;
+  }
   h1, h2, h3, h4, h5, h6 {
     line-height: 1.25;
   }
@@ -994,6 +1027,7 @@
   .story-prose :where(p) {
     margin-bottom: 1.125rem;
     line-height: 1.85;
+    text-wrap: pretty;
   }
 
   .story-prose :where(h1) {


### PR DESCRIPTION
## Summary

Promote the typography rules locked in PR #498 to a single discoverable section of `docs/design-system.md`:

| # | Rule | better-typography principle |
| --- | --- | --- |
| 10.1 | Type scale — 5 semantic tokens (`text-3xs/2xs/page-h1/section-h2/card-h3`) replacing 38 arbitrary `text-[Xpx]` values + magic `text-2xl font-bold` page-H1 strings | #5 (Type Scale with Semantic Names) |
| 10.2 | One `<h1>` per render path; loading/empty/error states use `<h2>` | (better-accessibility principle) |
| 10.3 | `text-wrap: balance` on h1-h3 + `text-wrap: pretty` on long-form paragraphs | #5 + #6 |
| 10.4 | Properties over raw tags — `font-variant-ligatures` over `font-feature-settings`, `font-weight` over `"wght"` axis, etc. | #2 |
| 10.5 | Every `line-clamp-N` heading exposes full text via `title={…}` | "Keep useful text selectable" |
| 10.6 | iOS input zoom — always `text-base` or `text-sm sm:text-base` in `<input>` | ("Inputs below 16px zoom on iOS") |

## Why in `docs/design-system.md` (not a new doc)

Same reasoning as the §9 motion section in PR #497: these rules are project-level design decisions, just like the OKLCH (§1-§8) and motion (§9) sections. Splitting them would duplicate reader context (browser matrix, token references). Promoting to a new §10 keeps the design-system doc as the single "read me before touching styles" entry point.

Doc grows 150 → 247 lines. Still well within the threshold for keeping the design system as one file.

## Verification

| Check | Result |
| --- | --- |
| `pnpm --filter @gomate/frontend i18n:validate` | PASS (0 errors / 0 warnings) |

## Refs

- PR #494: OKLCH + WCAG fixes (color tokens §1-§8)
- PR #495: this doc created
- PR #496: motion polish (§9)
- PR #498: typography polish (§10) — the rules being promoted here
- `/better-typography` skill: `~/.codex/skills/better-typography/SKILL.md`
- `/better-accessibility` skill (heading semantics): `~/.codex/skills/better-accessibility/SKILL.md`
