### PR TITLE
perf: 拆分前端丝滑体验改造

### DIFF
--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -44,9 +44,10 @@ export default defineConfig({
       rollupOptions: {
         output: {
           manualChunks: {
-            // 将大型依赖拆分为独立 chunk
+            // 图标库在多个 island 中复用，保持为稳定共享 chunk。
+            // Markdown 只在少数内容型页面使用，不强制注入所有页面的共享 chunk，
+            // 避免首页、地点列表和队伍列表承担无关的 React/Markdown 依赖。
             'vendor-lucide': ['lucide-react'],
-            'vendor-markdown': ['react-markdown', 'remark-gfm'],
           },
         },
       },

--- a/frontend/src/components/features/home/home-hero.tsx
+++ b/frontend/src/components/features/home/home-hero.tsx
@@ -86,7 +86,15 @@ export function HomeHero({ data }: { data: HomeData }) {
         <div className={`relative mx-auto w-full max-w-xl lg:mx-0 ${animate.search}`}>
           <div className="relative aspect-[0.92] overflow-hidden rounded-[2rem] bg-secondary shadow-warm-xl ring-1 ring-black/5 dark:ring-white/10">
             {featuredLocation?.coverImage ? (
-              <img src={featuredLocation.coverImage} alt={featuredLocation.name} className="h-full w-full object-cover outline outline-1 outline-black/10 transition-transform duration-500 hover:scale-[1.02] dark:outline-white/10" />
+              <img
+                src={featuredLocation.coverImage}
+                alt={featuredLocation.name}
+                loading="eager"
+                decoding="async"
+                // @ts-expect-error lowercase `fetchpriority` is the HTML DOM attribute name; React warns about `fetchPriority`
+                fetchpriority="high"
+                className="h-full w-full object-cover outline outline-1 outline-black/10 transition-transform duration-150 hover:scale-[1.02] motion-reduce:transition-none dark:outline-white/10"
+              />
             ) : (
               <div className="flex h-full w-full items-center justify-center bg-[radial-gradient(circle_at_50%_35%,color-mix(in_oklab,var(--primary)_34%,transparent),transparent_34%),linear-gradient(145deg,var(--brand-muted),var(--secondary))]">
                 <Compass className="h-24 w-24 text-primary/40" strokeWidth={1.1} aria-hidden="true" />

--- a/frontend/src/components/features/home/home-hero.tsx
+++ b/frontend/src/components/features/home/home-hero.tsx
@@ -65,7 +65,7 @@ export function HomeHero({ data }: { data: HomeData }) {
             )}
             <button
               type="submit"
-              className={`absolute right-2 top-1/2 -translate-y-1/2 rounded-xl bg-amber-700 px-4 py-2 text-sm font-semibold text-white shadow-brand-glow transition-[background-color,transform,box-shadow] duration-150 hover:bg-amber-800 hover:shadow-brand-glow-lg active:scale-[0.96] ${search.isButtonBouncing ? "animate-bounce-in" : ""}`}
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded-xl bg-amber-700 px-4 py-2 text-sm font-semibold text-white shadow-brand-glow transition-[background-color,transform,box-shadow] duration-150 motion-reduce:transition-none hover:bg-amber-800 hover:shadow-brand-glow-lg active:scale-[0.96]"
             >
               {t("common.search")}
             </button>

--- a/frontend/src/components/features/locations/locations-grid.test.tsx
+++ b/frontend/src/components/features/locations/locations-grid.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { Location } from "@/lib/types";
+import { LocationsGrid } from "./locations-grid";
+
+vi.mock("@/hooks/useI18n", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+    locale: "zh-CN",
+    loading: false,
+    getNsData: () => null,
+  }),
+}));
+
+const location = {
+  id: "wutong-mountain",
+  name: "梧桐山",
+  description: "深圳第一高峰",
+  cityName: "深圳",
+  address: "深圳市罗湖区",
+  coverImage: "https://cos.gomate.live/wutong.jpg",
+  tags: [],
+} as unknown as Location;
+
+describe("LocationsGrid", () => {
+  it("刷新列表时保留现有卡片，只显示忙碌状态", () => {
+    render(
+      <LocationsGrid
+        locations={[location]}
+        isLoading={false}
+        isRefreshing
+        pagination={{ total: 1, totalPages: 1 }}
+        onClear={vi.fn()}
+        currentPage={1}
+        onPageChange={vi.fn()}
+        getPageNumbers={() => [1]}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: /梧桐山/ })).toBeInTheDocument();
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByRole("status").parentElement).toHaveAttribute("aria-busy", "true");
+    expect(screen.queryByText("地点加载中")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/features/locations/locations-grid.tsx
+++ b/frontend/src/components/features/locations/locations-grid.tsx
@@ -262,23 +262,23 @@ export function LocationsGrid({
           </div>
         )}
         <div className={cn("transition-opacity duration-150 motion-reduce:transition-none", isRefreshing && locations.length > 0 && "opacity-60")}>
-        {isLoading ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-            {Array.from({ length: 6 }).map((_, i) => <ShimmerCard key={i} />)}
-          </div>
-        ) : locations.length === 0 ? (
-          <EmptyState
-            variant={emptyVariant ?? "noSearch"}
-            onClearSearch={onClear}
-            onClearAll={onClear}
-          />
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-            {locations.map((location, index) => (
-              <LocationCard key={location.id} location={location} index={index} />
-            ))}
-          </div>
-        )}
+          {isLoading ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+              {Array.from({ length: 6 }).map((_, i) => <ShimmerCard key={i} />)}
+            </div>
+          ) : locations.length === 0 ? (
+            <EmptyState
+              variant={emptyVariant ?? "noSearch"}
+              onClearSearch={onClear}
+              onClearAll={onClear}
+            />
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+              {locations.map((location, index) => (
+                <LocationCard key={location.id} location={location} index={index} />
+              ))}
+            </div>
+          )}
         </div>
       </div>
 
