### PR TITLE
fix: restore clickable homepage locations

### DIFF
--- a/frontend/src/__tests__/home-locations-section.test.tsx
+++ b/frontend/src/__tests__/home-locations-section.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { HomeLocationsSection } from "../components/features/home/home-locations-section";
+import type { Location } from "../lib/types";
+
+vi.mock("@/hooks/useI18n", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+    locale: "zh-CN",
+    loading: false,
+    getNsData: () => null,
+  }),
+}));
+
+const location: Location = {
+  id: "loc-1",
+  name: "梧桐山",
+  slug: "wutong-mountain",
+  description: "深圳经典徒步路线",
+  cityId: "city-sz",
+  cityName: "深圳",
+  bestSeason: [],
+  coverImage: "",
+  images: [],
+  coordinates: { lat: 22.6, lng: 114.2 },
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("HomeLocationsSection", () => {
+  it("renders each homepage location as a link to its detail page", () => {
+    render(
+      <HomeLocationsSection
+        data={{
+          locations: [location],
+          isLoading: false,
+          userCity: null,
+          cityMatch: null,
+        } as unknown as Parameters<typeof HomeLocationsSection>[0]["data"]}
+      />,
+    );
+
+    const locationLinks = screen.getAllByRole("link", { name: /梧桐山/ });
+    expect(locationLinks.length).toBeGreaterThan(0);
+    expect(locationLinks.every((link) => link.getAttribute("href") === "/locations/loc-1")).toBe(true);
+  });
+});

--- a/frontend/src/components/features/home/china-map.tsx
+++ b/frontend/src/components/features/home/china-map.tsx
@@ -182,7 +182,7 @@ export function ChinaMap({ className }: { className?: string }) {
         )}
 
         {loading && (
-          <div className="absolute inset-0 flex items-center justify-center bg-card/50">
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-card/50">
             <span className="text-sm text-muted-foreground">{t("common.loading")}</span>
           </div>
         )}

