### PR TITLE
feat: 重构 GoMate 首页体验

### DIFF
--- a/frontend/public/locales/en/home.json
+++ b/frontend/public/locales/en/home.json
@@ -33,5 +33,43 @@
   "mapPointHint": "Click a location for details",
   "mapFocusedEmptyTitle": "No locations have been added in {province} yet",
   "mapFocusedEmptyDesc": "Browse other regions to find an adventure.",
-  "mapBrowseOtherRegions": "Browse other regions"
+  "mapBrowseOtherRegions": "Browse other regions",
+  "memberHero": {
+    "kicker": "Where are you going today?",
+    "titleLine1": "Ready for your",
+    "titleLine2": "next outing?",
+    "description": "Search a place, see teams forming nearby, or start an outing of your own."
+  },
+  "discoveryEmpty": {
+    "title": "No locations match yet",
+    "description": "Browse all locations and find a direction for your next outing."
+  },
+  "discoveryMap": {
+    "title": "Find your next stop on the map",
+    "description": "Open a new starting point, from familiar cities to trails you have not walked yet."
+  },
+  "howItWorks": {
+    "kicker": "From idea to outing",
+    "title": "Three steps to find your people",
+    "description": "GoMate brings places, timing, and teams together so an idea can become a plan.",
+    "steps": {
+      "discover": {
+        "title": "Find somewhere to go",
+        "description": "Browse routes, cities, and nearby destinations to choose a direction."
+      },
+      "team": {
+        "title": "Join or start a team",
+        "description": "Find people with a matching pace, or start an outing yourself."
+      },
+      "go": {
+        "title": "Turn the plan into a start",
+        "description": "Confirm the meetup details, pack what you need, and go together."
+      }
+    }
+  },
+  "teamsEmpty": {
+    "guestTitle": "No public teams yet",
+    "memberTitle": "No public teams nearby yet",
+    "description": "Explore a location first, or be the first person to start an outing."
+  }
 }

--- a/frontend/public/locales/ja/home.json
+++ b/frontend/public/locales/ja/home.json
@@ -33,5 +33,43 @@
   "mapPointHint": "スポットをクリックして詳細を表示",
   "mapFocusedEmptyTitle": "{province}にはまだスポットがありません",
   "mapFocusedEmptyDesc": "ほかの地域から探索してみましょう。",
-  "mapBrowseOtherRegions": "ほかの地域を見る"
+  "mapBrowseOtherRegions": "ほかの地域を見る",
+  "memberHero": {
+    "kicker": "今日はどこへ行く？",
+    "titleLine1": "次の旅に",
+    "titleLine2": "出かけよう",
+    "description": "場所を検索して、近くで集まるチームを見つけるか、自分で旅を始めましょう。"
+  },
+  "discoveryEmpty": {
+    "title": "一致する場所がまだありません",
+    "description": "すべての場所を見て、次の旅の方向を見つけましょう。"
+  },
+  "discoveryMap": {
+    "title": "地図から次の場所を探す",
+    "description": "身近な街からまだ歩いていない道まで、新しい出発点を開きましょう。"
+  },
+  "howItWorks": {
+    "kicker": "思いから出発へ",
+    "title": "3ステップで仲間を見つける",
+    "description": "GoMateは場所、時間、チームをつなぎ、思いつきを旅の計画に変えます。",
+    "steps": {
+      "discover": {
+        "title": "行きたい場所を探す",
+        "description": "ルートや街、周辺の目的地を見て方向を決めます。"
+      },
+      "team": {
+        "title": "チームに参加・作成する",
+        "description": "ペースの合う仲間を見つけるか、自分で旅を始めます。"
+      },
+      "go": {
+        "title": "計画を出発に変える",
+        "description": "集合情報を確認して、必要なものを持って一緒に出かけます。"
+      }
+    }
+  },
+  "teamsEmpty": {
+    "guestTitle": "公開チームはまだありません",
+    "memberTitle": "近くに公開チームはまだありません",
+    "description": "まず場所を探すか、最初の旅を始めてみましょう。"
+  }
 }

--- a/frontend/public/locales/zh-CN/home.json
+++ b/frontend/public/locales/zh-CN/home.json
@@ -33,5 +33,43 @@
   "mapPointHint": "点击地点查看详情",
   "mapFocusedEmptyTitle": "{province} 暂时还没有收录地点",
   "mapFocusedEmptyDesc": "可以先浏览全国其他地区的探索路线。",
