### PR TITLE
fix: 修复地点搜索空态 query 展示

### DIFF
--- a/frontend/src/components/features/locations/locations-grid.test.tsx
+++ b/frontend/src/components/features/locations/locations-grid.test.tsx
@@ -5,7 +5,10 @@ import { LocationsGrid } from "./locations-grid";
 
 vi.mock("@/hooks/useI18n", () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string, vars?: Record<string, string | number>) => {
+      if (!vars) return key;
+      return `${key}[${Object.entries(vars).map(([name, value]) => `${name}=${value}`).join(",")}]`;
+    },
     locale: "zh-CN",
     loading: false,
     getNsData: () => null,
@@ -23,6 +26,25 @@ const location = {
 } as unknown as Location;
 
 describe("LocationsGrid", () => {
+  it("将搜索词传入无结果空态文案", () => {
+    render(
+      <LocationsGrid
+        locations={[]}
+        isLoading={false}
+        isRefreshing={false}
+        pagination={{ total: 0, totalPages: 0 }}
+        onClear={vi.fn()}
+        emptyVariant="noSearch"
+        query="咖啡馆"
+        currentPage={1}
+        onPageChange={vi.fn()}
+        getPageNumbers={() => []}
+      />,
+    );
+
+    expect(screen.getByText("locations.empty.noSearch.title[query=咖啡馆]")).toBeInTheDocument();
+  });
+
   it("刷新列表时保留现有卡片，只显示忙碌状态", () => {
     render(
       <LocationsGrid

--- a/frontend/src/components/features/locations/locations-grid.tsx
+++ b/frontend/src/components/features/locations/locations-grid.tsx
@@ -123,6 +123,8 @@ export type EmptyStateVariant = "noSearch" | "noCity" | "noCitySet" | "tooNarrow
 
 export interface EmptyStateProps {
   variant: EmptyStateVariant;
+  /** Search query for the noSearch variant template. */
+  query?: string;
   /** City name for noCity variant template (e.g. "深圳") */
   cityName?: string;
   onClearSearch?: () => void;
@@ -157,6 +159,7 @@ const VARIANT_SECONDARY: Record<EmptyStateVariant, string> = {
 
 export function EmptyState({
   variant,
+  query,
   cityName,
   onClearSearch,
   onClearAll,
@@ -170,9 +173,9 @@ export function EmptyState({
   const primaryConfig = VARIANT_PRIMARY[variant];
   const primaryAction = actionMap[primaryConfig.action];
 
-  const cn = cityName ?? "";
-  const title = t(`locations.empty.${variant}.title`, { cityName: cn });
-  const desc = t(`locations.empty.${variant}.desc`, { cityName: cn });
+  const titleVars: Record<string, string> = variant === "noSearch" ? { query: query ?? "" } : { cityName: cityName ?? "" };
+  const title = t(`locations.empty.${variant}.title`, titleVars);
+  const desc = t(`locations.empty.${variant}.desc`, titleVars);
   const primaryLabel = t(primaryConfig.labelKey);
   const secondaryLabel = t(VARIANT_SECONDARY[variant]);
 
@@ -226,6 +229,7 @@ export function LocationsGrid({
   pagination,
   onClear,
   emptyVariant,
+  query,
   currentPage,
   onPageChange,
   getPageNumbers,
@@ -237,6 +241,8 @@ export function LocationsGrid({
   onClear: () => void;
   /** @default "noSearch" */
   emptyVariant?: EmptyStateVariant;
+  /** Search query for the noSearch empty state. */
+  query?: string;
   currentPage: number;
   onPageChange: (page: number) => void;
   getPageNumbers: () => (number | "...")[];
@@ -269,6 +275,7 @@ export function LocationsGrid({
           ) : locations.length === 0 ? (
             <EmptyState
               variant={emptyVariant ?? "noSearch"}
+              query={query}
               onClearSearch={onClear}
               onClearAll={onClear}
             />

--- a/frontend/src/components/features/locations/locations-main.tsx
+++ b/frontend/src/components/features/locations/locations-main.tsx
@@ -4,16 +4,13 @@ import { Footer } from "@/components/layout/footer";
 import { useI18n } from "@/hooks/useI18n";
 import { useLocationsList, type LocationsListInitialData } from "./use-locations-list";
 import { LocationsHero, LocationsResultBar, LocationsCtaSection } from "./locations-hero";
-import { LocationsGrid } from "./locations-grid";
-
-type EmptyVariant = "noSearch" | "noCity" | "noCitySet" | "tooNarrow";
+import { LocationsGrid, type EmptyStateVariant } from "./locations-grid";
 
 export function LocationsClient({ initialData }: { initialData?: LocationsListInitialData }) {
   const ctx = useLocationsList(initialData);
   const { loading: _i18nLoading } = useI18n(["locations", "filter"]);
 
-  // 计算空态 variant（待 T1 EmptyState 4 variant 完成后透传）
-  const _emptyVariant: EmptyVariant =
+  const emptyVariant: EmptyStateVariant =
     ctx.searchQuery.length > 0
       ? "noSearch"
       : ctx.selectedCityId && ctx.locations.length === 0 && !ctx.searchQuery
@@ -95,6 +92,8 @@ export function LocationsClient({ initialData }: { initialData?: LocationsListIn
             isRefreshing={ctx.isRefreshing}
             pagination={ctx.pagination}
             onClear={ctx.handleClearAll}
+            emptyVariant={emptyVariant}
+            query={ctx.searchQuery}
             currentPage={ctx.currentPage}
             onPageChange={ctx.handlePageChange}
             getPageNumbers={ctx.getPageNumbers}


### PR DESCRIPTION
## 变更
- 修复地点搜索无结果时 `{query}` 未被插值、直接显示占位符的问题
- 将搜索词和空态 variant 从 LocationsClient 透传到 LocationsGrid
- 增加中文搜索词空态回归测试

## 验证
- `pnpm --filter @gomate/frontend test`
- `pnpm i18n:build && pnpm --filter @gomate/frontend i18n:validate`
- `pnpm --filter @gomate/frontend lint`
- `pnpm --filter @gomate/frontend type-check`
- `pnpm --filter @gomate/frontend build`

无 API、数据库、环境变量或生产资源变更。