### PR TITLE
test: fix CI compatibility for share poster tests

### DIFF
--- a/frontend/src/__tests__/share-poster-modal-layout.test.tsx
+++ b/frontend/src/__tests__/share-poster-modal-layout.test.tsx
@@ -26,7 +26,7 @@ describe("SharePosterModal layout", () => {
 
   function mockGeneratedPoster() {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(new Blob(["poster"], { type: "image/png" }), {
+      new Response("poster", {
         status: 200,
         headers: { "content-type": "image/png" },
       }),


### PR DESCRIPTION
## 问题
PR #526 合并后，Deploy Frontend 在 CI 的 Node/jsdom 环境中失败：`new Response(new Blob(...))` 抛出 `TypeError: object.stream is not a function`。本地环境未复现，导致前端部署未执行。

## 修复
将测试夹具的 Response body 从跨 realm 的 `Blob` 改为字符串，保留 image/png 响应头；测试行为和生产代码不变。

## 验证
- `pnpm --filter @gomate/frontend test -- src/__tests__/share-poster-modal-layout.test.tsx`：5 passed
- `pnpm --filter @gomate/frontend test`：27 files / 208 tests passed
- `git diff --check`：passed

## 风险与回滚
仅修改测试夹具，不涉及生产运行时代码、API、数据库、环境变量或 Cloudflare 资源；必要时可 revert 本 PR 提交。