-  "mapBrowseOtherRegions": "浏览其他地区"
+  "mapBrowseOtherRegions": "浏览其他地区",
+  "memberHero": {
+    "kicker": "今天想去哪儿",
+    "titleLine1": "准备下一次",
+    "titleLine2": "出发了吗",
+    "description": "搜索一个地点，看看附近正在集结的队伍，或者发起一场同行。"
+  },
+  "discoveryEmpty": {
+    "title": "还没有收录到合适的地点",
+    "description": "先去浏览全国地点，找到下一个想出发的方向。"
+  },
+  "discoveryMap": {
+    "title": "从地图找下一站",
+    "description": "从熟悉的城市到还没走过的山野，按省份打开一张新的出发清单。"
+  },
+  "howItWorks": {
+    "kicker": "从想去到出发",
+    "title": "三步，找到同行的人",
+    "description": "GoMate 把地点、时间和队伍放在一起，让一次出发从想法变成计划。",
+    "steps": {
+      "discover": {
+        "title": "先找到想去的地方",
+        "description": "浏览路线、城市和周边目的地，先确定方向。"
+      },
+      "team": {
+        "title": "加入或发起队伍",
+        "description": "按时间和节奏找到合适的同行者，也可以自己发起一场。"
+      },
+      "go": {
+        "title": "把计划变成出发",
+        "description": "确认集合信息，带上需要的装备，一起走完这段路。"
+      }
+    }
+  },
+  "teamsEmpty": {
+    "guestTitle": "还没有公开队伍",
+    "memberTitle": "附近暂时没有公开队伍",
+    "description": "可以先探索地点，或者成为第一个发起同行的人。"
+  }
 }

--- a/frontend/src/__tests__/home-locations-section.test.tsx
+++ b/frontend/src/__tests__/home-locations-section.test.tsx
@@ -44,4 +44,20 @@ describe("HomeLocationsSection", () => {
     expect(locationLinks.length).toBeGreaterThan(0);
     expect(locationLinks.every((link) => link.getAttribute("href") === "/locations/loc-1")).toBe(true);
   });
+
+  it("renders an actionable empty state when no locations are available", () => {
+    render(
+      <HomeLocationsSection
+        data={{
+          locations: [],
+          isLoading: false,
+          userCity: null,
+          cityMatch: null,
+        } as unknown as Parameters<typeof HomeLocationsSection>[0]["data"]}
+      />,
+    );
+
+    expect(screen.getByText("home.discoveryEmpty.title")).toBeTruthy();
+    expect(screen.getByRole("link", { name: /common\.exploreLocations/ })).toHaveAttribute("href", "/locations");
+  });
 });

