### PR TITLE
refactor: simplify location detail presentation

### DIFF
--- a/frontend/src/components/features/activity-posts/location-activity-posts.tsx
+++ b/frontend/src/components/features/activity-posts/location-activity-posts.tsx
@@ -10,9 +10,15 @@ import { Mountain, Loader2 } from "lucide-react";
 interface LocationActivityPostsProps {
   locationId: string;
   className?: string;
+  /** 不让没有内容的次要区块占据详情页首屏之后的大段空间。 */
+  hideEmpty?: boolean;
 }
 
-export function LocationActivityPosts({ locationId, className }: LocationActivityPostsProps) {
+export function LocationActivityPosts({
+  locationId,
+  className,
+  hideEmpty = false,
+}: LocationActivityPostsProps) {
   const { t } = useI18n(["teams"]);
   const [posts, setPosts] = React.useState<ActivityPost[]>([]);
   const [isLoading, setIsLoading] = React.useState(true);
@@ -47,6 +53,8 @@ export function LocationActivityPosts({ locationId, className }: LocationActivit
   }
 
   if (posts.length === 0) {
+    if (hideEmpty) return null;
+
     return (
       <div className={cn("bg-card rounded-2xl border border-border", className)}>
         <div className="p-6 border-b border-border">

--- a/frontend/src/components/features/location-detail-client.tsx
+++ b/frontend/src/components/features/location-detail-client.tsx
@@ -957,9 +957,9 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
             <div>
               <TeamListSection teams={teams} locationId={location.id} />
             </div>
-            <DecisionBlock location={location} />
+            <DecisionBlock location={location} showGear={false} />
             <div>
-              <LocationActivityPosts locationId={location.id} />
+              <LocationActivityPosts locationId={location.id} hideEmpty />
             </div>
           </div>
 
@@ -969,7 +969,9 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
               <div className="hidden space-y-4 lg:block">
                 <ActionCard location={location} teams={teams} />
               </div>
-              <RelatedLocations locations={relatedLocations} />
+              <div className="hidden lg:block">
+                <RelatedLocations locations={relatedLocations} />
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/components/features/location-detail/decision-block.tsx
+++ b/frontend/src/components/features/location-detail/decision-block.tsx
@@ -18,6 +18,10 @@ type Translate = (key: string, vars?: Record<string, string | number>) => string
 
 interface DecisionBlockProps {
   location: Location;
+  /**
+   * 地点页的徒步攻略已经展示装备和注意事项；其他复用场景仍可保留完整决策信息。
+   */
+  showGear?: boolean;
 }
 
 /**
@@ -36,7 +40,7 @@ function hasValidCoords(
   );
 }
 
-export function DecisionBlock({ location }: DecisionBlockProps) {
+export function DecisionBlock({ location, showGear = true }: DecisionBlockProps) {
   const { t } = useI18n(["locationDetail", "common"]);
 
   const hasCoords = hasValidCoords(location.coordinates);
@@ -45,9 +49,9 @@ export function DecisionBlock({ location }: DecisionBlockProps) {
   const parkingInfo = (location.parkingInfo ?? "").trim();
   const hasParking = parkingAvailable !== null || parkingInfo.length > 0;
 
-  const gearEssential = location.gearEssential ?? [];
-  const gearOptional = location.gearOptional ?? [];
-  const hiking = normalizeLocationHiking(location);
+  const gearEssential = showGear ? location.gearEssential ?? [] : [];
+  const gearOptional = showGear ? location.gearOptional ?? [] : [];
+  const hiking = showGear ? normalizeLocationHiking(location) : null;
   const gearWarnings = hiking?.warnings ?? [];
   const hasGear =
     gearEssential.length > 0 ||

--- a/frontend/src/components/features/location-detail/team-list-section.tsx
+++ b/frontend/src/components/features/location-detail/team-list-section.tsx
@@ -71,21 +71,12 @@ export function TeamListSection({ teams, locationId }: TeamListSectionProps) {
 function EmptyTeamsState({ locationId }: { locationId: string }) {
   const { t } = useI18n(["locations", "common"]);
   return (
-    <div className="flex flex-col items-center py-10">
-      <div className="relative mb-5">
-        <div className="w-16 h-16 rounded-full bg-amber-50 dark:bg-amber-950/30 flex items-center justify-center">
-          <div className="w-11 h-11 rounded-full bg-amber-100/80 dark:bg-amber-900/40 flex items-center justify-center">
-            <Users
-              className="h-6 w-6 text-amber-400 motion-reduce:animate-none"
-              style={{ animation: "float 3s ease-in-out infinite" }}
-            />
-          </div>
-        </div>
-        <div className="absolute -top-1 -right-1 w-3.5 h-3.5 rounded-full bg-amber-200 dark:bg-amber-800" />
-        <div className="absolute -bottom-1.5 -left-1.5 w-2.5 h-2.5 rounded-full bg-amber-200 dark:bg-amber-800" />
+    <div className="flex flex-col items-center py-6 sm:py-8">
+      <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-amber-50 dark:bg-amber-950/30">
+        <Users className="h-5 w-5 text-amber-500" />
       </div>
 
-      <p className="text-stone-500 dark:text-stone-400 text-sm text-center max-w-xs leading-relaxed mb-5">
+      <p className="mb-4 max-w-xs text-center text-sm leading-relaxed text-stone-500 dark:text-stone-400">
         {t('locations.detailNoTeamsDesc')}
       </p>
 


### PR DESCRIPTION
## 变更
- 精简地点详情页的信息层级，徒步攻略统一承载装备和注意事项
- 地点页决策区仅保留交通与停车信息
- 空活动记录不再渲染大块占位卡
- 移动端隐藏相关地点，桌面侧栏保留
- 压缩队伍空态的视觉占用，保留召集队伍入口

## UX 目标
将地点详情页收敛为“判断 → 选择 → 出发”，减少重复信息和低价值空态对主路径的干扰。

## 验证
- `pnpm i18n:build`
- `pnpm --filter @gomate/frontend i18n:validate`
- `pnpm --filter @gomate/frontend type-check`
- `pnpm --filter @gomate/frontend lint`
- `pnpm --filter @gomate/frontend test -- --run`（199/199）
- `pnpm --filter @gomate/frontend build`
- Playwright 验证 320/768/1440：无横向溢出、无控制台错误、无嵌套交互控件

## 风险与回滚
仅修改前端展示层，未改 API、数据模型、数据库或生产配置；回滚该提交即可恢复。