### PR TITLE
fix(frontend): make guest departure cards interactive

### DIFF
--- a/frontend/public/locales/en/home.json
+++ b/frontend/public/locales/en/home.json
@@ -61,7 +61,10 @@
     "startedBy": "Started by {name}",
     "viewAll": "View all teams",
     "startTeam": "Start a team",
-    "swipeHint": "Swipe to browse teams forming now",
+    "carouselLabel": "Teams forming now",
+    "previous": "Show previous team",
+    "next": "Show next team",
+    "swipeHint": "Drag a card, or use the buttons and arrow keys to switch teams",
     "emptyTitle": "The next team can start with you",
     "emptyDescription": "Choose a place, set a departure time, and invite others to join."
   },

--- a/frontend/public/locales/ja/home.json
+++ b/frontend/public/locales/ja/home.json
@@ -61,7 +61,10 @@
     "startedBy": "{name} が作成",
     "viewAll": "すべてのチームを見る",
     "startTeam": "チームを作る",
-    "swipeHint": "左右にスワイプして募集中のチームを見る",
+    "carouselLabel": "募集中のチーム",
+    "previous": "前のチームを見る",
+    "next": "次のチームを見る",
+    "swipeHint": "カードをドラッグするか、ボタンと矢印キーでチームを切り替えられます",
     "emptyTitle": "次のチームはあなたから始められます",
     "emptyDescription": "行きたい場所と出発時間を決めて、一緒に行く仲間を募集しましょう。"
   },

--- a/frontend/public/locales/zh-CN/home.json
+++ b/frontend/public/locales/zh-CN/home.json
@@ -61,7 +61,10 @@
     "startedBy": "由 {name} 发起",
     "viewAll": "查看全部队伍",
     "startTeam": "发起一支队伍",
-    "swipeHint": "左右滑动查看正在集结的队伍",
+    "carouselLabel": "正在集结的队伍",
+    "previous": "查看上一支队伍",
+    "next": "查看下一支队伍",
+    "swipeHint": "拖动卡片，或使用按钮和方向键切换队伍",
     "emptyTitle": "下一支队伍，也可以由你发起",
     "emptyDescription": "选择想去的地方，发布出发时间，等待同行的人加入。"
   },