--- a/frontend/src/__tests__/home-teams-section.test.tsx
+++ b/frontend/src/__tests__/home-teams-section.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { HomeTeamsSection } from "../components/features/home/home-teams-section";
+
+vi.mock("@/hooks/useI18n", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+    locale: "zh-CN",
+    loading: false,
+    getNsData: () => null,
+  }),
+}));
+
+const emptyData = {
+  teams: [],
+  teamsLoading: false,
+  teamsRef: undefined,
+  teamsInView: true,
+} as unknown as Parameters<typeof HomeTeamsSection>[0]["data"];
+
+describe("HomeTeamsSection", () => {
+  it("renders an actionable empty state for guests", () => {
+    render(<HomeTeamsSection data={emptyData} />);
+
+    expect(screen.getByText("home.teamsEmpty.guestTitle")).toBeTruthy();
+    expect(screen.getByRole("link", { name: /common\.exploreCreate/ })).toHaveAttribute("href", "/teams/create");
+  });
+
+  it("uses member-specific copy for logged-in users", () => {
+    render(<HomeTeamsSection data={emptyData} isMember />);
+
+    expect(screen.getByText("home.teamsEmpty.memberTitle")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/features/home/home-hero.tsx
+++ b/frontend/src/components/features/home/home-hero.tsx
@@ -15,7 +15,7 @@ export function HomeHero({ data, isMember = false }: { data: HomeData; isMember?
       <div aria-hidden="true" className="absolute inset-0 bg-[radial-gradient(circle_at_78%_18%,color-mix(in_oklab,var(--primary)_12%,transparent),transparent_28%),radial-gradient(circle_at_8%_82%,color-mix(in_oklab,var(--warm)_8%,transparent),transparent_24%)]" />
       <div aria-hidden="true" className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/60 to-transparent" />
 
-      <div className="relative mx-auto grid max-w-7xl gap-12 px-4 pb-16 pt-28 sm:px-6 sm:pb-20 sm:pt-32 lg:grid-cols-[minmax(0,1fr)_minmax(360px,0.82fr)] lg:items-center lg:gap-16 lg:px-8 lg:pb-24">
+      <div className="relative z-10 mx-auto grid max-w-7xl gap-12 px-4 pb-16 pt-28 sm:px-6 sm:pb-20 sm:pt-32 lg:grid-cols-[minmax(0,1fr)_minmax(360px,0.82fr)] lg:items-center lg:gap-16 lg:px-8 lg:pb-24">
         <div className="max-w-2xl">
           <div className={`home-hero-kicker mb-5 inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary-50/70 px-3 py-1.5 text-xs font-semibold tracking-wide text-amber-800 dark:bg-primary/10 dark:text-amber-300 ${animate.subtitle}`}>
             <span className="h-1.5 w-1.5 rounded-full bg-primary" aria-hidden="true" />

--- a/frontend/src/components/features/home/home-hero.tsx
+++ b/frontend/src/components/features/home/home-hero.tsx
@@ -4,31 +4,31 @@ import type { useHomeData } from "./use-home-data";
 
 type HomeData = ReturnType<typeof useHomeData>;
 
-export function HomeHero({ data }: { data: HomeData }) {
+export function HomeHero({ data, isMember = false }: { data: HomeData; isMember?: boolean }) {
   const { animate, search, handleSearch } = data;
   const { t } = useI18n(["common", "content", "home", "locations"]);
   const featuredLocation = data.locations[0];
   const featuredTeam = data.teams[0];
 
   return (
-    <section className="relative isolate overflow-hidden border-b border-border/70 bg-background">
+    <section className={`home-hero-shell relative isolate overflow-hidden border-b border-border/70 bg-background ${isMember ? "home-hero-member" : ""}`}>
       <div aria-hidden="true" className="absolute inset-0 bg-[radial-gradient(circle_at_78%_18%,color-mix(in_oklab,var(--primary)_12%,transparent),transparent_28%),radial-gradient(circle_at_8%_82%,color-mix(in_oklab,var(--warm)_8%,transparent),transparent_24%)]" />
       <div aria-hidden="true" className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/60 to-transparent" />
 
       <div className="relative mx-auto grid max-w-7xl gap-12 px-4 pb-16 pt-28 sm:px-6 sm:pb-20 sm:pt-32 lg:grid-cols-[minmax(0,1fr)_minmax(360px,0.82fr)] lg:items-center lg:gap-16 lg:px-8 lg:pb-24">
         <div className="max-w-2xl">
-          <div className={`mb-5 inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary-50/70 px-3 py-1.5 text-xs font-semibold tracking-wide text-amber-800 dark:bg-primary/10 dark:text-amber-300 ${animate.subtitle}`}>
+          <div className={`home-hero-kicker mb-5 inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary-50/70 px-3 py-1.5 text-xs font-semibold tracking-wide text-amber-800 dark:bg-primary/10 dark:text-amber-300 ${animate.subtitle}`}>
             <span className="h-1.5 w-1.5 rounded-full bg-primary" aria-hidden="true" />
-            {t("common.tagline")}
+            {isMember ? t("home.memberHero.kicker") : t("common.tagline")}
           </div>
 
-          <h1 className={`max-w-xl text-[clamp(2.75rem,7vw,5.5rem)] font-bold leading-[1.02] tracking-[-0.055em] text-foreground ${animate.title}`}>
-            <span className="block">{t("content.hero.titleLine1")}</span>
-            <span className="block text-gradient-brand">{t("content.hero.titleLine2")}</span>
+          <h1 className={`home-hero-title max-w-xl text-[clamp(2.75rem,7vw,5.5rem)] font-bold leading-[1.02] tracking-[-0.055em] text-foreground ${animate.title}`}>
+            <span className="block">{isMember ? t("home.memberHero.titleLine1") : t("content.hero.titleLine1")}</span>
+            <span className="block text-gradient-brand">{isMember ? t("home.memberHero.titleLine2") : t("content.hero.titleLine2")}</span>
           </h1>
 
           <p className={`mt-6 max-w-xl text-base leading-8 text-stone-700 dark:text-stone-300 sm:text-lg ${animate.subtitle}`}>
-            {t("content.hero.description")}
+            {isMember ? t("home.memberHero.description") : t("content.hero.description")}
           </p>
 
           <form
@@ -38,7 +38,7 @@ export function HomeHero({ data }: { data: HomeData }) {
               event.preventDefault();
               handleSearch(search.value);
             }}
-            className={`relative mt-8 max-w-2xl ${animate.search}`}
+            className={`home-search relative mt-8 max-w-2xl ${animate.search}`}
           >
             <label htmlFor="home-location-search" className="sr-only">{t("common.searchPlaceholder")}</label>
             <Search className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
@@ -65,26 +65,26 @@ export function HomeHero({ data }: { data: HomeData }) {
             )}
             <button
               type="submit"
-              className="absolute right-2 top-1/2 -translate-y-1/2 rounded-xl bg-amber-700 px-4 py-2 text-sm font-semibold text-white shadow-brand-glow transition-[background-color,transform,box-shadow] duration-150 motion-reduce:transition-none hover:bg-amber-800 hover:shadow-brand-glow-lg active:scale-[0.96]"
+              className="btn-brand-offset absolute right-2 top-1/2 -translate-y-1/2 rounded-xl bg-amber-700 px-4 py-2 text-sm font-semibold text-white transition-[background-color,transform,box-shadow] duration-150 motion-reduce:transition-none hover:bg-amber-800 active:scale-[0.96]"
             >
               {t("common.search")}
             </button>
           </form>
 
           <div className="mt-5 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm font-semibold text-stone-700 dark:text-stone-300">
-            <a href="/locations" className="group inline-flex items-center gap-1.5 transition-colors duration-150 hover:text-amber-700 dark:hover:text-amber-300">
-              {t("common.exploreLocations")}
+            <a href={isMember ? "/my-teams" : "/locations"} className="group inline-flex items-center gap-1.5 transition-colors duration-150 hover:text-amber-700 dark:hover:text-amber-300">
+              {isMember ? t("common.myTeams") : t("common.exploreLocations")}
               <ArrowRight className="h-4 w-4 transition-transform duration-150 group-hover:translate-x-0.5" aria-hidden="true" />
             </a>
-            <a href="/teams" className="group inline-flex items-center gap-1.5 transition-colors duration-150 hover:text-amber-700 dark:hover:text-amber-300">
-              {t("common.exploreTeams")}
+            <a href={isMember ? "/teams/create" : "/teams"} className="group inline-flex items-center gap-1.5 transition-colors duration-150 hover:text-amber-700 dark:hover:text-amber-300">
+              {isMember ? t("common.exploreCreate") : t("common.exploreTeams")}
               <ArrowRight className="h-4 w-4 transition-transform duration-150 group-hover:translate-x-0.5" aria-hidden="true" />
             </a>
           </div>
         </div>
 
         <div className={`relative mx-auto w-full max-w-xl lg:mx-0 ${animate.search}`}>
-          <div className="relative aspect-[0.92] overflow-hidden rounded-[2rem] bg-secondary shadow-warm-xl ring-1 ring-black/5 dark:ring-white/10">
+          <div className="home-route-card relative aspect-[0.92] overflow-hidden rounded-[2rem] bg-secondary shadow-warm-xl ring-1 ring-black/5 dark:ring-white/10">
             {featuredLocation?.coverImage ? (
               <img
                 src={featuredLocation.coverImage}

--- a/frontend/src/components/features/home/home-how-it-works-section.tsx
+++ b/frontend/src/components/features/home/home-how-it-works-section.tsx
@@ -1,0 +1,37 @@
+import { Compass, Footprints, UsersRound } from "lucide-react";
+import { useI18n } from "@/hooks/useI18n";
+
+const STEPS = [
+  { icon: Compass, key: "discover" },
+  { icon: UsersRound, key: "team" },
+  { icon: Footprints, key: "go" },
+] as const;
+
+export function HomeHowItWorksSection() {
+  const { t } = useI18n(["home"]);
+
+  return (
+    <section className="home-how-it-works border-y border-border/70 bg-secondary/45 py-16 sm:py-20 lg:py-24">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl text-center">
+          <p className="home-section-kicker">{t("home.howItWorks.kicker")}</p>
+          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">{t("home.howItWorks.title")}</h2>
+          <p className="mt-4 text-base leading-7 text-stone-700 dark:text-stone-300">{t("home.howItWorks.description")}</p>
+        </div>
+
+        <ol className="mt-10 grid gap-4 md:grid-cols-3 md:gap-5 lg:mt-12">
+          {STEPS.map(({ icon: Icon, key }, index) => (
+            <li key={key} className="home-step-card relative rounded-[1.35rem] border border-border bg-card p-6 shadow-card sm:p-7">
+              <span className="home-step-number" aria-hidden="true">0{index + 1}</span>
+              <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-brand-subtle text-brand">
+                <Icon className="h-5 w-5" aria-hidden="true" />
+              </div>
+              <h3 className="mt-6 text-lg font-semibold text-foreground">{t(`home.howItWorks.steps.${key}.title`)}</h3>
+              <p className="mt-2 text-sm leading-6 text-stone-700 dark:text-stone-300">{t(`home.howItWorks.steps.${key}.description`)}</p>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/features/home/home-location-card.tsx
+++ b/frontend/src/components/features/home/home-location-card.tsx
@@ -88,7 +88,7 @@ export const LocationCard = memo(function LocationCard({ location, index = 0, co
   return (
     <a href={`/locations/${location.id}`} className="block group">
       <article
-        className="overflow-hidden rounded-2xl cursor-pointer bg-card
+        className="home-editorial-card overflow-hidden rounded-2xl cursor-pointer bg-card
           shadow-[var(--shadow-card)]
           transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 ease-out
           hover:shadow-[var(--shadow-card-hover)]

--- a/frontend/src/components/features/home/home-locations-section.tsx
+++ b/frontend/src/components/features/home/home-locations-section.tsx
@@ -65,7 +65,11 @@ export function HomeLocationsSection({ data, showMap = false }: { data: HomeData
               {locations.map((location, index) => <LocationCard key={location.id} location={location} index={index} compact />)}
             </div>
             <div className="hidden md:grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {locations.map((location, index) => <LocationCard key={location.id} location={location} index={index} />)}
+              {locations.map((location, index) => (
+                <div key={location.id} className={index === 0 ? "lg:col-span-2" : ""}>
+                  <LocationCard location={location} index={index} />
+                </div>
+              ))}
             </div>
             <div className="text-center mt-14">
               <a href={locationsUrl} className="group inline-flex items-center gap-2 px-7 py-3.5 border border-border rounded-2xl text-base font-semibold text-foreground transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-200 hover:border-amber-300 dark:hover:border-amber-700 hover:text-amber-700 dark:hover:text-amber-400 hover:shadow-warm-sm active:scale-[0.96]">

--- a/frontend/src/components/features/home/home-locations-section.tsx
+++ b/frontend/src/components/features/home/home-locations-section.tsx
@@ -1,11 +1,12 @@
-import { ArrowRight, MapPin } from "lucide-react";
+import { ArrowRight, Compass, MapPin } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import type { useHomeData } from "./use-home-data";
 import { LocationCard } from "./home-location-card";
+import { ChinaMap } from "./china-map";
 
 type HomeData = ReturnType<typeof useHomeData>;
 
-export function HomeLocationsSection({ data }: { data: HomeData }) {
+export function HomeLocationsSection({ data, showMap = false }: { data: HomeData; showMap?: boolean }) {
   const { locations, isLoading, locationsRef, locationsInView, userCity, cityMatch } = data;
   const showViewAllCity = userCity && cityMatch && cityMatch !== "fallback" && locations[0]?.cityName;
   const locationsUrl = showViewAllCity ? `/locations?cityId=${encodeURIComponent(userCity)}` : "/locations";
@@ -13,8 +14,6 @@ export function HomeLocationsSection({ data }: { data: HomeData }) {
 
   const showCityChip = userCity && cityMatch && cityMatch !== "fallback" && locations[0]?.cityName;
   const cityChipName = showCityChip ? locations[0].cityName : null;
-
-  if (!isLoading && locations.length === 0) return null;
 
   return (
     <section
@@ -50,6 +49,16 @@ export function HomeLocationsSection({ data }: { data: HomeData }) {
               {Array.from({ length: 6 }).map((_, i) => <div key={i} className="h-72 rounded-2xl bg-muted animate-pulse" />)}
             </div>
           </>
+        ) : locations.length === 0 ? (
+          <div className="home-empty-state rounded-[1.5rem] border border-dashed border-primary/35 bg-primary-50/50 px-6 py-10 text-center dark:bg-primary/10">
+            <Compass className="mx-auto h-9 w-9 text-primary" aria-hidden="true" />
+            <h3 className="mt-4 text-lg font-semibold text-foreground">{t("home.discoveryEmpty.title")}</h3>
+            <p className="mx-auto mt-2 max-w-md text-sm leading-6 text-stone-700 dark:text-stone-300">{t("home.discoveryEmpty.description")}</p>
+            <a href="/locations" className="mt-5 inline-flex items-center gap-2 rounded-xl bg-foreground px-4 py-2.5 text-sm font-semibold text-background transition-colors hover:bg-primary hover:text-white">
+              {t("common.exploreLocations")}
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </a>
+          </div>
         ) : (
           <>
             <div className="md:hidden flex flex-col gap-2">
@@ -65,6 +74,28 @@ export function HomeLocationsSection({ data }: { data: HomeData }) {
               </a>
             </div>
           </>
+        )}
+
+        {showMap && (
+          <div className="mt-16 border-t border-border/70 pt-16 sm:mt-20 sm:pt-20">
+            <div className="grid items-center gap-8 lg:grid-cols-[minmax(220px,0.38fr)_minmax(0,1fr)] lg:gap-14">
+              <div className="max-w-md">
+                <div className="mb-4 inline-flex items-center gap-2 text-xs font-bold uppercase tracking-[0.16em] text-amber-800 dark:text-amber-300">
+                  <Compass className="h-4 w-4" aria-hidden="true" />
+                  {t("common.explore")}
+                </div>
+                <h3 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">{t("home.discoveryMap.title")}</h3>
+                <p className="mt-4 text-base leading-7 text-stone-700 dark:text-stone-300">{t("home.discoveryMap.description")}</p>
+                <a href="/locations" className="mt-6 inline-flex items-center gap-2 rounded-xl bg-foreground px-4 py-3 text-sm font-semibold text-background transition-colors hover:bg-primary hover:text-white">
+                  {t("common.exploreLocations")}
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </a>
+              </div>
+              <div className="home-map-frame rounded-[1.5rem] bg-card p-2 shadow-warm-xl ring-1 ring-black/5 dark:ring-white/10">
+                <ChinaMap />
+              </div>
+            </div>
+          </div>
         )}
       </div>
     </section>

--- a/frontend/src/components/features/home/home-main.tsx
+++ b/frontend/src/components/features/home/home-main.tsx
@@ -6,21 +6,23 @@ import { HomeHero } from "./home-hero";
 import { HomeLocationsSection } from "./home-locations-section";
 import { HomeTeamsSection } from "./home-teams-section";
 import { HomeLocalCircleSection } from "./local-circle/home-local-circle-section";
-import { HomeExploreSection } from "./home-explore-section";
+import { HomeHowItWorksSection } from "./home-how-it-works-section";
 import { OnboardingModal } from "@/components/features/onboarding/onboarding-modal";
 import { PreloadImages } from "./preload-images";
 import { fetchCurrentUser } from "@/lib/api";
 
 export function HomeClient({ initialData }: { initialData?: HomeInitialData }) {
-  const [userCity, setUserCity] = React.useState<string | null | undefined>(undefined);
+  const [currentUser, setCurrentUser] = React.useState<Awaited<ReturnType<typeof fetchCurrentUser>> | undefined>(undefined);
 
-  // P1 city 个性化 #193 T3: 获取用户 city，用于探索地点城市筛选
+  // P0：访客首页强调理解产品，登录首页优先展示可执行的本地行动。
   React.useEffect(() => {
     fetchCurrentUser()
-      .then((user) => setUserCity(user?.city ?? null))
-      .catch(() => setUserCity(null));
+      .then((user) => setCurrentUser(user))
+      .catch(() => setCurrentUser(null));
   }, []);
 
+  const isMember = currentUser !== undefined && Boolean(currentUser);
+  const userCity = currentUser?.city ?? null;
   const data = useHomeData(initialData, userCity);
 
   return (
@@ -28,11 +30,11 @@ export function HomeClient({ initialData }: { initialData?: HomeInitialData }) {
       {/* 预加载首屏图片 */}
       <PreloadImages images={data.preloadImages} />
       <main className="min-h-screen bg-background">
-        <HomeHero data={data} />
+        <HomeHero data={data} isMember={isMember} />
         <HomeLocalCircleSection />
-        <HomeLocationsSection data={data} />
-        <HomeExploreSection />
-        <HomeTeamsSection data={data} />
+        <HomeLocationsSection data={data} showMap={!isMember} />
+        {!isMember && currentUser === null && <HomeHowItWorksSection />}
+        <HomeTeamsSection data={data} isMember={isMember} />
         {/* P1-1 T2：首次引导流 modal（登录 + 无队伍 + 未看过才弹，gating 全在 hook 内） */}
         <OnboardingModal />
       </main>

--- a/frontend/src/components/features/home/home-team-card.tsx
+++ b/frontend/src/components/features/home/home-team-card.tsx
@@ -53,7 +53,7 @@ export function TeamCard({ team, featured = false }: { team: Team; featured?: bo
 
   return (
     <a href={`/teams/${team.id}`} className="block group">
-      <article className={`overflow-hidden rounded-2xl cursor-pointer bg-card relative transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-300 hover:-translate-y-1.5 hover:shadow-warm-md ${featured ? 'ring-2 ring-amber-500/50' : ''}`}>
+      <article className={`home-editorial-card overflow-hidden rounded-2xl cursor-pointer bg-card relative transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-300 hover:-translate-y-1.5 hover:shadow-warm-md ${featured ? 'ring-2 ring-amber-500/50' : ''}`}>
 
         {/* Featured badge */}
         {featured && (

--- a/frontend/src/components/features/home/home-teams-section.tsx
+++ b/frontend/src/components/features/home/home-teams-section.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, UsersRound } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import type { useHomeData } from "./use-home-data";
 import { TeamCard } from "./home-team-card";
@@ -6,14 +6,9 @@ import { TeamCardSkeleton } from "./home-team-card-skeleton";
 
 type HomeData = ReturnType<typeof useHomeData>;
 
-export function HomeTeamsSection({ data }: { data: HomeData }) {
+export function HomeTeamsSection({ data, isMember = false }: { data: HomeData; isMember?: boolean }) {
   const { teams, teamsLoading, teamsRef, teamsInView } = data;
   const { t } = useI18n(["home", "teams", "common"]);
-
-  // 条件渲染：teams.length === 0 时整区不渲染（spec §5）
-  if (!teamsLoading && teams.length === 0) {
-    return null;
-  }
 
   return (
     <section id="teams" ref={teamsRef}
@@ -33,6 +28,22 @@ export function HomeTeamsSection({ data }: { data: HomeData }) {
             {Array.from({ length: 6 }).map((_, i) => (
               <TeamCardSkeleton key={i} />
             ))}
+          </div>
+        ) : teams.length === 0 ? (
+          <div className="home-empty-state rounded-[1.5rem] border border-dashed border-primary/35 bg-primary-50/50 px-6 py-10 text-center dark:bg-primary/10">
+            <UsersRound className="mx-auto h-9 w-9 text-primary" aria-hidden="true" />
+            <h3 className="mt-4 text-lg font-semibold text-foreground">{t(isMember ? "home.teamsEmpty.memberTitle" : "home.teamsEmpty.guestTitle")}</h3>
+            <p className="mx-auto mt-2 max-w-md text-sm leading-6 text-stone-700 dark:text-stone-300">{t("home.teamsEmpty.description")}</p>
+            <div className="mt-5 flex flex-wrap justify-center gap-3">
+              <a href="/teams" className="inline-flex items-center gap-2 rounded-xl border border-border bg-card px-4 py-2.5 text-sm font-semibold text-foreground transition-colors hover:border-primary hover:text-primary">
+                {t("common.exploreTeams")}
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </a>
+              <a href="/teams/create" className="inline-flex items-center gap-2 rounded-xl bg-foreground px-4 py-2.5 text-sm font-semibold text-background transition-colors hover:bg-primary hover:text-white">
+                {t("common.exploreCreate")}
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </a>
+            </div>
           </div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/frontend/src/components/layout/navbar.tsx
+++ b/frontend/src/components/layout/navbar.tsx
@@ -487,7 +487,7 @@ function CtaButton({
       data-testid={dataTestId}
       // task #180 a11y：`bg-primary` (#D97706 amber-600) on cream `#FFFBEB` primary-foreground = ~3.3:1 挂 WCAG AA 4.5:1
       // 走 amber-700 (#B45309) + text-white = ~5.5:1 稳过；不改 --primary token 避免全站隐性回归
-      className="flex items-center gap-1.5 text-sm font-medium px-4 py-1.5 rounded-lg transition-[transform,background-color,border-color,color,opacity,box-shadow] hover:scale-[1.02] active:scale-[0.96] bg-amber-700 text-white hover:bg-amber-800 shadow-md hover:shadow-lg transition-shadow"
+      className="btn-brand-offset flex items-center gap-1.5 rounded-xl border border-amber-900/15 bg-amber-700 px-4 py-2 text-sm font-semibold tracking-wide text-white transition-[transform,background-color,border-color,color,opacity,box-shadow] hover:scale-[1.02] hover:bg-amber-800 active:scale-[0.96]"
     >
       {icon}
       {label}
@@ -537,4 +537,3 @@ function _NavbarSkeleton({ className }: { className?: string }) {
     </header>
   );
 }
-

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -611,6 +611,125 @@
    ============================================================ */
 @layer utilities {
 
+  /* ---- Home editorial language ----
+   * A small set of expressive primitives keeps the homepage distinctive
+   * without introducing a second component library or a remote font.
+   */
+  .home-hero-shell {
+    background:
+      radial-gradient(circle at 78% 16%, color-mix(in oklab, var(--primary) 12%, transparent), transparent 28%),
+      linear-gradient(115deg, color-mix(in oklab, var(--background) 92%, var(--warm) 8%), var(--background) 60%);
+  }
+
+  .home-hero-shell::before {
+    content: "";
+    position: absolute;
+    z-index: 0;
+    top: 7rem;
+    right: -8rem;
+    width: min(44vw, 40rem);
+    height: min(44vw, 40rem);
+    border: 1px solid color-mix(in oklab, var(--primary) 25%, transparent);
+    border-radius: 58% 42% 47% 53%;
+    background: color-mix(in oklab, var(--primary) 7%, transparent);
+    transform: rotate(13deg);
+  }
+
+  .home-hero-shell::after {
+    content: "";
+    position: absolute;
+    z-index: 0;
+    top: 11rem;
+    right: 13%;
+    width: min(22vw, 18rem);
+    aspect-ratio: 1;
+    border: 1px dashed color-mix(in oklab, var(--primary) 32%, transparent);
+    border-radius: 50%;
+    transform: rotate(-18deg);
+  }
+
+  .home-hero-kicker,
+  .home-section-kicker {
+    letter-spacing: 0.08em;
+  }
+
+  .home-hero-title {
+    text-wrap: balance;
+  }
+
+  .home-route-card {
+    border: 1.5px solid color-mix(in oklab, var(--foreground) 72%, transparent);
+    box-shadow: 10px 12px 0 color-mix(in oklab, var(--primary) 24%, transparent), var(--shadow-warm-xl);
+  }
+
+  .btn-brand-offset {
+    box-shadow: 3px 3px 0 color-mix(in oklab, var(--foreground) 78%, transparent), var(--shadow-brand-glow);
+  }
+
+  .home-step-card {
+    isolation: isolate;
+    overflow: hidden;
+    transition: transform var(--duration-normal) ease, box-shadow var(--duration-normal) ease, border-color var(--duration-normal) ease;
+  }
+
+  .home-step-card:hover {
+    transform: translateY(-4px) rotate(-0.4deg);
+    border-color: color-mix(in oklab, var(--primary) 48%, var(--border));
+    box-shadow: var(--shadow-card-hover);
+  }
+
+  .home-step-number {
+    position: absolute;
+    z-index: 0;
+    top: 0.4rem;
+    right: 0.9rem;
+    color: color-mix(in oklab, var(--primary) 18%, transparent);
+    font-size: 4.5rem;
+    font-weight: 800;
+    line-height: 1;
+  }
+
+  .home-map-frame {
+    border: 1.5px solid color-mix(in oklab, var(--foreground) 20%, transparent);
+  }
+
+  .home-editorial-card {
+    border: 1px solid color-mix(in oklab, var(--foreground) 10%, var(--border));
+    box-shadow: var(--shadow-card);
+  }
+
+  .home-editorial-card:hover {
+    border-color: color-mix(in oklab, var(--primary) 34%, var(--border));
+  }
+
+  .home-empty-state {
+    background-image: radial-gradient(circle at 20% 20%, color-mix(in oklab, var(--primary) 9%, transparent) 0 1px, transparent 1px);
+    background-size: 14px 14px;
+  }
+
+  @media (max-width: 767px) {
+    .home-hero-shell::before {
+      top: 26rem;
+      right: -12rem;
+      width: 34rem;
+      height: 34rem;
+    }
+
+    .home-hero-shell::after {
+      display: none;
+    }
+
+    .home-route-card {
+      box-shadow: 6px 8px 0 color-mix(in oklab, var(--primary) 22%, transparent), var(--shadow-warm-xl);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .home-step-card:hover {
+      transform: none;
+    }
+  }
+
   /* ---- 文字渐变 ---- */
   .text-gradient-brand {
     background: linear-gradient(135deg, oklch(0.666 0.157 58.3) 0%, oklch(0.769 0.165 70.1) 60%, oklch(0.879 0.153 91.6) 100%);


### PR DESCRIPTION
## 变更范围

执行首页 P0、P1、P3：

- 按访客 / 登录态切换首页叙事与行动入口
- 合并地点列表与全国地图，删除重复探索区块
- 为地点与队伍增加可行动空态
- 新增访客三步流程区块
- 引入路线/等高线式 Hero 背景、编辑式卡片、品牌错位阴影与主 CTA
- 地点首卡桌面端提升为主推荐
- 增加地点/队伍空态测试

## 验证

- `pnpm i18n:build`
- `pnpm --filter @gomate/frontend i18n:validate`
- `pnpm --filter @gomate/frontend test -- src/__tests__/home-locations-section.test.tsx src/__tests__/home-local-circle-section.test.tsx src/__tests__/home-teams-section.test.tsx`
- `pnpm --filter @gomate/frontend lint`（0 errors；保留仓库既有 2 warnings）
- `pnpm --filter @gomate/frontend type-check`
- `pnpm --filter @gomate/frontend build`
- Playwright 浏览器检查：访客与模拟登录态在 320/768/1024/1440 均无横向溢出、首屏可见、首个 Tab 落在跳过链接、无页面错误

## 风险与回滚

- 不涉及 API、数据库、环境变量或生产资源。
- 登录态切换依赖现有 `fetchCurrentUser`，认证请求失败时按访客首页降级。
- 如需回滚，revert 本 PR 两个提交即可。

## 备注

视觉方向借鉴 Detach 首页的叙事节奏与强 CTA，不复制其字体或插画资产。