### PR TITLE
fix: ignore unapplied legacy migrations in drift check

### DIFF
--- a/api/scripts/check-migrations-drift.mjs
+++ b/api/scripts/check-migrations-drift.mjs
@@ -2,7 +2,7 @@
 /**
  * check-migrations-drift.mjs
  *
- * v1.1 规约第 4 条：远端 D1 d1_migrations 表与本仓 _journal.json 条目数对比。
+ * v1.1 规约第 4 条：远端 D1 d1_migrations 表与本仓 migration 名称对比。
  * deploy 前置 check（drift >0 则 abort）+ 每日定时兜底。
  *
  * 用法：node scripts/check-migrations-drift.mjs [--env <envName>] [--quiet]
@@ -18,10 +18,11 @@
  * 任务边界：不动 v1.0 三条款、不改 #456、不动 D1 schema。
  */
 
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execSync } from "node:child_process";
+import { compareMigrationState } from "./migration-drift.mjs";
 
 const apiRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const journalPath = join(apiRoot, "db", "migrations", "meta", "_journal.json");
@@ -31,11 +32,21 @@ const envIndex = args.indexOf("--env");
 const env = envIndex >= 0 ? args[envIndex + 1] : "staging";
 const quiet = args.includes("--quiet");
 
-// 1. 读取本地 journal entries 数
-let journalCount;
+// 1. 读取本地 journal 和 migration 文件
+let localNames;
+let legacyNames;
 try {
   const journal = JSON.parse(readFileSync(journalPath, "utf8"));
-  journalCount = (journal.entries ?? []).length;
+  localNames = (journal.entries ?? []).map((entry) => `${entry.tag}.sql`);
+  const localNameSet = new Set(localNames);
+  legacyNames = readdirSync(join(apiRoot, "db", "migrations"))
+    .filter((name) => name.endsWith(".sql"))
+    .filter((name) => localNameSet.has(name))
+    .filter((name) =>
+      readFileSync(join(apiRoot, "db", "migrations", name), "utf8").includes(
+        "legacy manual migration (pre-drizzle era)",
+      ),
+    );
 } catch (err) {
   if (!quiet) console.error(`⚠ 无法读取 _journal.json: ${err.message}`);
   process.exit(2);
@@ -46,8 +57,8 @@ const apiToken = process.env.CLOUDFLARE_API_TOKEN;
 const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
 const hasToken = Boolean(apiToken);
 
-// 3. 查询远端 D1 账本行数
-let remoteCount;
+// 3. 查询远端 D1 账本中的 migration 名称
+let remoteNames;
 try {
   const dbName = env === "production" ? "gomate-db" : "gomate-db-staging";
 
@@ -60,48 +71,47 @@ try {
   }
 
   const result = execSync(
-    `npx wrangler d1 execute "${dbName}" --command "SELECT COUNT(*) AS cnt FROM d1_migrations" --json --remote${env === "staging" ? " --env staging" : ""}`,
+    `npx wrangler d1 execute "${dbName}" --command "SELECT name FROM d1_migrations ORDER BY id" --json --remote${env === "staging" ? " --env staging" : ""}`,
     {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
       timeout: 30_000,
       env: envVars,
-    }
+    },
   );
 
-  // wrangler d1 execute --json 返回数组 [{results:[{cnt:N}]}]
+  // wrangler d1 execute --json 返回数组 [{results:[{name:"..."}]}]
   const parsed = JSON.parse(result);
   const rows = parsed[0]?.results ?? [];
-  remoteCount = Number(rows[0]?.cnt ?? 0);
+  remoteNames = rows.map((row) => String(row.name ?? "")).filter(Boolean);
 } catch (err) {
   // 远端不可达：静默 skip，下次重试
   if (!quiet) console.error(`⚠ 远端 D1 不可达 (${env}): ${err.message}`);
   process.exit(2);
 }
 
-// 4. 漂移判定
-const diff = remoteCount - journalCount;
+// 4. 漂移判定。legacy baseline migration 允许在远端缺失。
+const { missing, unexpected } = compareMigrationState({
+  localNames,
+  legacyNames,
+  remoteNames,
+});
 