@@ -322,7 +322,7 @@ export function LocationsGrid({
             className="w-9 h-9 rounded-xl flex items-center justify-center bg-popover border border-stone-200 dark:border-stone-700 hover:border-stone-300 dark:hover:border-stone-600 hover:text-stone-700 dark:hover:text-stone-300 disabled:bg-stone-100 disabled:border-stone-200 dark:disabled:bg-stone-900 dark:disabled:border-stone-700 disabled:cursor-not-allowed transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200"
           >
             <span className={cn("text-stone-900 dark:text-stone-100", currentPage === pagination.totalPages && "text-stone-500 dark:text-stone-500")}>
-            <ChevronRight className="h-4 w-4" />
+              <ChevronRight className="h-4 w-4" />
             </span>
           </button>
         </div>

--- a/frontend/src/components/features/locations/locations-grid.tsx
+++ b/frontend/src/components/features/locations/locations-grid.tsx
@@ -1,4 +1,4 @@
-import { MapPin, TreePine, ChevronLeft, ChevronRight, Clock, TrendingUp, ArrowRight, Search, Map, Filter } from "lucide-react";
+import { MapPin, TreePine, ChevronLeft, ChevronRight, Clock, TrendingUp, ArrowRight, Search, Map, Filter, LoaderCircle } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import { cn } from "@/lib/utils";
 import type { Location, Tag } from "@/lib/types";
@@ -32,22 +32,19 @@ function LocationCard({ location, index }: { location: Location; index: number }
   const hiking = normalizeLocationHiking(location);
   const durationText = formatRouteMetric(hiking?.duration, t);
   const distanceText = hiking?.distance?.value;
-  const delayMs = Math.min(index, 5) * 60;
-
   return (
     <a
       href={`/locations/${location.id}`}
       className="group block"
-      style={{ animation: `fade-up 0.35s cubic-bezier(0.16, 1, 0.3, 1) ${delayMs}ms both` }}
     >
-      <article className="bg-card rounded-2xl overflow-hidden border border-border hover:border-amber-200/50 dark:hover:border-amber-800/50 hover:shadow-xl hover:shadow-amber-100/40 dark:hover:shadow-amber-900/20 hover:ring-1 hover:ring-amber-200/40 dark:hover:ring-amber-700/40 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-300 hover:-translate-y-1">
+      <article className="bg-card rounded-2xl overflow-hidden border border-border hover:border-amber-200/50 dark:hover:border-amber-800/50 hover:shadow-xl hover:shadow-amber-100/40 dark:hover:shadow-amber-900/20 hover:ring-1 hover:ring-amber-200/40 dark:hover:ring-amber-700/40 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150 motion-reduce:transition-none hover:-translate-y-1">
         <div className="relative h-52 overflow-hidden bg-stone-100 dark:bg-stone-800">
           {location.coverImage ? (
             <LocationCoverImage
               src={location.coverImage}
               alt={location.name}
               priority={index === 0}
-              className="group-hover:scale-[1.06] transition-transform duration-500 ease-out"
+              className="group-hover:scale-[1.03] transition-transform duration-150 ease-out motion-reduce:transition-none"
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-stone-800 to-stone-900">
@@ -109,7 +106,7 @@ function LocationCard({ location, index }: { location: Location; index: number }
             </span>
             <span className="inline-flex items-center gap-1.5 text-xs font-semibold text-amber-700 dark:text-amber-400 group-hover:text-amber-800 dark:group-hover:text-amber-300 transition-colors">
               {t("common.viewDetail")}
-              <ArrowRight className="h-3.5 w-3.5 transition-transform duration-300 ease-[cubic-bezier(0.34,1.56,0.64,1)] group-hover:translate-x-1" />
+              <ArrowRight className="h-3.5 w-3.5 transition-transform duration-150 ease-out motion-reduce:transition-none group-hover:translate-x-1" />
             </span>
           </div>
         </div>
@@ -181,12 +178,11 @@ export function EmptyState({
 
   return (
     <div className="flex flex-col items-center justify-center py-24 px-4">
-      {/* Icon container — TreePine float animation + amber dots PRESERVED (#222 T1) */}
+      {/* Icon container */}
       <div className="relative mb-6">
         <div className="w-20 h-20 rounded-full bg-stone-100 dark:bg-stone-800 flex items-center justify-center">
           <Icon
-            className="h-9 w-9 text-stone-500 dark:text-stone-500 motion-reduce:animate-none"
-            style={{ animation: "float 3s ease-in-out infinite" }}
+            className="h-9 w-9 text-stone-500 dark:text-stone-500"
           />
         </div>
         <div className="absolute -top-1 -right-1 w-4 h-4 rounded-full bg-amber-200" />
@@ -226,8 +222,7 @@ export function EmptyState({
 export function LocationsGrid({
   locations,
   isLoading,
-  gridKey,
-  gridFading,
+  isRefreshing,
   pagination,
   onClear,
   emptyVariant,
@@ -237,8 +232,7 @@ export function LocationsGrid({
 }: {
   locations: Location[];
   isLoading: boolean;
-  gridKey: number;
-  gridFading: boolean;
+  isRefreshing: boolean;
   pagination: { total: number; totalPages: number };
   onClear: () => void;
   /** @default "noSearch" */
@@ -247,14 +241,27 @@ export function LocationsGrid({
   onPageChange: (page: number) => void;
   getPageNumbers: () => (number | "...")[];
 }) {
-  const { t } = useI18n(["locations"]);
+  const { t } = useI18n(["locations", "common"]);
   return (
     <div>
       <h2 className="sr-only">{t("locations.locationList")}</h2>
       <div
-        className="transition-opacity duration-200"
-        style={{ opacity: gridFading ? 0 : 1 }}
+        className="relative transition-opacity duration-150 motion-reduce:transition-none"
+        aria-busy={isLoading || isRefreshing}
       >
+        {isRefreshing && locations.length > 0 && (
+          <div
+            role="status"
+            aria-label={t("common.loading")}
+            className="pointer-events-none absolute inset-x-0 top-5 z-10 flex justify-center"
+          >
+            <span className="inline-flex items-center gap-2 rounded-full bg-card/95 px-3 py-2 text-xs font-medium text-muted-foreground shadow-warm-md ring-1 ring-black/5 backdrop-blur-sm dark:ring-white/10">
+              <LoaderCircle className="h-3.5 w-3.5 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+              {t("common.loading")}
+            </span>
+          </div>
+        )}
+        <div className={cn("transition-opacity duration-150 motion-reduce:transition-none", isRefreshing && locations.length > 0 && "opacity-60")}>
         {isLoading ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
             {Array.from({ length: 6 }).map((_, i) => <ShimmerCard key={i} />)}
@@ -266,19 +273,20 @@ export function LocationsGrid({
             onClearAll={onClear}
           />
         ) : (
-          <div key={gridKey} className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
             {locations.map((location, index) => (
               <LocationCard key={location.id} location={location} index={index} />
             ))}
           </div>
         )}
+        </div>
       </div>
 
       {pagination.totalPages > 1 && (
         <div className="flex justify-center items-center gap-1.5 mt-12">
           <button
             onClick={() => currentPage > 1 && onPageChange(currentPage - 1)}
-            disabled={currentPage === 1}
+            disabled={currentPage === 1 || isRefreshing}
             aria-label={t("locations.paginationPrev")}
             className="w-9 h-9 rounded-xl flex items-center justify-center bg-popover border border-stone-200 dark:border-stone-700 hover:border-stone-300 dark:hover:border-stone-600 hover:text-stone-700 dark:hover:text-stone-300 disabled:bg-stone-100 disabled:border-stone-200 dark:disabled:bg-stone-900 dark:disabled:border-stone-700 disabled:cursor-not-allowed transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200"
           >
@@ -294,8 +302,9 @@ export function LocationsGrid({
               <button
                 key={page}
                 onClick={() => onPageChange(page as number)}
+                disabled={isRefreshing}
                 className={cn(
-                  "w-9 h-9 rounded-xl text-sm font-medium transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200",
+                  "w-9 h-9 rounded-xl text-sm font-medium transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150 motion-reduce:transition-none",
                   page === currentPage
                     ? "bg-stone-900 dark:bg-stone-100 dark:text-stone-900 text-white shadow-sm"
                     : "bg-card text-stone-600 dark:text-stone-400 border border-border hover:border-stone-300 dark:hover:border-stone-600 hover:text-stone-700 dark:hover:text-stone-300"
@@ -308,12 +317,12 @@ export function LocationsGrid({
 
           <button
             onClick={() => currentPage < pagination.totalPages && onPageChange(currentPage + 1)}
-            disabled={currentPage === pagination.totalPages}
+            disabled={currentPage === pagination.totalPages || isRefreshing}
             aria-label={t("locations.paginationNext")}
             className="w-9 h-9 rounded-xl flex items-center justify-center bg-popover border border-stone-200 dark:border-stone-700 hover:border-stone-300 dark:hover:border-stone-600 hover:text-stone-700 dark:hover:text-stone-300 disabled:bg-stone-100 disabled:border-stone-200 dark:disabled:bg-stone-900 dark:disabled:border-stone-700 disabled:cursor-not-allowed transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200"
           >
             <span className={cn("text-stone-900 dark:text-stone-100", currentPage === pagination.totalPages && "text-stone-500 dark:text-stone-500")}>
-              <ChevronRight className="h-4 w-4" />
+            <ChevronRight className="h-4 w-4" />
             </span>
           </button>
         </div>

--- a/frontend/src/components/features/locations/locations-main.tsx
+++ b/frontend/src/components/features/locations/locations-main.tsx
@@ -92,8 +92,7 @@ export function LocationsClient({ initialData }: { initialData?: LocationsListIn
           <LocationsGrid
             locations={ctx.locations}
             isLoading={ctx.isLoading}
-            gridKey={ctx.gridKey}
-            gridFading={ctx.gridFading}
+            isRefreshing={ctx.isRefreshing}
             pagination={ctx.pagination}
             onClear={ctx.handleClearAll}
             currentPage={ctx.currentPage}

--- a/frontend/src/components/features/locations/use-locations-list.test.ts
+++ b/frontend/src/components/features/locations/use-locations-list.test.ts
@@ -1,0 +1,69 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { Location } from "@/lib/types";
+import { fetchCurrentUser, fetchPublicAPI } from "@/lib/api";
+import { useLocationsList, type LocationsListInitialData } from "./use-locations-list";
+
+vi.mock("@/lib/api", () => ({
+  fetchCurrentUser: vi.fn(),
+  fetchPublicAPI: vi.fn(),
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function response(data: unknown) {
+  return { json: async () => data } as Response;
+}
+
+const initialLocation = { id: "initial", name: "初始地点" } as unknown as Location;
+const nextLocation = { id: "next", name: "最新地点" } as unknown as Location;
+const staleLocation = { id: "stale", name: "过期地点" } as unknown as Location;
+
+const initialData: LocationsListInitialData = {
+  locations: [initialLocation],
+  pagination: { page: 1, pageSize: 12, total: 1, totalPages: 1 },
+  popularTags: [],
+  cities: [],
+};
+
+describe("useLocationsList", () => {
+  it("只应用最新请求，避免旧筛选结果覆盖用户当前选择", async () => {
+    vi.mocked(fetchCurrentUser).mockResolvedValue(null);
+    const firstRequest = deferred<Response>();
+    const secondRequest = deferred<Response>();
+    vi.mocked(fetchPublicAPI).mockImplementation((path) => {
+      if (path.includes("search=first")) return firstRequest.promise;
+      return secondRequest.promise;
+    });
+
+    const { result } = renderHook(() => useLocationsList(initialData));
+
+    let firstLoad: Promise<void> | undefined;
+    let secondLoad: Promise<void> | undefined;
+    await act(async () => {
+      firstLoad = result.current.loadLocations({ page: 1, search: "first" });
+      secondLoad = result.current.loadLocations({ page: 1, search: "second" });
+      secondRequest.resolve(response({
+        success: true,
+        locations: [nextLocation],
+        pagination: { page: 1, pageSize: 12, total: 1, totalPages: 1 },
+      }));
+      await secondLoad;
+      firstRequest.resolve(response({
+        success: true,
+        locations: [staleLocation],
+        pagination: { page: 1, pageSize: 12, total: 1, totalPages: 1 },
+      }));
+      await firstLoad;
+    });
+
+    expect(result.current.locations).toEqual([nextLocation]);
+    expect(result.current.isRefreshing).toBe(false);
+  });
+});

--- a/frontend/src/components/features/locations/use-locations-list.ts
+++ b/frontend/src/components/features/locations/use-locations-list.ts
@@ -20,7 +20,7 @@ export interface LocationsListInitialData {
 export function useLocationsList(initialData?: LocationsListInitialData) {
   const [locations, setLocations] = React.useState<Location[]>(initialData?.locations ?? []);
   const [isLoading, setIsLoading] = React.useState(!initialData);
-  const [gridKey, setGridKey] = React.useState(0);
+  const [isRefreshing, setIsRefreshing] = React.useState(false);
   const [searchQuery, setSearchQuery] = React.useState("");
   const [currentPage, setCurrentPage] = React.useState(1);
   const [pagination, setPagination] = React.useState<LocationsPagination>(
@@ -33,14 +33,22 @@ export function useLocationsList(initialData?: LocationsListInitialData) {
   const [activeRole, setActiveRole] = React.useState<RoleKey>("");
   const [showCityDropdown, setShowCityDropdown] = React.useState(false);
   const [cityDropdownPos, setCityDropdownPos] = React.useState({ top: 0, left: 0 });
-  const [gridFading, setGridFading] = React.useState(false);
   const [userCity, setUserCity] = React.useState<string | null | undefined>(undefined);
   const hasInitialDataRef = React.useRef(Boolean(initialData));
   const skipInitialFilterFetchRef = React.useRef(true);
+  const locationsRef = React.useRef(locations);
+  const requestIdRef = React.useRef(0);
+  const abortControllerRef = React.useRef<AbortController | null>(null);
 
   const loadLocations = React.useCallback(
     async (params: { page?: number; search?: string; tagIds?: string[]; cityId?: string; type?: string }) => {
-      setIsLoading(true);
+      const requestId = ++requestIdRef.current;
+      abortControllerRef.current?.abort();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+      const hasExistingLocations = locationsRef.current.length > 0;
+      setIsLoading(!hasExistingLocations);
+      setIsRefreshing(hasExistingLocations);
       try {
         const query = new URLSearchParams();
         if (params.page) query.set("page", params.page.toString());
@@ -49,20 +57,31 @@ export function useLocationsList(initialData?: LocationsListInitialData) {
         if (params.tagIds?.length) query.set("tagIds", params.tagIds.join(","));
         if (params.cityId) query.set("cityId", params.cityId);
         if (params.type) query.set("type", params.type);
-        const res = await fetchPublicAPI(`/locations?${query}`);
+        const res = await fetchPublicAPI(`/locations?${query}`, { signal: controller.signal });
         const data = await res.json();
+        if (requestId !== requestIdRef.current) return;
         if (data.success) {
+          locationsRef.current = data.locations;
           setLocations(data.locations);
           setPagination(data.pagination);
-          setGridKey((k) => k + 1);
+        }
+      } catch (error) {
+        if (!(error instanceof Error && error.name === "AbortError")) {
+          console.error("[locations] Failed to load locations:", error);
         }
       } finally {
-        setIsLoading(false);
-        setGridFading(false);
+        if (requestId === requestIdRef.current) {
+          setIsLoading(false);
+          setIsRefreshing(false);
+        }
       }
     },
     []
   );
+
+  React.useEffect(() => {
+    return () => abortControllerRef.current?.abort();
+  }, []);
 
   // URL 参数初始化
   React.useEffect(() => {
@@ -142,7 +161,6 @@ export function useLocationsList(initialData?: LocationsListInitialData) {
   }, [activeRole]);
 
   const handlePageChange = React.useCallback((page: number) => {
-    setGridFading(true);
     setCurrentPage(page);
     loadLocations({ page, search: searchQuery, tagIds: selectedTags, cityId: selectedCityId, type: activeRole });
     window.scrollTo({ top: 0, behavior: "smooth" });
@@ -177,7 +195,7 @@ export function useLocationsList(initialData?: LocationsListInitialData) {
   return {
     locations,
     isLoading,
-    gridKey,
+    isRefreshing,
     searchQuery,
     currentPage,
     pagination,
@@ -188,7 +206,6 @@ export function useLocationsList(initialData?: LocationsListInitialData) {
     activeRole,
     showCityDropdown,
     cityDropdownPos,
-    gridFading,
     selectedCityName,
     hasActiveFilters,
     userCity,

--- a/frontend/src/components/ui/lazy-image.test.tsx
+++ b/frontend/src/components/ui/lazy-image.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { LocationCoverImage } from "./lazy-image";
+
+describe("LocationCoverImage", () => {
+  it("首屏图片使用 eager 加载和异步解码，避免同步解码阻塞主线程", () => {
+    render(
+      <LocationCoverImage
+        src="https://cos.gomate.live/example.jpg"
+        alt="梧桐山"
+        priority
+      />,
+    );
+
+    const image = screen.getByRole("img", { name: "梧桐山" });
+    expect(image).toHaveAttribute("loading", "eager");
+    expect(image).toHaveAttribute("decoding", "async");
+    expect(image).toHaveAttribute("fetchpriority", "high");
+  });
+});

--- a/frontend/src/components/ui/lazy-image.tsx
+++ b/frontend/src/components/ui/lazy-image.tsx
@@ -95,7 +95,7 @@ export function LazyImage({
           onLoad={handleLoad}
           onError={handleError}
           className={cn(
-            "w-full h-full object-cover transition-opacity duration-500 ease-out",
+            "w-full h-full object-cover transition-opacity duration-150 ease-out motion-reduce:transition-none",
             loaded ? "opacity-100" : "opacity-0",
             className
           )}
@@ -164,13 +164,13 @@ export function LocationCoverImage({
           src={src}
           alt={alt}
           loading={priority ? "eager" : "lazy"}
-          decoding={priority ? "sync" : "async"}
+          decoding="async"
           // @ts-expect-error lowercase `fetchpriority` is the HTML DOM attribute name; React warns about `fetchPriority`
           fetchpriority={priority ? "high" : "auto"}
           onLoad={() => setLoaded(true)}
           className={cn(
             "w-full h-full object-cover",
-            "transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-500 ease-out",
+            "transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150 ease-out motion-reduce:transition-none",
             "group-hover:scale-[1.06]",
             loaded || priority ? "opacity-100" : "opacity-0",
             className

--- a/frontend/src/hooks/use-animations.test.ts
+++ b/frontend/src/hooks/use-animations.test.ts
@@ -1,0 +1,17 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useSearchInteraction } from "./use-animations";
+
+describe("useSearchInteraction", () => {
+  it("输入时只更新搜索值，不为每个字符触发按钮弹跳", () => {
+    const { result } = renderHook(() => useSearchInteraction());
+
+    act(() => {
+      result.current.setValue("梧桐山");
+    });
+
+    expect(result.current.value).toBe("梧桐山");
+    expect(result.current).not.toHaveProperty("isButtonBouncing");
+    expect(result.current).not.toHaveProperty("triggerButtonBounce");
+  });
+});

--- a/frontend/src/hooks/use-animations.ts
+++ b/frontend/src/hooks/use-animations.ts
@@ -81,51 +81,24 @@ export function useAnimateIn(enabled = true): AnimateInConfig {
 export interface SearchState {
   value: string;
   isFocused: boolean;
-  /** 搜索按钮是否触发弹跳动画 */
-  isButtonBouncing: boolean;
   setValue: (v: string) => void;
   setFocused: (v: boolean) => void;
-  triggerButtonBounce: () => void;
   clear: () => void;
 }
 
 export function useSearchInteraction(initialValue = ""): SearchState {
   const [value, setValue] = useState(initialValue);
   const [isFocused, setFocused] = useState(false);
-  const [isButtonBouncing, setIsButtonBouncing] = useState(false);
-  const bounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const triggerButtonBounce = useCallback(() => {
-    setIsButtonBouncing(true);
-    if (bounceTimerRef.current) clearTimeout(bounceTimerRef.current);
-    // scale-in 动画时长 200ms，动画结束后重置
-    bounceTimerRef.current = setTimeout(() => setIsButtonBouncing(false), 300);
-  }, []);
 
   const clear = useCallback(() => {
     setValue("");
   }, []);
 
-  useEffect(() => {
-    // 输入时触发按钮弹跳
-    if (value.length > 0) {
-      triggerButtonBounce();
-    }
-  }, [value, triggerButtonBounce]);
-
-  useEffect(() => {
-    return () => {
-      if (bounceTimerRef.current) clearTimeout(bounceTimerRef.current);
-    };
-  }, []);
-
   return {
     value,
     isFocused,
-    isButtonBouncing,
     setValue,
     setFocused,
-    triggerButtonBounce,
     clear,
   };
 }

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -234,8 +234,8 @@ function getHreflangUrl(loc: Locale) {
     <link rel="preconnect" href="https://api.gomate.live" crossorigin />
 
     {/* R2 存储预连接（图片加载优化） */}
-    <link rel="dns-prefetch" href="https://gomate.cos.jiahongw.com" />
-    <link rel="preconnect" href="https://gomate.cos.jiahongw.com" crossorigin />
+    <link rel="dns-prefetch" href="https://cos.gomate.live" />
+    <link rel="preconnect" href="https://cos.gomate.live" crossorigin />
 
     {/* hreflang alternate links */}
     {SUPPORTED_LOCALES.map((loc) => (

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -435,6 +435,19 @@
    Base Layer — 全局基础样式
    ============================================================ */
 @media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  html {
+    scroll-behavior: auto !important;
+  }
+
   .animate-overlay-in,
   .animate-overlay-out,
   .animate-panel-in,


### PR DESCRIPTION
## 改动概览

将“丝滑体验”改造拆成四个可审查切片：

1. 优化实际图片域名预连接，首屏图片使用 eager + async 解码，缩短图片淡入与 hover 过渡。
2. 地点列表刷新保留现有卡片，增加轻量 busy 状态；用 AbortController 和 requestId 防止旧请求覆盖新筛选结果；取消刷新时整网格淡出和动画重播。
3. 移除搜索输入时每字符触发的按钮弹跳，统一 reduced-motion 行为。
4. 移除强制共享的 vendor-markdown chunk，避免首页、地点列表和队伍列表承担无关 Markdown 依赖。

## 验证

- `pnpm i18n:build`
- `pnpm --filter @gomate/frontend i18n:validate`
- `pnpm --filter @gomate/frontend type-check`（0 errors，既有 27 hints）
- `pnpm --filter @gomate/frontend lint`（0 errors，既有 2 warnings）
- `pnpm --filter @gomate/frontend test`（33 files / 206 tests passed）
- `pnpm --filter @gomate/frontend build`（passed）
- 构建产物确认无 `vendor-markdown` chunk

## 范围边界

本 PR 不包含 Astro ClientRouter、Service Binding 缓存和完整 i18n namespace 重构，这些涉及更大的 SSR/部署边界，单独拆分处理。

## 风险与回滚

- 仅涉及前端加载、列表状态、动效和 Vite chunk 配置，不涉及 API、数据库、Secrets 或 Cloudflare 资源。
- 若线上出现回归，可回滚本 PR 的合并提交；列表请求仍保持原接口和响应结构。
