### PR TITLE
refactor(frontend): truncated-text title attrs + P2 control distinctness

### DIFF
--- a/frontend/src/components/features/discover/featured-story-card.tsx
+++ b/frontend/src/components/features/discover/featured-story-card.tsx
@@ -128,13 +128,13 @@ export function FeaturedStoryCard({ story, onClick, className }: FeaturedStoryCa
               {story.author?.name?.charAt(0) || "?"}
             </div>
           )}
-          <span className="text-sm text-muted-foreground truncate">
+          <span title={story.author?.name || t("content.discover.anonymous")} className="text-sm text-muted-foreground truncate">
             {story.author?.name || t("content.discover.anonymous")}
           </span>
           <span className="text-muted-foreground/40">·</span>
           <span className="text-sm text-muted-foreground shrink-0" suppressHydrationWarning>{formatDate(story.createdAt)}</span>
           {story.location && (
-            <span className="ml-auto text-xs text-primary/80 bg-primary/5 px-2 py-0.5 rounded truncate max-w-[40%]">
+            <span title={story.location.name} className="ml-auto text-xs text-primary/80 bg-primary/5 px-2 py-0.5 rounded truncate max-w-[40%]">
               {story.location.name}
             </span>
           )}

--- a/frontend/src/components/features/discover/share-story-sheet.tsx
+++ b/frontend/src/components/features/discover/share-story-sheet.tsx
@@ -67,7 +67,7 @@ export function ShareStorySheet({ open, onClose, title, storyId, summary, onCopy
             <span className="text-sm font-medium text-muted-foreground">{t("teams.shareOptions")}</span>
             <button onClick={onClose} className="p-1 hover:bg-muted rounded-full transition-colors"><X className="w-4 h-4 text-muted-foreground" /></button>
           </div>
-          <p className="text-sm font-medium text-foreground truncate">{title}</p>
+          <p title={title} className="text-sm font-medium text-foreground truncate">{title}</p>
 
           <div className="grid grid-cols-4 gap-4 py-4">
             <button onClick={handleCopyLink} className="flex flex-col items-center gap-2">

--- a/frontend/src/components/features/discover/story-card.tsx
+++ b/frontend/src/components/features/discover/story-card.tsx
@@ -143,7 +143,7 @@ export function StoryCard({ story, onClick, className }: StoryCardProps) {
                 {story.author?.name?.charAt(0) || "?"}
               </div>
             )}
-            <span className="text-xs text-muted-foreground truncate max-w-[80px]">
+            <span title={story.author?.name || t("content.discover.anonymous")} className="text-xs text-muted-foreground truncate max-w-[80px]">
               {story.author?.name || t("content.discover.anonymous")}
             </span>
           </div>

--- a/frontend/src/components/features/discover/story-detail-ui.tsx
+++ b/frontend/src/components/features/discover/story-detail-ui.tsx
@@ -50,7 +50,7 @@ export function StoryByline({
         <div className="flex min-w-0 items-center gap-3">
           <Avatar src={story.author?.image} name={authorName} size="md" />
           <div className="min-w-0">
-            <p className="truncate text-sm font-medium text-foreground">{authorName}</p>
+            <p title={authorName} className="truncate text-sm font-medium text-foreground">{authorName}</p>
             <p className="text-sm text-muted-foreground">{metrics[0].value}</p>
           </div>
         </div>
@@ -86,7 +86,7 @@ export function RelatedLocationLink({ story, t }: { story: Story; t: TFunction }
           <span className="block text-xs font-medium uppercase text-muted-foreground">
             {t("content.discover.relatedLocation")}
           </span>
-          <span className="block truncate font-semibold text-foreground transition-colors group-hover:text-primary">
+          <span title={story.location.name} className="block truncate font-semibold text-foreground transition-colors group-hover:text-primary">
             {story.location.name}
           </span>
         </span>

--- a/frontend/src/components/features/home/home-team-card.tsx
+++ b/frontend/src/components/features/home/home-team-card.tsx
@@ -90,7 +90,7 @@ export function TeamCard({ team, featured = false }: { team: Team; featured?: bo
             <div className="absolute bottom-0 left-0 right-0 px-3.5 pb-3 pt-6">
               <div className="flex items-center gap-1.5 min-w-0">
                 <MapPin className="h-3.5 w-3.5 text-white/70 flex-shrink-0" />
-                <span className="text-white text-sm font-semibold drop-shadow-sm truncate">{team.location!.name}</span>
+                <span title={team.location!.name} className="text-white text-sm font-semibold drop-shadow-sm truncate">{team.location!.name}</span>
               </div>
             </div>
           </div>
@@ -108,7 +108,7 @@ export function TeamCard({ team, featured = false }: { team: Team; featured?: bo
           {!hasCover && team.location && (
             <div className="flex items-center gap-1.5 mb-2">
               <MapPin className="h-3 w-3 flex-shrink-0 text-amber-600" />
-              <span className="text-xs font-medium truncate text-amber-800 dark:text-amber-300">{team.location.name}</span>
+              <span title={team.location.name} className="text-xs font-medium truncate text-amber-800 dark:text-amber-300">{team.location.name}</span>
               <div className="ml-auto flex-shrink-0">
                 <TeamUrgencyLabel
                   status={team.status}

--- a/frontend/src/components/features/home/local-circle/local-circle-card.tsx
+++ b/frontend/src/components/features/home/local-circle/local-circle-card.tsx
@@ -51,7 +51,7 @@ export const LocalCircleCard = memo(function LocalCircleCard({ location, index =
                 size="sm"
                 tooltip={t("home.localCircle.avatarStack.tooltip")}
               />
-              <span className="text-sm text-stone-700 dark:text-stone-300 truncate">
+              <span title={t("home.localCircle.inAction", { n: location.uniqueVisitors })} className="text-sm text-stone-700 dark:text-stone-300 truncate">
                 {t("home.localCircle.inAction", { n: location.uniqueVisitors })}
               </span>
             </div>

--- a/frontend/src/components/features/home/local-circle/neighbor-team-row.tsx
+++ b/frontend/src/components/features/home/local-circle/neighbor-team-row.tsx
@@ -57,7 +57,7 @@ export const NeighborTeamRow = memo(function NeighborTeamRow({ team, cityName }:
         <div className="mt-1 flex items-center gap-3 text-xs text-stone-600 dark:text-stone-400">
           <span className="inline-flex items-center gap-1 min-w-0">
             <MapPin className="w-3 h-3 flex-shrink-0" strokeWidth={2} />
-            <span className="truncate">{team.locationName}</span>
+            <span title={team.locationName} className="truncate">{team.locationName}</span>
           </span>
           {timeLabel && (
             <span className="inline-flex items-center gap-1 flex-shrink-0">

--- a/frontend/src/components/features/profile-client.tsx
+++ b/frontend/src/components/features/profile-client.tsx
@@ -227,7 +227,7 @@ export function ProfileClient() {
               </span>
 
               {/* 邮箱 */}
-              <p className="mt-1 text-xs text-stone-400 dark:text-zinc-500 truncate max-w-[200px]">{user.email}</p>
+              <p title={user.email ?? undefined} className="mt-1 text-xs text-stone-400 dark:text-zinc-500 truncate max-w-[200px]">{user.email}</p>
             </div>
 
             {/* 操作按钮 */}
@@ -371,7 +371,7 @@ export function ProfileClient() {
                     <a key={team.id} href={`/teams/${team.id}`} className="block group">
                       <div className="px-4 py-3.5 hover:bg-stone-50 dark:hover:bg-zinc-800/50 transition-colors">
                         <div className="flex items-center justify-between gap-2">
-                          <h3 className="text-sm font-medium text-stone-800 dark:text-zinc-100 truncate group-hover:text-[var(--anthropic-accent)] transition-colors">
+                          <h3 title={team.title} className="text-sm font-medium text-stone-800 dark:text-zinc-100 truncate group-hover:text-[var(--anthropic-accent)] transition-colors">
                             {team.title}
                           </h3>
                           <StatusBadge status={team.status} size="sm" />
@@ -416,7 +416,7 @@ export function ProfileClient() {
                     <a key={team.id} href={`/teams/${team.id}`} className="block group">
                       <div className="px-4 py-3.5 hover:bg-stone-50 dark:hover:bg-zinc-800/50 transition-colors">
                         <div className="flex items-center justify-between gap-2">
-                          <h3 className="text-sm font-medium text-stone-800 dark:text-zinc-100 truncate group-hover:text-[var(--anthropic-accent)] transition-colors">
+                          <h3 title={team.title} className="text-sm font-medium text-stone-800 dark:text-zinc-100 truncate group-hover:text-[var(--anthropic-accent)] transition-colors">
                             {team.title}
                           </h3>
                           <StatusBadge status={team.status} size="sm" />

--- a/frontend/src/components/features/team-detail/team-detail-members.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-members.tsx
@@ -84,7 +84,7 @@ export function MemberAvatarGrid({
                   </span>
                 )}
                 {m.wechat && (
-                  <p className="text-xs text-muted-foreground max-w-[60px] truncate text-center leading-tight">
+                  <p title={m.wechat} className="text-xs text-muted-foreground min-w-0 truncate text-center leading-tight">
                     {m.wechat}
                   </p>
                 )}

--- a/frontend/src/components/layout/navbar.tsx
+++ b/frontend/src/components/layout/navbar.tsx
@@ -205,7 +205,7 @@ export function Navbar({ className }: NavbarProps) {
                         name={session.user.nickname || session.user.name}
                         size="xs"
                       />
-                      <span className="max-w-[80px] truncate">{session.user.nickname || session.user.name}</span>
+                      <span title={session.user.nickname || session.user.name} className="max-w-[80px] truncate">{session.user.nickname || session.user.name}</span>
                       <ChevronDown
                         className={cn("h-3.5 w-3.5 transition-transform duration-200", showUserMenu && "rotate-180")}
                       />
@@ -350,7 +350,7 @@ export function Navbar({ className }: NavbarProps) {
                     size="md"
                   />
                   <div className="min-w-0">
-                    <p className="font-semibold text-foreground text-sm truncate">{session.user.nickname || session.user.name}</p>
+                    <p title={session.user.nickname || session.user.name} className="font-semibold text-foreground text-sm truncate">{session.user.nickname || session.user.name}</p>
                   </div>
                 </div>
               </div>

--- a/frontend/src/components/ui/city-select.tsx
+++ b/frontend/src/components/ui/city-select.tsx
@@ -180,6 +180,7 @@ export function CitySelect({
             "truncate",
             selectedCity ? "text-zinc-900" : "text-zinc-400"
           )}
+          title={selectedCity?.name}
         >
           {selectedCity ? selectedCity.name : t("common.selectCity")}
         </span>

--- a/frontend/src/components/ui/sticky-action-bar.tsx
+++ b/frontend/src/components/ui/sticky-action-bar.tsx
@@ -77,7 +77,7 @@ export function StickyActionBar({
             type="button"
             onClick={onDiscard}
             disabled={isSaving}
-            className="text-sm text-stone-500 hover:text-stone-700 disabled:opacity-40 transition-colors px-2 py-1.5"
+            className="text-sm text-stone-500 hover:text-stone-700 hover:bg-stone-100 disabled:opacity-40 disabled:hover:bg-transparent transition-colors rounded-md px-2 py-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             {t("common.discardChanges")}
           </button>


### PR DESCRIPTION
## Summary

Implements the **B scope** of `/better-layout` review. **12 files, +18 / −17** — a mechanical a11y sweep + one P2 control-distinctness fix.

## What's in this PR

### A. Truncate-title sweep (Principle #10: Plan for Growth and Clipping)

16 sites across 12 files — every `max-w-[Xpx] truncate` / plain `truncate` span now exposes the full value via `title={...}` so keyboard / screen-reader users can read the clipped content (same pattern as the typography PR #498's line-clamp `title=` attrs; this is the `truncate`-variant residue).

| File | Sites | Content |
| --- | --- | --- |
| `layout/navbar.tsx` | ×2 | nickname (desktop pill + mobile drawer) |
| `discover/story-card.tsx` | ×1 | author name |
| `discover/featured-story-card.tsx` | ×2 | author + location tag |
| `discover/story-detail-ui.tsx` | ×2 | author + related location |
| `team-detail/team-detail-members.tsx` | ×1 | wechat ID — also **dropped `max-w-[60px]`** → `min-w-0 truncate` (60px box clipped "Chri…" style; now flex-column truncation) |
| `home/home-team-card.tsx` | ×2 | cover location name + body location name |
| `home/local-circle/neighbor-team-row.tsx` | ×1 | locationName |
| `home/local-circle/local-circle-card.tsx` | ×1 | inAction i18n string |
| `profile-client.tsx` | ×3 | email + created-teams / joined-teams titles |
| `discover/share-story-sheet.tsx` | ×1 | sheet title |
| `ui/city-select.tsx` | ×1 | selected city name |

### B. Keep Controls Distinct from Content (Principle #2)

`ui/sticky-action-bar.tsx` — the "放弃更改" (discard) button was text-only (`text-stone-500`) directly adjacent to a `text-stone-600` status line. Now:

```diff
- className="text-sm text-stone-500 hover:text-stone-700 disabled:opacity-40 transition-colors px-2 py-1.5"
+ className="text-sm text-stone-500 hover:text-stone-700 hover:bg-stone-100 disabled:opacity-40
+            disabled:hover:bg-transparent transition-colors rounded-md px-2 py-1.5
+            focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
```

It now reads interactive on hover/focus; disabled stays flat. The primary "保存" CTA keeps its amber fill — hierarchy preserved.

## What this PR does **not** change

- **RTL logical properties** (Principle #3): gomate ships only LTR locales (zh-CN / en / ja); physical `left/right` on icon positioning is deferred — replacing `left-3`→`start-3` etc. without a RTL locale to verify would be an unverifiable change (FYI noted in review).
- **Profile divide-y lists**: kept — bordered container + row dividers is the established settings-list pattern giving each clickable row a target boundary (validated, not noise).
- **Breakpoints**: 166 `md:/lg:` uses are content-driven card grids, no default-only abuse found.
- **Carousels**: already satisfy #5 (68% cards + snap-center peek ~30%).

## Verification

| Check | Result |
| --- | --- |
| `pnpm --filter @gomate/frontend build` | PASS |
| `pnpm --filter @gomate/frontend i18n:validate` | PASS (0 errors / 0 warnings) |

Not verified live: rendered truncation at 320px viewport (needs dev server + browser resize); JA locale string lengths (gomate ships ja poster UI — card titles longer than zh).

## Risk / rollback

- Visual: zero on light theme (title attr only). The wechat-ID change (`max-w-[60px]` → `min-w-0`) can shift truncation point — verify on `/teams/:id` members section.
- No API / i18n-key / CSS-token changes.
- Rollback: `git revert 192eda8`.

## Refs

- `/better-layout` skill: `~/.codex/skills/better-layout/SKILL.md`
- Prior: PR #498 typography (line-clamp `title=` attrs — same pattern)
