### PR TITLE
fix: 修复分享海报布局与 i18n

### DIFF
--- a/api/src/__tests__/unit/location-poster.test.ts
+++ b/api/src/__tests__/unit/location-poster.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("satori", () => ({
+  default: vi.fn(async (tree: unknown, options: unknown) =>
+    JSON.stringify({ tree, options }),
+  ),
+}));
+
+import { renderLocationPoster } from "../../templates/share-image/location-poster";
+
+describe("location poster layout", () => {
+  it("keeps the QR footer compact instead of stretching into the poster remainder", async () => {
+    const serialized = await renderLocationPoster({
+      title: "梧桐山",
+      description: "深圳第一高峰，适合周末徒步。",
+      tags: [],
+      qrCodeDataUrl: "data:image/svg+xml;base64,qr",
+      fonts: [],
+    });
+    const rendered = JSON.parse(serialized) as {
+      tree: {
+        props: {
+          children: Array<{ props?: { style?: Record<string, unknown> } }>;
+        };
+      };
+      options: { height: number };
+    };
+
+    const footer = rendered.tree.props.children[2];
+
+    expect(rendered.options.height).toBe(584);
+    expect(footer.props?.style?.flex).toBeUndefined();
+    expect(footer.props?.style?.minHeight).toBe(112);
+  });
+
+  it("localizes season pills for non-Chinese posters", async () => {
+    const serialized = await renderLocationPoster({
+      title: "Wutong Mountain",
+      description: "A short route description.",
+      tags: [],
+      bestSeason: ["spring", "autumn"],
+      locale: "en",
+      fonts: [],
+    });
+
+    expect(serialized).toContain("Spring · Autumn");
+  });
+});

--- a/api/src/routes/share-image.ts
+++ b/api/src/routes/share-image.ts
@@ -3,7 +3,7 @@
  *
  * Replaces the prior four-handler shape (preview, location, team, story)
  * collapsed under one dispatcher in `services/share-image/poster.ts`.
- * Query: ?locale=zh-CN|en | ?refresh=1
+ * Query: ?locale=zh-CN|en|ja | ?refresh=1
  *
  * Skill: `zero-tech-debt` — Step 3 "Reshape around the final product surface".
  */