--- a/frontend/src/components/features/home/home-locations-section.tsx
+++ b/frontend/src/components/features/home/home-locations-section.tsx
@@ -1,0 +1,72 @@
+import { ArrowRight, MapPin } from "lucide-react";
+import { useI18n } from "@/hooks/useI18n";
+import type { useHomeData } from "./use-home-data";
+import { LocationCard } from "./home-location-card";
+
+type HomeData = ReturnType<typeof useHomeData>;
+
+export function HomeLocationsSection({ data }: { data: HomeData }) {
+  const { locations, isLoading, locationsRef, locationsInView, userCity, cityMatch } = data;
+  const showViewAllCity = userCity && cityMatch && cityMatch !== "fallback" && locations[0]?.cityName;
+  const locationsUrl = showViewAllCity ? `/locations?cityId=${encodeURIComponent(userCity)}` : "/locations";
+  const { t } = useI18n(["home", "locations", "common"]);
+
+  const showCityChip = userCity && cityMatch && cityMatch !== "fallback" && locations[0]?.cityName;
+  const cityChipName = showCityChip ? locations[0].cityName : null;
+
+  if (!isLoading && locations.length === 0) return null;
+
+  return (
+    <section
+      id="locations"
+      ref={locationsRef}
+      className={`bg-background py-16 sm:py-20 lg:py-24 section-hidden ${locationsInView ? "section-visible" : ""}`}
+    >
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mb-8 max-w-2xl sm:mb-10">
+          <div className="flex flex-wrap items-baseline gap-x-3 gap-y-2">
+            <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">{t("locations.pageTitle")}</h2>
+            {cityChipName && (
+              <span className="inline-flex items-center text-sm font-medium text-stone-600 dark:text-stone-400" data-testid="locations-city-chip">
+                {t("home.locations.cityChip", { city: cityChipName })}
+              </span>
+            )}
+          </div>
+          <p className="mt-3 text-base leading-7 text-stone-700 dark:text-stone-300">{t("locations.pageSubtitle")}</p>
+          {userCity && cityMatch === "fallback" && locations.length > 0 && (
+            <div className="mt-3 flex items-center gap-1.5">
+              <MapPin className="h-3.5 w-3.5 text-amber-700 dark:text-amber-400 flex-shrink-0" />
+              <p className="text-sm font-medium text-amber-700 dark:text-amber-400">{t("home.locations.fallbackHint")}</p>
+            </div>
+          )}
+        </div>
+
+        {isLoading ? (
+          <>
+            <div className="md:hidden flex flex-col gap-2" aria-busy="true" aria-label={t("common.loading")}>
+              {Array.from({ length: 6 }).map((_, i) => <div key={i} className="h-[88px] rounded-xl bg-muted animate-pulse" />)}
+            </div>
+            <div className="hidden md:grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" aria-busy="true" aria-label={t("common.loading")}>
+              {Array.from({ length: 6 }).map((_, i) => <div key={i} className="h-72 rounded-2xl bg-muted animate-pulse" />)}
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="md:hidden flex flex-col gap-2">
+              {locations.map((location, index) => <LocationCard key={location.id} location={location} index={index} compact />)}
+            </div>
+            <div className="hidden md:grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {locations.map((location, index) => <LocationCard key={location.id} location={location} index={index} />)}
+            </div>
+            <div className="text-center mt-14">
+              <a href={locationsUrl} className="group inline-flex items-center gap-2 px-7 py-3.5 border border-border rounded-2xl text-base font-semibold text-foreground transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 hover:border-amber-300 dark:hover:border-amber-700 hover:text-amber-700 dark:hover:text-amber-400 hover:shadow-warm-sm active:scale-[0.96]">
+                {t("common.viewAll")}
+                <ArrowRight className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-0.5" />
+              </a>
+            </div>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/features/home/home-main.tsx
+++ b/frontend/src/components/features/home/home-main.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import { useHomeData, type HomeInitialData } from "./use-home-data";
 import { HomeHero } from "./home-hero";
+import { HomeLocationsSection } from "./home-locations-section";
 import { HomeTeamsSection } from "./home-teams-section";
 import { HomeLocalCircleSection } from "./local-circle/home-local-circle-section";
 import { HomeExploreSection } from "./home-explore-section";
@@ -29,6 +30,7 @@ export function HomeClient({ initialData }: { initialData?: HomeInitialData }) {
       <main className="min-h-screen bg-background">
         <HomeHero data={data} />
         <HomeLocalCircleSection />
+        <HomeLocationsSection data={data} />
         <HomeExploreSection />
         <HomeTeamsSection data={data} />
         {/* P1-1 T2：首次引导流 modal（登录 + 无队伍 + 未看过才弹，gating 全在 hook 内） */}

--- a/frontend/src/components/features/home/use-home-data.ts
+++ b/frontend/src/components/features/home/use-home-data.ts
@@ -17,7 +17,7 @@ export interface HomeInitialData {
  */
 export function useHomeData(initialData?: HomeInitialData, userCity?: string | null) {
   // 使用 SWR 获取地点列表（带缓存 + city 维度）
-  const { locations } = useLocations(1, 6, initialData?.locations, userCity);
+  const { locations, cityMatch, isLoading } = useLocations(1, 6, initialData?.locations, userCity);
 
   const [teams, setTeams] = React.useState<Team[]>(initialData?.teams ?? []);
   const [teamsLoading, setTeamsLoading] = React.useState(!initialData?.teams);
@@ -37,6 +37,7 @@ export function useHomeData(initialData?: HomeInitialData, userCity?: string | n
   const search = useSearchInteraction();
 
   // Section refs
+  const [locationsRef, locationsInView] = useInView(0.08);
   const [teamsRef, teamsInView] = useInView(0.08);
 
   // Data fetchers
@@ -77,9 +78,10 @@ export function useHomeData(initialData?: HomeInitialData, userCity?: string | n
   };
 
   return {
-    locations, teams, teamsLoading, isDark,
+    locations, teams, teamsLoading, isLoading, cityMatch, isDark,
     preloadImages,
     animate, search,
+    locationsRef, locationsInView,
     teamsRef, teamsInView,
     userCity: userCity ?? null,
     handleSearch,


### PR DESCRIPTION
## Summary
- restore the homepage location card section removed by the map-only refactor
- keep city-aware location links and responsive mobile/desktop cards
- make the map loading overlay pass pointer events through
- add a regression test for homepage location detail links

## Verification
- `pnpm --filter @gomate/frontend test` — 27 files, 204 tests passed
- `pnpm --filter @gomate/frontend type-check` — 0 errors
- `pnpm --filter @gomate/frontend lint` — 0 errors, 2 pre-existing warnings
- `pnpm --filter @gomate/frontend build` — passed
- Playwright runtime check — homepage location card navigated to `/locations/:id`

## Risk / rollback
- frontend-only, no API/schema/env changes
- revert commit `0e9a4ba` to roll back