### PR TITLE
feat: 首页新增推荐地点卡片

### DIFF
--- a/frontend/public/locales/en/home.json
+++ b/frontend/public/locales/en/home.json
@@ -40,6 +40,12 @@
     "title": "Find your next stop on the map",
     "description": "Open a new starting point, from familiar cities to trails you have not walked yet."
   },
+  "featuredLocations": {
+    "kicker": "Places worth going",
+    "title": "Your next stop starts here",
+    "description": "Start with three places and choose the one you want to leave for next.",
+    "viewAll": "View all places"
+  },
   "howItWorks": {
     "kicker": "From idea to outing",
     "title": "Three steps to find your people",

--- a/frontend/public/locales/ja/home.json
+++ b/frontend/public/locales/ja/home.json
@@ -40,6 +40,12 @@
     "title": "地図から次の場所を探す",
     "description": "身近な街からまだ歩いていない道まで、新しい出発点を開きましょう。"
   },
+  "featuredLocations": {
+    "kicker": "出かけたい場所",
+    "title": "次は、ここへ",
+    "description": "3つの場所から、次に出かけたいところを選びましょう。",
+    "viewAll": "すべての場所を見る"
+  },
   "howItWorks": {
     "kicker": "思いから出発へ",
     "title": "3ステップで仲間を見つける",

--- a/frontend/public/locales/zh-CN/home.json
+++ b/frontend/public/locales/zh-CN/home.json
@@ -40,6 +40,12 @@
     "title": "从地图找下一站",
     "description": "从熟悉的城市到还没走过的山野，按省份打开一张新的出发清单。"
   },