-if (diff === 0) {
-  if (!quiet) console.log(`✓ 无漂移 (${env}): journal=${journalCount}, d1_migrations=${remoteCount}`);
+if (missing.length === 0 && unexpected.length === 0) {
+  if (!quiet) {
+    console.log(
+      `✓ 无漂移 (${env}): local=${localNames.length}, remote=${remoteNames.length}, legacy-baseline=${legacyNames.length}`,
+    );
+  }
   process.exit(0);
 }
 
-if (diff > 0) {
-  const msg = `[${env.toUpperCase()} 漂移告警] ${new Date().toISOString()}
-  journal=${journalCount}, d1_migrations=${remoteCount}, diff=+${diff}
-  status: stale — 远端 migration 数超过本仓 _journal.json
-  action: 补齐 migration 文件 + journal entry（按 v1.0 规则 5 急救 SOP）
-  inspect: https://dash.cloudflare.com/${accountId ? accountId : "<account_id>"}/workers/d1/${env === "production" ? "gomate-db" : "gomate-db-staging"}`;
-  console.error(msg);
-  process.exit(1);
-}
-
-// diff < 0
 const msg = `[${env.toUpperCase()} 漂移告警] ${new Date().toISOString()}
-journal=${journalCount}, d1_migrations=${remoteCount}, diff=${diff}
-status: future — 本仓 migration 文件超前远端
-action: 检查 pipeline 是否应用所有迁移 / deploy 是否失败
+local=${localNames.length}, remote=${remoteNames.length}, legacy-baseline=${legacyNames.length}
+missing: ${missing.length > 0 ? missing.join(", ") : "none"}
+unexpected: ${unexpected.length > 0 ? unexpected.join(", ") : "none"}
+status: migration name set mismatch
+action: 检查 pipeline 是否应用所有迁移，或是否存在未纳入仓库的远端 migration
 inspect: https://dash.cloudflare.com/${accountId ? accountId : "<account_id>"}/workers/d1/${env === "production" ? "gomate-db" : "gomate-db-staging"}`;
 console.error(msg);
 process.exit(1);

--- a/api/scripts/check-migrations-drift.test.mjs
+++ b/api/scripts/check-migrations-drift.test.mjs
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { compareMigrationState } from "./migration-drift.mjs";
+
+describe("compareMigrationState", () => {
+  it("does not report missing legacy baseline migrations as drift", () => {
+    const result = compareMigrationState({
+      localNames: [
+        "0000_bright_jackpot.sql",
+        "0001_init.sql",
+        "0018_add_actor_api_key_id.sql",
+      ],
+      legacyNames: ["0001_init.sql"],
+      remoteNames: ["0000_bright_jackpot.sql", "0018_add_actor_api_key_id.sql"],
+    });
+
+    expect(result).toEqual({
+      missing: [],
+      unexpected: [],
+    });
+  });
+
+  it("reports a real local migration missing remotely", () => {
+    const result = compareMigrationState({
+      localNames: ["0000_bright_jackpot.sql", "0019_new_feature.sql"],
+      legacyNames: [],
+      remoteNames: ["0000_bright_jackpot.sql"],
+    });
+
+    expect(result.missing).toEqual(["0019_new_feature.sql"]);
+    expect(result.unexpected).toEqual([]);
+  });
+
+  it("reports a remote migration that is not tracked locally", () => {
+    const result = compareMigrationState({
+      localNames: ["0000_bright_jackpot.sql"],
+      legacyNames: [],
+      remoteNames: ["0000_bright_jackpot.sql", "manual_hotfix.sql"],
+    });
+
+    expect(result.missing).toEqual([]);
+    expect(result.unexpected).toEqual(["manual_hotfix.sql"]);
+  });
+});

--- a/api/scripts/migration-drift.mjs
+++ b/api/scripts/migration-drift.mjs
@@ -1,0 +1,23 @@
+/**
+ * Compare local migration names with the migrations recorded by a remote D1.
+ *
+ * Legacy pre-Drizzle migrations are kept in the local journal as no-op
+ * baseline files. They are allowed to be absent remotely because some
+ * environments were created after the baseline was introduced.
+ */
+export function compareMigrationState({
+  localNames,
+  legacyNames,
+  remoteNames,
+}) {
+  const local = new Set(localNames);
+  const legacy = new Set(legacyNames);
+  const remote = new Set(remoteNames);
+
+  const missing = [...local]
+    .filter((name) => !legacy.has(name) && !remote.has(name))
+    .sort();
+  const unexpected = [...remote].filter((name) => !local.has(name)).sort();
+
+  return { missing, unexpected };
+}

--- a/docs/prod-change-policy.md
+++ b/docs/prod-change-policy.md
@@ -45,7 +45,7 @@ pnpm --filter @gomate/api check:migrations
 
 与 v1.0 三条款的 PR 阶段门禁互补，本条款针对**远端 D1 实际状态**漂移（PR 门禁看不到的运行时漂移）。
 
-**告警源**：远端 `d1_migrations` 表行数 vs 本仓 `_journal.json` entries 数。`diff > 0` 为 stale（手工 execute 未补 migration），`diff < 0` 为 future（migration 未应用），`diff === 0` 正常。
+**告警源**：远端 `d1_migrations.name` 集合 vs 本仓 `_journal.json` / migration 文件集合。远端缺少真实 migration 名称为 future（migration 未应用），远端出现本仓未登记名称为 stale（手工 execute 未补 migration）。被 `0000_bright_jackpot` 吸收的 legacy no-op migration 允许在远端缺失，避免新建环境因 baseline 补录记录而误报。
 
 **采集双轨**：
 


### PR DESCRIPTION
## Root cause
`Deploy Staging` failed at `Drift Check` after PR #516 merged. The checker compared `_journal.json` count (27) with remote staging `d1_migrations` count (19), but 8 entries are pre-Drizzle legacy `SELECT 1` baseline migrations absorbed by `0000_bright_jackpot`. They are intentionally absent in staging environments created after the baseline.

## Fix
- Compare migration name sets instead of raw counts.
- Allow only explicitly marked legacy baseline migrations to be absent remotely.
- Continue failing for real local migrations missing remotely or remote migrations not tracked locally.
- Add unit regression tests and update the D1 drift policy documentation.

## Validation
- Staging remote check: passed (`local=27, remote=19, legacy-baseline=8`)
- Drift helper tests: 3 passed
- API migration sync: passed
- API lint/type-check/build: passed
- Isolated full local-circle test: 16 passed

The existing parallel API suite had one unrelated 5-second local-circle timeout; isolated rerun passed. Merging this PR will rerun the staging deployment and allow the existing migration step to register the harmless baseline no-ops.