### PR TITLE
fix: 优化分享海报弹窗移动端布局

### DIFF
--- a/frontend/src/__tests__/share-poster-modal-layout.test.tsx
+++ b/frontend/src/__tests__/share-poster-modal-layout.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SharePosterModal } from "../components/features/share-poster-modal";
+
+vi.mock("@/hooks/useI18n", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+    locale: "zh-CN",
+    loading: false,
+    getNsData: () => null,
+  }),
+}));
+
+vi.mock("@/i18n", () => ({
+  getLocale: () => "zh-CN",
+}));
+
+vi.mock("@/lib/api", () => ({
+  API_BASE: "https://api.example.com",
+}));
+
+describe("SharePosterModal layout", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the location poster centered at the available width and preserves action-bar spacing", () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      () => new Promise<Response>(() => undefined),
+    );
+
+    render(
+      <SharePosterModal
+        type="location"
+        id="location-1"
+        title="梧桐山"
+        url="https://gomate.live/locations/location-1"
+        onClose={vi.fn()}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.parentElement).toHaveClass("items-center");
+    expect(screen.getByRole("button", { name: "common.wechat.close" })).toHaveClass(
+      "size-11",
+    );
+
+    const preview = screen.getByTestId("share-poster-preview");
+    expect(preview).toHaveClass("mx-auto", "w-full");
+    expect(preview.parentElement).not.toHaveClass("flex");
+    expect(preview.style.maxHeight).toBe("");
+    expect(preview.style.aspectRatio).toBe("375 / 584");
+
+    const actions = screen.getByTestId("share-poster-actions");
+    expect(actions).toHaveClass(
+      "pb-[max(1rem,env(safe-area-inset-bottom))]",
+    );
+    for (const button of screen.getAllByRole("button").slice(-2)) {
+      expect(button).toHaveClass("min-h-11");
+    }
+  });
+
+  it("keeps the shorter team poster ratio without viewport-height constraints", () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      () => new Promise<Response>(() => undefined),
+    );
+
+    render(
+      <SharePosterModal
+        type="team"
+        id="team-1"
+        title="周末徒步"
+        url="https://gomate.live/teams/team-1"
+        onClose={vi.fn()}
+      />,
+    );
+
+    const preview = screen.getByTestId("share-poster-preview");
+    expect(preview.style.aspectRatio).toBe("375 / 468");
+    expect(preview.style.maxHeight).toBe("");
+  });
+});

--- a/frontend/src/components/features/share-poster-modal.tsx
+++ b/frontend/src/components/features/share-poster-modal.tsx
@@ -157,37 +157,38 @@ export function SharePosterModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto"
+      className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto p-4"
       style={{ background: "rgba(0,0,0,0.6)" }}
       onClick={onClose}
     >
       <div
-        className="mx-4 my-4 flex max-h-[calc(100dvh-2rem)] w-full max-w-sm flex-col rounded-2xl bg-white"
+        className="flex max-h-[calc(100dvh-2rem)] w-full max-w-sm flex-col rounded-2xl bg-white"
         role="dialog"
         aria-modal="true"
         aria-labelledby="share-poster-title"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between px-4 pt-4 pb-2">
-          <span id="share-poster-title" className="text-sm font-semibold text-foreground">
+        <div className="flex items-center justify-between px-4 py-2">
+          <span id="share-poster-title" className="text-base font-semibold text-foreground">
             {type === "team" ? t("share.title") : t("share.locationTitle")}
           </span>
           <button
             onClick={onClose}
-            className="text-lg leading-none text-stone-400 transition-colors hover:text-stone-600"
+            className="-me-2 flex size-11 items-center justify-center rounded-full text-stone-400 transition-colors hover:bg-stone-100 hover:text-stone-600"
             aria-label={t("common.wechat.close")}
           >
-            ✕
+            <X className="size-5" />
           </button>
         </div>
 
         <div className="relative min-h-0 flex-1 overflow-y-auto px-4 pt-2">
           {/* Poster Preview - 根据海报类型动态适配长宽比 */}
           <div
