### PR TITLE
refactor: remove location hiking guide section

### DIFF
--- a/frontend/src/components/features/location-detail-client.tsx
+++ b/frontend/src/components/features/location-detail-client.tsx
@@ -27,7 +27,6 @@ import { Navbar } from "@/components/layout/navbar";
 import { Footer } from "@/components/layout/footer";
 import {
   LocationIntroCard,
-  RouteInfoCard,
   TeamListSection,
 } from "@/components/features/location-detail-main-content";
 import { LocationActivityPosts } from "@/components/features/activity-posts";
@@ -954,7 +953,6 @@ export function LocationDetailClient({ locationId }: LocationDetailClientProps) 
                 showTravelMeta
               />
             </div>
-            <RouteInfoCard location={location} />
             <div>
               <TeamListSection teams={teams} locationId={location.id} />
             </div>


### PR DESCRIPTION
## 变更
- 从地点详情页移除“徒步攻略”独立区块
- 保留 Hero 区的难度、时长、距离、爬升核心指标
- 保留 RouteInfoCard 组件和路线数据工具，避免影响其他页面复用

## UX 目标
地点详情页只保留用户做出“是否出发、是否组队”判断所需的信息，减少大段攻略内容对主路径的干扰。

## 验证
- `pnpm --filter @gomate/frontend type-check`
- `pnpm --filter @gomate/frontend lint`
- `pnpm --filter @gomate/frontend test -- --run`（202/202）
- `pnpm --filter @gomate/frontend build`
- Playwright 验证 320/768/1440：徒步攻略和决策信息均不可见，核心指标、地址导航正常，无横向溢出和控制台错误

## 风险与回滚
仅修改地点详情页前端组合层，未改 API、数据模型、数据库或生产配置；回滚该提交即可恢复。