--- a/api/src/templates/share-image/location-poster.tsx
+++ b/api/src/templates/share-image/location-poster.tsx
@@ -57,20 +57,42 @@ const C = {
 // 尺寸常量
 const W = 375;
 const COVER_H = 210; // 16:9 → 375/211
+export const LOCATION_POSTER_HEIGHT = 584;
+export const LOCATION_POSTER_FOOTER_MIN_HEIGHT = 112;
 const HERO_STRIP = 4;
 const DESC_MAX_LEN = 60; // 描述截断长度（含 3 个省略号字符）
 
 // 季节短标签（用于封面胶囊）
-const SEASON_SHORT: Record<string, string> = {
-  spring: "春",
-  春季: "春",
-  summer: "夏",
-  夏季: "夏",
-  autumn: "秋",
-  秋季: "秋",
-  winter: "冬",
-  冬季: "冬",
-  全年: "全年",
+const SEASON_SHORT: Record<PosterLocale, Record<string, string>> = {
+  "zh-CN": {
+    spring: "春",
+    春季: "春",
+    summer: "夏",
+    夏季: "夏",
+    autumn: "秋",
+    秋季: "秋",
+    winter: "冬",
+    冬季: "冬",
+    全年: "全年",
+  },
+  en: {
+    spring: "Spring",
+    summer: "Summer",
+    autumn: "Autumn",
+    winter: "Winter",
+    全年: "All year",
+  },
+  ja: {
+    spring: "春",
+    春季: "春",
+    summer: "夏",
+    夏季: "夏",
+    autumn: "秋",
+    秋季: "秋",
+    winter: "冬",
+    冬季: "冬",
+    全年: "通年",
+  },
 };
 
 function formatDuration(min: number, max: number): string {
@@ -107,7 +129,8 @@ function formatElevation(m: number): string {
  * - 标题保留白色并增加 sun-glow 微光晕
  * - QR 区域使用极淡 sun-glow 底色，像被晨光打亮
  *
- * 高度固定 696px（展示信息密度足够、且不超过一般朋友圈一屏）
+ * 高度固定 584px。底栏使用最小高度而不是 flex: 1，避免把剩余高度
+ * 变成二维码区域的空白。
  */
 export async function renderLocationPoster(data: LocationPosterData): Promise<string> {
   const {
@@ -152,7 +175,9 @@ export async function renderLocationPoster(data: LocationPosterData): Promise<st
 
   // 季节胶囊
   const seasons = (bestSeason ?? []).filter(Boolean).slice(0, 3);
-  const seasonText = seasons.map((s) => SEASON_SHORT[s] ?? clampText(s, 6)).join(" · ");
+  const seasonText = seasons
+    .map((s) => SEASON_SHORT[locale][s] ?? clampText(s, 6))
+    .join(" · ");
   const displaySubtitle = subtitle ? clampText(subtitle, 28) : null;
   const displayAddress = address ? clampText(address, 38) : null;
 
@@ -168,7 +193,7 @@ export async function renderLocationPoster(data: LocationPosterData): Promise<st
           display: "flex",
           flexDirection: "column",
           width: W,
-          height: 696,
+          height: LOCATION_POSTER_HEIGHT,
           backgroundColor: C.bg,
           fontFamily,
           position: "relative",
@@ -499,7 +524,7 @@ export async function renderLocationPoster(data: LocationPosterData): Promise<st
                 backgroundColor: "rgba(232,144,48,0.04)",
                 borderRadius: 14,
                 border: `1px solid ${C.border}`,
-                flex: 1,
+                minHeight: LOCATION_POSTER_FOOTER_MIN_HEIGHT,
               },
               children: [
                 // 文案
@@ -615,7 +640,7 @@ export async function renderLocationPoster(data: LocationPosterData): Promise<st
     },
     {
       width: W,
-      height: 696,
+      height: LOCATION_POSTER_HEIGHT,
       fonts: fonts.map((f) => ({
         name: f.name,
         data: f.data,

--- a/frontend/src/__tests__/copy.test.ts
+++ b/frontend/src/__tests__/copy.test.ts
@@ -9,8 +9,7 @@ import { hydrateSSRData } from "../i18n";
 
 // 预加载枚举数据到内存缓存
 beforeAll(async () => {
-  // 将两个语言的枚举数据直接注入缓存，避免 fetch
-  const _locales: Locale[] = ["zh-CN", "en"];
+  // 将各语言的枚举数据直接注入缓存，避免 fetch
   const zhEnums = {
     difficulty: { easy: "🌿 轻松", moderate: "⛰ 适中", hard: "🧗 挑战", expert: "🏔 专家" },
     teamStatus: {
@@ -38,6 +37,7 @@ beforeAll(async () => {
   const data: Record<Locale, Record<string, Record<string, unknown>>> = {
     "zh-CN": { enums: zhEnums, common: zhCommon, teams: zhTeams, auth: zhAuth, errors: zhErrors },
     en: { enums: zhEnums, common: zhCommon, teams: zhTeams, auth: zhAuth, errors: zhErrors },
+    ja: { enums: zhEnums, common: zhCommon, teams: zhTeams, auth: zhAuth, errors: zhErrors },
   };
   hydrateSSRData(data);
 });

--- a/frontend/src/__tests__/i18n-locale.test.ts
+++ b/frontend/src/__tests__/i18n-locale.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { getLocaleFromCookie, getLocaleName, SUPPORTED_LOCALES } from "../i18n";
+
+describe("locale support", () => {
+  it("keeps the Japanese locale aligned with the checked-in locale resources", () => {
+    expect(SUPPORTED_LOCALES).toContain("ja");
+    expect(getLocaleFromCookie("gomate_locale=ja")).toBe("ja");
+    expect(getLocaleName("ja")).toBe("日本語");
+  });
+});

--- a/frontend/src/components/features/share-poster-modal.tsx
+++ b/frontend/src/components/features/share-poster-modal.tsx
@@ -181,7 +181,7 @@ export function SharePosterModal({
           <div
             className="overflow-hidden rounded-xl shadow border border-stone-200"
             style={type === "location"
-              ? { aspectRatio: "375 / 696", maxHeight: "min(60dvh, 698px)" }
+              ? { aspectRatio: "375 / 584", maxHeight: "min(60dvh, 584px)" }
               : { aspectRatio: "375 / 468", maxHeight: "min(55dvh, 468px)" }}
           >
             {isLoading ? (

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -11,14 +11,15 @@
 
 // ─── 类型定义 ─────────────────────────────────────────────────────────────────
 
-export type Locale = "zh-CN" | "en";
+export type Locale = "zh-CN" | "en" | "ja";
 
-const SUPPORTED_LOCALES: Locale[] = ["zh-CN", "en"];
+const SUPPORTED_LOCALES: Locale[] = ["zh-CN", "en", "ja"];
 const DEFAULT_LOCALE: Locale = "zh-CN";
 
-// 语言回退链：en → zh-CN
+// 语言回退链：ja → en → zh-CN，en → zh-CN
 const FALLBACK_MAP: Record<Locale, Locale[]> = {
   en: ["zh-CN"],
+  ja: ["en", "zh-CN"],
   "zh-CN": [],
 };
 
@@ -320,7 +321,7 @@ export function getLocale(): Locale {
     return globalThis.__SSR_LOCALE__ ?? DEFAULT_LOCALE;
   }
 
-  const match = document.cookie.match(/gomate_locale=(zh-CN|en)/);
+  const match = document.cookie.match(/gomate_locale=(zh-CN|en|ja)/);
   if (match) return match[1] as Locale;
 
   // task #162：无 cookie 时回退到 SSR 渲染的 locale（html lang 由 Layout 按
@@ -343,7 +344,7 @@ export function setLocale(locale: Locale): void {
  * 从 cookie 字符串中提取 locale（SSR 用）
  */
 export function getLocaleFromCookie(cookieStr: string): Locale {
-  const match = cookieStr.match(/gomate_locale=(zh-CN|en)/);
+  const match = cookieStr.match(/gomate_locale=(zh-CN|en|ja)/);
   if (match) return match[1] as Locale;
   return DEFAULT_LOCALE;
 }
@@ -355,6 +356,7 @@ export function getLocaleName(locale: Locale): string {
   const names: Record<Locale, string> = {
     "zh-CN": "中文",
     en: "English",
+    ja: "日本語",
   };
   return names[locale];
 }

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -54,8 +54,10 @@ function matchAcceptLanguage(header: string): Locale {
   for (const { lang } of langs) {
     if (lang === "zh-cn" || lang === "zh") return "zh-CN";
     if (lang === "en") return "en";
+    if (lang === "ja" || lang === "jp") return "ja";
     if (lang.startsWith("zh")) return "zh-CN";
     if (lang.startsWith("en")) return "en";
+    if (lang.startsWith("ja")) return "ja";
   }
 
   return DEFAULT_LOCALE;

--- a/frontend/src/pages/blog/index.astro
+++ b/frontend/src/pages/blog/index.astro
@@ -30,6 +30,7 @@ function formatDate(date: Date, locale: Locale) {
   const langMap: Record<Locale, string> = {
     "zh-CN": "zh-CN",
     "en": "en-US",
+    "ja": "ja-JP",
   };
   return date.toLocaleDateString(langMap[locale], {
     year: "numeric",

--- a/frontend/src/pages/locations/[id].astro
+++ b/frontend/src/pages/locations/[id].astro
@@ -9,7 +9,7 @@ import { ErrorBoundary } from "../../components/ui/error-boundary";
 import { declareI18nNs } from "../../middleware";
 import { API_BASE } from "../../lib/api";
 
-declareI18nNs(Astro.locals, ["locationDetail", "locations", "errors", "admin", "enums", "teams", "content"]);
+declareI18nNs(Astro.locals, ["locationDetail", "locations", "errors", "admin", "enums", "teams", "share", "content"]);
 
 const { id } = Astro.params;
 

--- a/frontend/src/pages/teams/[id].astro
+++ b/frontend/src/pages/teams/[id].astro
@@ -8,7 +8,7 @@ import { TeamDetailPartiful } from "../../components/features/team-detail-partif
 import { declareI18nNs } from "../../middleware";
 import { API_BASE } from "../../lib/api";
 
-declareI18nNs(Astro.locals, ["teams", "locationDetail", "enums", "profile", "errors", "content"]);
+declareI18nNs(Astro.locals, ["teams", "locationDetail", "enums", "profile", "errors", "share", "content"]);
 
 const { id } = Astro.params;
 


### PR DESCRIPTION
## 变更

- 修复地点海报二维码区域因 `flex: 1` 导致的大面积空白，调整为紧凑布局并同步前端预览比例。
- 为地点详情页、队伍详情页 SSR 注入 `share` namespace，避免分享弹窗显示 `share.download` 等原始 key。
- 对齐已有日语资源的前端 locale 支持，并本地化地点海报季节胶囊文案。
- 增加地点海报布局与 locale 回归测试。

## 验证

- `pnpm --filter @gomate/api lint`
- `pnpm --filter @gomate/api type-check`
- `pnpm --filter @gomate/api build`
- `pnpm --filter @gomate/api test`（320 tests）
- `pnpm i18n:build`
- `pnpm --filter @gomate/frontend i18n:validate`
- `pnpm --filter @gomate/frontend type-check`
- `pnpm --filter @gomate/frontend test`（203 tests）
- `pnpm --filter @gomate/frontend build`

## 风险与回滚

- 未涉及数据库、环境变量、密钥或 Cloudflare 资源。
- 回滚提交 `2050be8` 即可恢复原行为。