-            className="overflow-hidden rounded-xl shadow border border-stone-200"
+            data-testid="share-poster-preview"
+            className="mx-auto w-full overflow-hidden rounded-xl border border-stone-200 shadow"
             style={type === "location"
-              ? { aspectRatio: "375 / 584", maxHeight: "min(60dvh, 584px)" }
-              : { aspectRatio: "375 / 468", maxHeight: "min(55dvh, 468px)" }}
+              ? { aspectRatio: "375 / 584" }
+              : { aspectRatio: "375 / 468" }}
           >
             {isLoading ? (
               <div className="w-full h-full bg-muted flex flex-col items-center justify-center">
@@ -199,7 +200,7 @@ export function SharePosterModal({
             ) : imageUrl ? (
               <img
                 src={imageUrl}
-                alt="Share Poster"
+                alt={type === "team" ? t("share.title") : t("share.locationTitle")}
                 className="w-full h-full object-contain"
               />
             ) : error ? (
@@ -228,18 +229,21 @@ export function SharePosterModal({
           </div>
         </div>
 
-        <div className="mt-4 flex gap-3 px-4 pb-4 flex-shrink-0 pb-[env(safe-area-inset-bottom)]">
+        <div
+          data-testid="share-poster-actions"
+          className="mt-4 flex flex-shrink-0 gap-3 px-4 pb-[max(1rem,env(safe-area-inset-bottom))]"
+        >
           <button
             onClick={handleDownload}
             disabled={isLoading || !imageUrl}
-            className="flex-1 flex items-center justify-center gap-2 rounded-lg bg-amber-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-amber-600 disabled:opacity-50"
+            className="flex min-h-11 flex-1 items-center justify-center gap-2 rounded-lg bg-amber-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-amber-600 disabled:opacity-50"
           >
             <Download className="w-4 h-4" />
             {t("share.download")}
           </button>
           <button
             onClick={handleCopyLink}
-            className="flex-1 flex items-center justify-center gap-2 rounded-lg border border-stone-300 px-4 py-2 text-sm font-medium text-stone-700 transition-colors hover:border-stone-400"
+            className="flex min-h-11 flex-1 items-center justify-center gap-2 rounded-lg border border-stone-300 px-4 py-2 text-sm font-medium text-stone-700 transition-colors hover:border-stone-400"
           >
             <Link2 className="w-4 h-4" />
             {t("share.copyLink")}


### PR DESCRIPTION
## 问题

移动端分享地点海报仍存在布局失衡：iOS 动态视口下，预览的 viewport-height 上限会让海报收窄并偏左；操作栏安全区样式会覆盖常规底部留白；弹窗固定顶部对齐。

## 改动

- 移除地点/队伍海报预览的视口高度上限，保持原始长宽比并占满可用宽度
- 弹窗在可用视口居中，短屏由预览区域内部滚动
- 操作栏保留至少 16px 底部间距并兼容 safe area
- 下载、复制与关闭按钮达到 44px 触控尺寸
- 海报 alt 改用现有 i18n 文案
- 新增地点与队伍海报布局回归测试

## 验证

- pnpm i18n:build && pnpm --filter @gomate/frontend i18n:validate
- pnpm --filter @gomate/frontend lint（0 errors；2 条既有无关 warnings）
- pnpm --filter @gomate/frontend test（27 files / 205 tests passed）
- pnpm --filter @gomate/frontend type-check（0 errors）
- pnpm --filter @gomate/frontend build
- Chrome DevTools：320x568、390x844、1440x900 均通过；390x844 下海报保持 375:584，操作栏底部 16px，关闭按钮 44x44，控制台无错误或警告

## 风险与回滚

- 影响范围仅分享海报弹窗布局，不改 API、数据、缓存键或部署配置
- 极短视口会滚动预览区，操作栏保持可见
- 回滚方式：revert commit eb61b17

## 生产资源

不涉及数据库、环境变量、Secrets 或 Cloudflare 资源变更。