### PR TITLE
fix: 支持 iOS 下载海报

### DIFF
--- a/frontend/src/__tests__/share-poster-modal-layout.test.tsx
+++ b/frontend/src/__tests__/share-poster-modal-layout.test.tsx
@@ -25,11 +25,12 @@ describe("SharePosterModal layout", () => {
   });
 
   function mockGeneratedPoster() {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response("poster", {
-        status: 200,
-        headers: { "content-type": "image/png" },
-      }),
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () =>
+        new Response("poster", {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
     );
     Object.defineProperties(URL, {
       createObjectURL: {
@@ -130,17 +131,15 @@ describe("SharePosterModal layout", () => {
     });
   });
 
-  it("opens the poster on iOS and only reports success when the new tab opens", async () => {
+  it("uses the download link on iOS", async () => {
     mockGeneratedPoster();
     vi.stubGlobal("navigator", {
       ...navigator,
       userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
     });
-    const openedDocument = document.implementation.createHTMLDocument();
-    const open = vi.spyOn(window, "open").mockReturnValue({
-      document: openedDocument,
-      opener: window,
-    } as Window);
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
 
     render(
       <SharePosterModal
@@ -159,22 +158,26 @@ describe("SharePosterModal layout", () => {
     fireEvent.click(downloadButton);
 
     await waitFor(() => {
-      expect(open).toHaveBeenCalledWith("about:blank", "_blank");
-      expect(openedDocument.body.textContent).toContain("share.posterOpened");
-      expect(openedDocument.querySelector("img")?.getAttribute("src")).toBe(
-        "blob:poster",
-      );
-      expect(screen.getByRole("status")).toHaveTextContent("share.posterOpened");
+      expect(click).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole("status")).toHaveTextContent("share.posterDownloaded");
     });
   });
 
-  it("shows an error instead of a false success when iOS blocks the new tab", async () => {
+  it("uses iOS native file sharing when the browser supports it", async () => {
     mockGeneratedPoster();
+    const share = vi.fn().mockResolvedValue(undefined);
+    const canShare = vi.fn(() => true);
     vi.stubGlobal("navigator", {
       ...navigator,
       userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
     });
-    vi.spyOn(window, "open").mockReturnValue(null);
+    Object.defineProperties(navigator, {
+      share: { configurable: true, value: share },
+      canShare: { configurable: true, value: canShare },
+    });
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
 
     render(
       <SharePosterModal
@@ -193,8 +196,10 @@ describe("SharePosterModal layout", () => {
     fireEvent.click(downloadButton);
 
     await waitFor(() => {
-      expect(screen.getByRole("alert")).toHaveTextContent("share.downloadFailed");
-      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      expect(canShare).toHaveBeenCalledWith({ files: [expect.any(File)] });
+      expect(share).toHaveBeenCalledWith(expect.objectContaining({ files: [expect.any(File)] }));
+      expect(click).not.toHaveBeenCalled();
+      expect(screen.getByRole("status")).toHaveTextContent("share.posterDownloaded");
     });
   });
 });

--- a/frontend/src/components/features/share-poster-modal.tsx
+++ b/frontend/src/components/features/share-poster-modal.tsx
@@ -75,7 +75,7 @@ async function copyText(text: string) {
 export function SharePosterModal({
   type,
   id,
-  title: _title,
+  title,
   url,
   onClose,
   onToast,
@@ -187,44 +187,50 @@ export function SharePosterModal({
     setIsDownloading(true);
 
     try {
-      if (isIOSDevice()) {
-        // iOS Safari ignores the download attribute. Open the blob directly so
-        // users can long-press the image and save it to Photos.
-        // eslint-disable-next-line no-restricted-properties -- iOS Safari requires opening the blob in a new tab
-        const newWindow = window.open("about:blank", "_blank");
-        if (!newWindow) {
-          throw new Error("Unable to open poster");
+      if (
+        isIOSDevice() &&
+        typeof File !== "undefined" &&
+        typeof navigator.share === "function" &&
+        typeof navigator.canShare === "function"
+      ) {
+        try {
+          const response = await fetch(imageUrl);
+          const blob = await response.blob();
+          const file = new File(
+            [blob],
+            `gomate-${type}-${id.slice(0, 8)}-${Date.now()}.png`,
+            { type: blob.type || "image/png" },
+          );
+
+          if (navigator.canShare({ files: [file] })) {
+            await navigator.share({
+              title,
+              files: [file],
+            });
+            notifyAction({ type: "success", message: t("share.posterDownloaded") });
+            return;
+          }
+        } catch (error) {
+          if (error instanceof DOMException && error.name === "AbortError") {
+            return;
+          }
+          // Fall through to the regular download attempt if native sharing
+          // is unavailable or rejected by the host browser.
         }
-        newWindow.opener = null;
-        const document = newWindow.document;
-        document.title = t("share.posterOpened");
-        document.body.style.cssText =
-          "margin:0;display:flex;min-height:100vh;flex-direction:column;align-items:center;justify-content:center;gap:16px;background:#1c1917;padding:16px;box-sizing:border-box;";
-
-        const hint = document.createElement("p");
-        hint.textContent = t("share.posterOpened");
-        hint.style.cssText =
-          "margin:0;color:#fff;font:16px -apple-system,BlinkMacSystemFont,sans-serif;text-align:center;";
-
-        const image = document.createElement("img");
-        image.src = imageUrl;
-        image.alt = type === "team" ? t("share.title") : t("share.locationTitle");
-        image.style.cssText =
-          "display:block;max-width:100%;max-height:calc(100vh - 72px);object-fit:contain;border-radius:12px;";
-        document.body.replaceChildren(hint, image);
-        notifyAction({ type: "success", message: t("share.posterOpened") });
-      } else {
-        // Standard download for Android/PC. Appending the link is required by
-        // Safari and some embedded browsers before click() is dispatched.
-        const link = document.createElement("a");
-        link.href = imageUrl;
-        link.download = `gomate-${type}-${id.slice(0, 8)}-${Date.now()}.png`;
-        link.style.display = "none";
-        document.body.appendChild(link);
-        link.click();
-        link.remove();
-        notifyAction({ type: "success", message: t("share.posterDownloaded") });
       }
+
+      // Use the same user-initiated download flow on iOS as on other browsers.
+      // iOS may still choose to preview the blob instead of saving it, but the
+      // download is now attempted and the user is not silently redirected to
+      // a new tab.
+      const link = document.createElement("a");
+      link.href = imageUrl;
+      link.download = `gomate-${type}-${id.slice(0, 8)}-${Date.now()}.png`;
+      link.style.display = "none";
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      notifyAction({ type: "success", message: t("share.posterDownloaded") });
     } catch {
       notifyAction({ type: "error", message: t("share.downloadFailed") });
     } finally {


### PR DESCRIPTION
## 变更
- iOS 点击下载海报时不再无条件打开新标签页
- 支持文件分享的 iOS 浏览器调用原生文件分享，可保存到照片或文件
- 不支持原生分享时继续触发 `<a download>` 下载尝试
- 增加 iOS 下载链接和原生文件分享回归测试

## 验证
- `pnpm --filter @gomate/frontend test`（33 files / 207 tests）
- `pnpm --filter @gomate/frontend lint`
- `pnpm --filter @gomate/frontend type-check`
- `pnpm --filter @gomate/frontend build`

无 API、数据库、环境变量或生产资源变更。