--- a/frontend/src/__tests__/home-departure-stack.test.tsx
+++ b/frontend/src/__tests__/home-departure-stack.test.tsx
@@ -1,0 +1,117 @@
+import { createEvent, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { HomeDepartureStack } from "../components/features/home/home-departure-stack";
+import type { Team } from "../lib/types";
+
+vi.mock("@/hooks/useI18n", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+    locale: "zh-CN",
+    loading: false,
+    getNsData: () => null,
+  }),
+}));
+
+const teams = ["周末去梧桐山", "海边日落散步", "城市骑行计划"].map(
+  (title, index) =>
+    ({
+      id: `team-${index}`,
+      locationId: `location-${index}`,
+      title,
+      description: `${title}的活动介绍`,
+      date: "2026-08-16",
+      time: "09:00",
+      duration: "4 小时",
+      maxMembers: 6,
+      currentMembers: index + 2,
+      requirements: [],
+      status: "recruiting",
+      createdAt: "2026-08-01",
+      leader: {
+        id: `leader-${index}`,
+        name: `领队 ${index + 1}`,
+        nickname: null,
+        avatar: null,
+        level: "beginner",
+        completedHikes: 0,
+        bio: "",
+      },
+      location: {
+        id: `location-${index}`,
+        name: `地点 ${index + 1}`,
+        coverImage: `/images/location-${index}.jpg`,
+      },
+    }) as unknown as Team,
+);
+
+describe("HomeDepartureStack", () => {
+  it("只有一支队伍时保持单卡模式且不显示切换控件", () => {
+    render(<HomeDepartureStack teams={teams.slice(0, 1)} />);
+
+    expect(screen.getAllByTestId("guest-departure-card")).toHaveLength(1);
+    expect(screen.getByTestId("guest-departure-card")).toHaveAttribute(
+      "data-active",
+      "true",
+    );
+    expect(
+      screen.queryByRole("button", { name: "home.departures.next" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("把三支队伍渲染为可切换且不会撑宽首页的牌组", () => {
+    render(<HomeDepartureStack teams={teams} />);
+
+    const carousel = screen.getByRole("region", {
+      name: "home.departures.carouselLabel",
+    });
+    const cards = screen.getAllByTestId("guest-departure-card");
+
+    expect(carousel).toHaveClass("min-w-0");
+    expect(cards).toHaveLength(3);
+    expect(cards[0]).toHaveAttribute("data-active", "true");
+    expect(cards[1]).toHaveAttribute("data-active", "false");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "home.departures.next" }),
+    );
+
+    expect(cards[0]).toHaveAttribute("data-active", "false");
+    expect(cards[1]).toHaveAttribute("data-active", "true");
+
+    fireEvent.keyDown(carousel, { key: "ArrowLeft" });
+
+    expect(cards[0]).toHaveAttribute("data-active", "true");
+  });
+
+  it("横向拖动会将下一张队伍卡移到最上层", () => {
+    render(<HomeDepartureStack teams={teams} />);
+
+    const viewport = screen.getByTestId("guest-departure-viewport");
+    const cards = screen.getAllByTestId("guest-departure-card");
+
+    fireEvent.pointerDown(viewport, {
+      clientX: 260,
+      pointerId: 1,
+      pointerType: "touch",
+    });
+    fireEvent.pointerMove(viewport, {
+      clientX: 120,
+      pointerId: 1,
+      pointerType: "touch",
+    });
+    fireEvent.pointerUp(viewport, {
+      clientX: 120,
+      pointerId: 1,
+      pointerType: "touch",
+    });
+
+    expect(cards[0]).toHaveAttribute("data-active", "false");
+    expect(cards[1]).toHaveAttribute("data-active", "true");
+
+    const draggedCardLink = cards[0].querySelector("a");
+    const clickEvent = createEvent.click(draggedCardLink!);
+    fireEvent(draggedCardLink!, clickEvent);
+
+    expect(clickEvent.defaultPrevented).toBe(true);
+  });
+});

--- a/frontend/src/components/features/home/home-departure-stack.tsx
+++ b/frontend/src/components/features/home/home-departure-stack.tsx
@@ -1,14 +1,33 @@
-import { ArrowUpRight, CalendarDays, MapPin, Users } from "lucide-react";
+import {
+  useId,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+  type PointerEvent,
+} from "react";
+import {
+  ArrowUpRight,
+  CalendarDays,
+  ChevronLeft,
+  ChevronRight,
+  MapPin,
+  Users,
+} from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import { LocationCoverImage } from "@/components/ui/lazy-image";
 import { Avatar } from "@/components/ui/avatar";
 import type { Team } from "@/lib/types";
 
-const STACK_POSITIONS = [
-  "lg:left-0 lg:top-6 lg:z-30 lg:w-[88%] lg:-rotate-2",
-  "lg:right-0 lg:top-36 lg:z-20 lg:w-[82%] lg:rotate-3",
-  "lg:left-8 lg:top-64 lg:z-10 lg:w-[84%] lg:-rotate-1",
+const DECK_POSITIONS = [
+  "z-30 translate-x-0 translate-y-0 rotate-0 scale-100 opacity-100",
+  "z-20 translate-x-5 translate-y-7 rotate-2 scale-[0.96] opacity-90 sm:translate-x-8",
+  "z-10 -translate-x-4 translate-y-12 -rotate-2 scale-[0.92] opacity-70 sm:-translate-x-7",
 ] as const;
+
+const SWIPE_THRESHOLD = 48;
+const CLICK_CANCEL_THRESHOLD = 8;
+const MAX_DRAG_DISTANCE = 144;
 
 function RemainingSpots({ team }: { team: Team }) {
   const { t } = useI18n(["home"]);
@@ -23,9 +42,100 @@ function RemainingSpots({ team }: { team: Team }) {
   );
 }
 
+interface DepartureCardProps {
+  team: Team;
+  index: number;
+  deckPosition: number;
+  isActive: boolean;
+  isDragging: boolean;
+  dragOffset: number;
+}
+
+function DepartureCard({
+  team,
+  index,
+  deckPosition,
+  isActive,
+  isDragging,
+  dragOffset,
+}: DepartureCardProps) {
+  const { t } = useI18n(["home"]);
+  const coverImage = team.location?.coverImage;
+  const locationName = team.location?.name;
+  const leaderName = team.leader.nickname || team.leader.name;
+
+  return (
+    <div
+      aria-hidden={!isActive}
+      data-active={isActive}
+      data-testid="guest-departure-card"
+      className={`absolute inset-x-0 top-3 flex justify-center transition-[transform,opacity] duration-500 ease-out motion-reduce:transition-none ${DECK_POSITIONS[deckPosition]}`}
+    >
+      <div
+        className={`w-[88%] max-w-[30rem] ${isDragging ? "" : "transition-transform duration-300 ease-out motion-reduce:transition-none"}`}
+        style={
+          isActive
+            ? ({
+                transform: `translate3d(${dragOffset}px, 0, 0)`,
+              } satisfies CSSProperties)
+            : undefined
+        }
+      >
+        <a
+          href={`/teams/${team.id}`}
+          tabIndex={isActive ? 0 : -1}
+          className={`group relative block h-[22rem] overflow-hidden rounded-[2rem] bg-neutral-900 text-white shadow-warm-xl ring-1 ring-black/10 transition-[transform,box-shadow] duration-300 ease-out motion-reduce:transition-none sm:h-[24rem] lg:h-[27rem] ${isActive ? "pointer-events-auto active:scale-[0.98] lg:hover:-translate-y-1 lg:hover:shadow-2xl" : "pointer-events-none"}`}
+        >
+          {coverImage ? (
+            <LocationCoverImage src={coverImage} alt="" priority={index === 0} className="h-full w-full object-cover" />
+          ) : (
+            <div className="h-full w-full bg-neutral-900" aria-hidden="true" />
+          )}
+          <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/25 to-black/10" aria-hidden="true" />
+
+          <div className="absolute inset-0 flex flex-col p-5 sm:p-6">
+            <div className="flex items-center justify-between gap-3">
+              <span className="inline-flex items-center gap-2 rounded-full bg-black/60 px-3 py-1.5 font-mono text-xs font-semibold text-white/90">
+                <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
+                {team.date}{team.time ? ` · ${team.time}` : ""}
+              </span>
+              <RemainingSpots team={team} />
+            </div>
+
+            <div className="mt-auto">
+              <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">{team.title}</h2>
+              {locationName && (
+                <p className="mt-2 flex items-center gap-1.5 text-sm text-white/75">
+                  <MapPin className="h-4 w-4 shrink-0" aria-hidden="true" />
+                  <span className="truncate">{locationName}</span>
+                </p>
+              )}
+              <div className="mt-5 flex items-center justify-between border-t border-white/20 pt-4">
+                <div className="flex min-w-0 items-center gap-2">
+                  <Avatar src={team.leader.avatar} name={leaderName} size="sm" className="ring-white/80" />
+                  <span className="truncate text-xs text-white/75">{t("home.departures.startedBy", { name: leaderName })}</span>
+                </div>
+                <span className="ml-3 shrink-0 font-mono text-xs font-semibold text-white/90">
+                  {team.currentMembers} / {team.maxMembers}
+                </span>
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+    </div>
+  );
+}
+
 export function HomeDepartureStack({ teams }: { teams: Team[] }) {
   const { t } = useI18n(["home", "common"]);
   const featuredTeams = teams.slice(0, 3);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [dragOffset, setDragOffset] = useState(0);
+  const pointerStartX = useRef<number | null>(null);
+  const dragDistance = useRef(0);
+  const suppressClick = useRef(false);
+  const instructionsId = useId();
 
   if (featuredTeams.length === 0) {
     return (
@@ -43,60 +153,169 @@ export function HomeDepartureStack({ teams }: { teams: Team[] }) {
     );
   }
 
+  const currentIndex = activeIndex % featuredTeams.length;
+
+  const showPrevious = () => {
+    setActiveIndex((current) =>
+      (current - 1 + featuredTeams.length) % featuredTeams.length,
+    );
+  };
+
+  const showNext = () => {
+    setActiveIndex((current) => (current + 1) % featuredTeams.length);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (featuredTeams.length < 2) return;
+
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      showPrevious();
+    } else if (event.key === "ArrowRight") {
+      event.preventDefault();
+      showNext();
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      setActiveIndex(0);
+    } else if (event.key === "End") {
+      event.preventDefault();
+      setActiveIndex(featuredTeams.length - 1);
+    }
+  };
+
+  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    if (
+      featuredTeams.length < 2 ||
+      (event.pointerType === "mouse" && event.button !== 0)
+    ) {
+      return;
+    }
+
+    pointerStartX.current = event.clientX;
+    dragDistance.current = 0;
+    suppressClick.current = false;
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+  };
+
+  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    if (pointerStartX.current === null) return;
+
+    const distance = event.clientX - pointerStartX.current;
+    dragDistance.current = distance;
+    setDragOffset(
+      Math.max(-MAX_DRAG_DISTANCE, Math.min(MAX_DRAG_DISTANCE, distance)),
+    );
+  };
+
+  const finishPointerGesture = (event: PointerEvent<HTMLDivElement>) => {
+    if (pointerStartX.current === null) return;
+
+    const distance = dragDistance.current;
+    suppressClick.current = Math.abs(distance) > CLICK_CANCEL_THRESHOLD;
+
+    if (distance <= -SWIPE_THRESHOLD) {
+      showNext();
+    } else if (distance >= SWIPE_THRESHOLD) {
+      showPrevious();
+    }
+
+    pointerStartX.current = null;
+    dragDistance.current = 0;
+    setDragOffset(0);
+    event.currentTarget.releasePointerCapture?.(event.pointerId);
+
+    window.setTimeout(() => {
+      suppressClick.current = false;
+    }, 0);
+  };
+
   return (
-    <div className="relative -mr-4 overflow-hidden sm:-mr-6 lg:mr-0 lg:h-[34rem] lg:overflow-visible" data-testid="guest-departure-stack">
-      <div className="flex snap-x snap-mandatory gap-4 overflow-x-auto pb-8 pr-12 pt-4 [scrollbar-width:none] lg:block lg:overflow-visible lg:p-0">
+    <div
+      role="region"
+      aria-roledescription="carousel"
+      aria-label={t("home.departures.carouselLabel")}
+      aria-describedby={instructionsId}
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      className="relative min-w-0 w-full outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-4 focus-visible:ring-offset-background"
+      data-testid="guest-departure-stack"
+    >
+      <div
+        className="relative h-[25rem] min-w-0 w-full touch-pan-y select-none sm:h-[27rem] lg:h-[31rem]"
+        data-testid="guest-departure-viewport"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={finishPointerGesture}
+        onPointerCancel={(event) => {
+          pointerStartX.current = null;
+          dragDistance.current = 0;
+          suppressClick.current = false;
+          setDragOffset(0);
+          event.currentTarget.releasePointerCapture?.(event.pointerId);
+        }}
+        onClickCapture={(event) => {
+          if (!suppressClick.current) return;
+          event.preventDefault();
+          event.stopPropagation();
+          suppressClick.current = false;
+        }}
+      >
         {featuredTeams.map((team, index) => {
-          const coverImage = team.location?.coverImage;
-          const locationName = team.location?.name;
-          const leaderName = team.leader.nickname || team.leader.name;
+          const deckPosition =
+            (index - currentIndex + featuredTeams.length) % featuredTeams.length;
+          const isActive = deckPosition === 0;
 
           return (
-            <a
+            <DepartureCard
               key={team.id}
-              href={`/teams/${team.id}`}
-              className={`group relative h-[22rem] w-[82vw] max-w-[23rem] shrink-0 snap-center overflow-hidden rounded-[2rem] bg-neutral-900 text-white shadow-warm-xl ring-1 ring-black/10 transition-[transform,box-shadow] duration-300 ease-out active:scale-[0.98] motion-reduce:transition-none lg:absolute lg:h-[21rem] lg:max-w-none lg:hover:-translate-y-2 ${STACK_POSITIONS[index]}`}
-            >
-              {coverImage ? (
-                <LocationCoverImage src={coverImage} alt="" priority={index === 0} className="h-full w-full object-cover" />
-              ) : (
-                <div className="h-full w-full bg-neutral-900" aria-hidden="true" />
-              )}
-              <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/25 to-black/10" aria-hidden="true" />
-
-              <div className="absolute inset-0 flex flex-col p-5 sm:p-6">
-                <div className="flex items-center justify-between gap-3">
-                  <span className="inline-flex items-center gap-2 rounded-full bg-black/60 px-3 py-1.5 font-mono text-xs font-semibold text-white/90">
-                    <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
-                    {team.date}{team.time ? ` · ${team.time}` : ""}
-                  </span>
-                  <RemainingSpots team={team} />
-                </div>
-
-                <div className="mt-auto">
-                  <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">{team.title}</h2>
-                  {locationName && (
-                    <p className="mt-2 flex items-center gap-1.5 text-sm text-white/75">
-                      <MapPin className="h-4 w-4 shrink-0" aria-hidden="true" />
-                      <span className="truncate">{locationName}</span>
-                    </p>
-                  )}
-                  <div className="mt-5 flex items-center justify-between border-t border-white/20 pt-4">
-                    <div className="flex min-w-0 items-center gap-2">
-                      <Avatar src={team.leader.avatar} name={leaderName} size="sm" className="ring-white/80" />
-                      <span className="truncate text-xs text-white/75">{t("home.departures.startedBy", { name: leaderName })}</span>
-                    </div>
-                    <span className="ml-3 shrink-0 font-mono text-xs font-semibold text-white/90">
-                      {team.currentMembers} / {team.maxMembers}
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </a>
+              team={team}
+              index={index}
+              deckPosition={deckPosition}
+              isActive={isActive}
+              isDragging={isActive && pointerStartX.current !== null}
+              dragOffset={dragOffset}
+            />
           );
         })}
       </div>
-      <p className="pr-4 text-center text-xs text-muted-foreground lg:hidden">{t("home.departures.swipeHint")}</p>
+
+      {featuredTeams.length > 1 && (
+        <div className="mt-1 flex items-center justify-center gap-3">
+          <button
+            type="button"
+            onClick={showPrevious}
+            aria-label={t("home.departures.previous")}
+            className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-border bg-background text-foreground shadow-sm transition-[transform,border-color,color] duration-150 hover:border-primary/50 hover:text-primary active:scale-95 motion-reduce:transition-none"
+          >
+            <ChevronLeft className="h-5 w-5" aria-hidden="true" />
+          </button>
+
+          <div className="flex items-center gap-2" aria-hidden="true">
+            {featuredTeams.map((team, index) => (
+              <span
+                key={team.id}
+                className={`h-2 rounded-full transition-[width,background-color] duration-300 motion-reduce:transition-none ${index === currentIndex ? "w-6 bg-primary" : "w-2 bg-border"}`}
+              />
+            ))}
+          </div>
+
+          <button
+            type="button"
+            onClick={showNext}
+            aria-label={t("home.departures.next")}
+            className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-border bg-background text-foreground shadow-sm transition-[transform,border-color,color] duration-150 hover:border-primary/50 hover:text-primary active:scale-95 motion-reduce:transition-none"
+          >
+            <ChevronRight className="h-5 w-5" aria-hidden="true" />
+          </button>
+        </div>
+      )}
+
+      <p id={instructionsId} className="mt-3 text-center text-xs text-muted-foreground">
+        {t("home.departures.swipeHint")}
+      </p>
+      <p className="sr-only" aria-live="polite">
+        {featuredTeams[currentIndex]?.title}
+      </p>
     </div>
   );
 }

--- a/frontend/src/components/features/home/home-hero.tsx
+++ b/frontend/src/components/features/home/home-hero.tsx
@@ -43,7 +43,7 @@ export function HomeHero({ data }: { data: HomeData }) {
           <p className="mt-3 text-xs text-muted-foreground">{t("home.guestHero.noLoginRequired")}</p>
         </div>
 
-        <div className={`relative mx-auto w-full lg:mx-0 ${animate.search}`}>
+        <div className={`relative mx-auto min-w-0 w-full lg:mx-0 ${animate.search}`}>
           {data.teams.length > 0 || data.locations.length === 0 ? (
             <HomeDepartureStack teams={data.teams} />
           ) : (


### PR DESCRIPTION
## 改动
- 将访客首页队伍展示从移动端横向列表 / 桌面端静态堆叠，统一为三张可交互牌组
- 支持触摸与鼠标横向拖动、前后按钮、方向键 / Home / End 切换
- 拖动后阻止误触进入队伍详情；非当前卡片退出键盘与指针交互
- 为首页网格子项和牌组补上 `min-w-0`，修复卡片行撑宽后没有滚动距离的问题
- 补齐中、英、日文无障碍标签与操作提示

## 验证
- 回归测试红绿验证：旧实现 2/2 失败，新实现通过
- `pnpm i18n:build`
- `pnpm --filter @gomate/frontend i18n:validate`
- `pnpm --filter @gomate/frontend lint`（0 errors；2 条既有 warning）
- `pnpm --filter @gomate/frontend type-check`
- `pnpm --filter @gomate/frontend test`（42 files / 226 tests passed）
- `pnpm --filter @gomate/frontend build`
- 真实浏览器：375 / 768 / 1440px 下 `body.scrollWidth === viewport width`；按钮、键盘、鼠标拖动均成功轮换卡片

## 风险与回滚
- 仅影响未登录首页首屏的队伍展示，不涉及 API、数据库、环境变量、Cloudflare 或其他生产资源
- 回滚方式：revert commit `9fe6e3a`