+  "featuredLocations": {
+    "kicker": "值得出发",
+    "title": "下一次，去这里",
+    "description": "从三个地点开始，挑一个现在就想去的。",
+    "viewAll": "查看全部地点"
+  },
   "howItWorks": {
     "kicker": "从想去到出发",
     "title": "三步，找到同行的人",

--- a/frontend/src/__tests__/home-locations-section.test.tsx
+++ b/frontend/src/__tests__/home-locations-section.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { Location } from "../lib/types";
+import { HomeLocationsSection } from "../components/features/home/home-locations-section";
+
+vi.mock("@/hooks/useI18n", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+    locale: "zh-CN",
+    loading: false,
+    getNsData: () => null,
+  }),
+}));
+
+const locations = ["天山", "白云山", "海珠湖", "帽峰山"].map((name, index) => ({
+  id: `location-${index}`,
+  name,
+  slug: name,
+  description: `${name}适合周末出发`,
+  address: `广州 · ${name}`,
+  cityId: "guangzhou",
+  cityName: "广州",
+  coverImage: `/images/${index}.jpg`,
+  images: [],
+  coordinates: { lat: 23.1, lng: 113.3 },
+  bestSeason: [],
+  createdAt: "2026-01-01",
+  updatedAt: "2026-01-01",
+} as unknown as Location));
+
+describe("HomeLocationsSection", () => {
+  it("展示最多三个地点卡片并链接到地点详情", () => {
+    render(<HomeLocationsSection locations={locations} />);
+
+    expect(screen.getByTestId("home-featured-locations")).toBeInTheDocument();
+    expect(screen.getAllByTestId("home-location-card")).toHaveLength(3);
+    expect(screen.getByRole("link", { name: /天山/ })).toHaveAttribute(
+      "href",
+      "/locations/location-0",
+    );
+    expect(screen.queryByText("帽峰山")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/features/home/home-locations-section.tsx
+++ b/frontend/src/components/features/home/home-locations-section.tsx
@@ -1,0 +1,96 @@
+import { ArrowUpRight, MapPin } from "lucide-react";
+import { useI18n } from "@/hooks/useI18n";
+import { LocationCoverImage } from "@/components/ui/lazy-image";
+import type { Location } from "@/lib/types";
+
+const CARD_STYLES = [
+  "bg-primary-50 dark:bg-primary/10 md:-rotate-2 md:hover:rotate-0",
+  "bg-secondary dark:bg-secondary/70 md:rotate-[1.5deg] md:hover:rotate-0",
+  "bg-brand-subtle dark:bg-brand-subtle/70 md:-rotate-1 md:hover:rotate-0",
+] as const;
+
+export function HomeLocationsSection({ locations }: { locations: Location[] }) {
+  const { t } = useI18n(["home", "common"]);
+  const featuredLocations = locations.slice(0, 3);
+
+  if (featuredLocations.length === 0) return null;
+
+  return (
+    <section
+      id="featured-locations"
+      className="overflow-hidden border-b border-border/70 bg-secondary/30 py-16 sm:py-20 lg:py-24"
+      data-testid="home-featured-locations"
+    >
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="mb-10 flex flex-col gap-6 sm:mb-14 sm:flex-row sm:items-end sm:justify-between">
+          <div className="max-w-2xl">
+            <p className="home-section-kicker mb-4 text-xs font-bold uppercase tracking-[0.16em] text-amber-800 dark:text-amber-300">
+              {t("home.featuredLocations.kicker")}
+            </p>
+            <h2 className="max-w-xl text-4xl font-bold tracking-[-0.04em] text-foreground sm:text-5xl">
+              {t("home.featuredLocations.title")}
+            </h2>
+            <p className="mt-4 max-w-xl text-base leading-7 text-stone-700 dark:text-stone-300 sm:text-lg">
+              {t("home.featuredLocations.description")}
+            </p>
+          </div>
+
+          <a
+            href="/locations"
+            className="group inline-flex shrink-0 items-center gap-2 text-sm font-semibold text-amber-800 transition-colors hover:text-amber-600 dark:text-amber-300 dark:hover:text-amber-200"
+          >
+            {t("home.featuredLocations.viewAll")}
+            <ArrowUpRight className="h-4 w-4 transition-transform duration-150 group-hover:-translate-y-0.5 group-hover:translate-x-0.5" aria-hidden="true" />
+          </a>
+        </div>
+
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 lg:gap-8">
+          {featuredLocations.map((location, index) => {
+            const summary = location.subtitle?.trim() || location.description;
+
+            return (
+              <a
+                key={location.id}
+                href={`/locations/${location.id}`}
+                className={`group block rounded-[1.75rem] transition-transform duration-300 ease-out focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary motion-reduce:transition-none ${CARD_STYLES[index]}`}
+                data-testid="home-location-card"
+              >
+                <article className="h-full overflow-hidden rounded-[1.75rem] border border-foreground/10 bg-card shadow-warm-lg ring-1 ring-black/5 transition-[box-shadow,transform] duration-300 group-hover:-translate-y-1 group-hover:shadow-warm-xl dark:ring-white/10">
+                  <div className="relative aspect-[4/3] overflow-hidden bg-muted">
+                    <LocationCoverImage
+                      src={location.coverImage}
+                      alt=""
+                      priority={index === 0}
+                      className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105 motion-reduce:transition-none"
+                    />
+                    <div className="absolute inset-0 bg-gradient-to-t from-black/55 via-black/0 to-black/10" aria-hidden="true" />
+                    <span className="absolute left-4 top-4 inline-flex items-center gap-1.5 rounded-full bg-black/30 px-3 py-1.5 text-xs font-semibold text-white backdrop-blur-md">
+                      <MapPin className="h-3.5 w-3.5" aria-hidden="true" />
+                      {location.cityName}
+                    </span>
+                    <span className="absolute bottom-4 left-4 right-4 text-2xl font-bold tracking-tight text-white drop-shadow-sm sm:text-3xl">
+                      {location.name}
+                    </span>
+                  </div>
+
+                  <div className={`flex min-h-44 flex-col p-5 sm:p-6 ${CARD_STYLES[index].split(" ")[0]}`}>
+                    <p className="line-clamp-2 text-sm leading-6 text-stone-700 dark:text-stone-200">
+                      {summary}
+                    </p>
+                    <div className="mt-auto flex items-center justify-between gap-3 pt-6 text-sm font-semibold text-foreground">
+                      <span className="truncate text-stone-700 dark:text-stone-200">{location.address || location.cityName}</span>
+                      <span className="inline-flex shrink-0 items-center gap-1 text-amber-800 dark:text-amber-300">
+                        {t("common.viewDetail")}
+                        <ArrowUpRight className="h-4 w-4 transition-transform duration-150 group-hover:-translate-y-0.5 group-hover:translate-x-0.5" aria-hidden="true" />
+                      </span>
+                    </div>
+                  </div>
+                </article>
+              </a>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/features/home/home-main.tsx
+++ b/frontend/src/components/features/home/home-main.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import { useHomeData, type HomeInitialData } from "./use-home-data";
 import { HomeHero } from "./home-hero";
+import { HomeLocationsSection } from "./home-locations-section";
 import { HomeLocalCircleSection } from "./local-circle/home-local-circle-section";
 import { HomeHowItWorksSection } from "./home-how-it-works-section";
 import { HomeMapSection } from "./home-map-section";
@@ -30,6 +31,7 @@ export function HomeClient({ initialData }: { initialData?: HomeInitialData }) {
       <PreloadImages images={data.preloadImages} />
       <main className="min-h-screen bg-background">
         <HomeHero data={data} isMember={isMember} />
+        <HomeLocationsSection locations={data.locations} />
         <HomeLocalCircleSection />
         <HomeMapSection />
         {!isMember && currentUser === null && <HomeHowItWorksSection />}


### PR DESCRIPTION
## 变更
- 首页 Hero 下方新增最多 3 个推荐地点卡片
- 参考 Detach 的错落倾斜彩色卡片节奏，保留地点封面、城市、简介和详情跳转
- 所有文案补齐 zh-CN / en / ja i18n
- 新增组件测试，保证最多展示 3 个地点

## 验证
- `pnpm i18n:build`
- `pnpm --filter @gomate/frontend i18n:validate`
- `pnpm --filter @gomate/frontend lint`（仅已有 2 条 warning）
- `pnpm --filter @gomate/frontend type-check`
- `pnpm --filter @gomate/frontend build`
- `pnpm --filter @gomate/frontend test`（208 passed）

## 风险与回滚
- 仅前端首页展示和翻译资源，无 API、数据库、环境变量或 Cloudflare 资源变更
- 回滚提交 `87acf65` 即可移除该区块