### PR TITLE
feat: 优化队伍详情页双端体验

### DIFF
--- a/frontend/src/__tests__/team-detail-responsive-layout.test.tsx
+++ b/frontend/src/__tests__/team-detail-responsive-layout.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TeamDepartureBrief } from "../components/features/team-detail/team-detail-overview";
+import { TeamDecisionPrimaryAction } from "../components/features/team-detail/team-detail-sidebar";
+import type { Location, Team } from "../lib/types";
+
+vi.mock("@/hooks/useI18n", () => ({
+  useI18n: () => ({
+    t: (key: string) => {
+      const copy: Record<string, string> = {
+        "common.backTeams": "Back to teams",
+        "teams.activityLocation": "Activity location",
+        "teams.creatorLabel": "Creator",
+        "teams.estimatedPrefix": "Estimated",
+        "teams.joinTeam": "Apply to join",
+        "teams.loginBtn": "Log in",
+        "teams.loginToJoinTeam": "Log in to apply and join the team",
+        "teams.statusEnded": "Ended",
+        "teams.viewLocationDetail": "View location details",
+        "enums.level.advanced": "Advanced",
+      };
+      return copy[key] || key;
+    },
+  }),
+}));
+
+const team = {
+  id: "team-1",
+  locationId: "location-1",
+  title: "惠州大南山｜周末徒步",
+  description: "本周六前往惠州大南山徒步，集合信息由队长通知。",
+  date: "2026-08-08",
+  time: "06:30",
+  duration: "8h",
+  durationMin: 480,
+  maxMembers: 10,
+  currentMembers: 1,
+  requirements: [],
+  status: "recruiting",
+  createdAt: "2026-08-01T00:00:00Z",
+  leader: {
+    id: "leader-1",
+    name: "Victor",
+    nickname: null,
+    avatar: null,
+    level: "advanced",
+    completedHikes: 8,
+    bio: "",
+  },
+} satisfies Team;
+
+const location = {
+  id: "location-1",
+  name: "大南山",
+  slug: "da-nan-shan",
+  description: "",
+  cityId: "huizhou",
+  cityName: "惠州",
+  bestSeason: [],
+  coverImage: "https://example.com/location.jpg",
+  images: [],
+  coordinates: { lat: 22.8, lng: 114.4 },
+  createdAt: "2026-08-01T00:00:00Z",
+  updatedAt: "2026-08-01T00:00:00Z",
+} satisfies Location;
+
+describe("team detail responsive information architecture", () => {
+  it("renders the location image before the decision summary in one departure brief", () => {
+    render(
+      <TeamDepartureBrief
+        team={team}
+        location={location}
+        statusLabel="等你一起"
+        canMessageLeader={false}
+      />,
+    );
+
+    const brief = screen.getByTestId("team-departure-brief");
+    const image = screen.getByRole("img", { name: "大南山" });
+    const heading = screen.getByRole("heading", { level: 1, name: team.title });
+
+    expect(brief).toContainElement(image);
+    expect(brief).toContainElement(heading);
+    expect(image.compareDocumentPosition(heading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(image).toHaveAttribute("width", "1200");
+    expect(image).toHaveAttribute("height", "900");
+    expect(image).toHaveAttribute("loading", "eager");
+    expect(screen.getByRole("link", { name: /大南山/ })).toHaveAttribute(
+      "href",
+      "/locations/location-1",
+    );
+  });
+
+  it("shows only login for an anonymous visitor even when the team has space", () => {
+    render(
+      <TeamDecisionPrimaryAction
+        team={team}
+        userId={null}
+        canJoin
+        isFull={false}
+        isLeader={false}
+        isMember={false}
+        isPending={false}
+        onJoin={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "Log in" })).toHaveAttribute(
+      "href",
+      "/login?redirect=/teams/team-1",
+    );
+    expect(screen.queryByRole("button", { name: "Apply to join" })).not.toBeInTheDocument();
+  });
+
+  it("shows the join action for an authenticated visitor when the team has space", () => {
+    render(
+      <TeamDecisionPrimaryAction
+        team={team}
+        userId="visitor-1"
+        canJoin
+        isFull={false}
+        isLeader={false}
+        isMember={false}
+        isPending={false}
+        onJoin={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Apply to join" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Log in" })).not.toBeInTheDocument();
+  });
+
+  it("does not invite an anonymous visitor to log in when the team has ended", () => {
+    render(
+      <TeamDecisionPrimaryAction
+        team={{ ...team, status: "completed" }}
+        userId={null}
+        canJoin={false}
+        isFull={false}
+        isLeader={false}
+        isMember={false}
+        isPending={false}
+        onJoin={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Ended")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Log in" })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/features/team-detail/team-detail-bottom-bar.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-bottom-bar.tsx
@@ -199,14 +199,16 @@ function MobileBottomBar({ ctx, team, location }: { ctx: ReturnType<typeof useTe
 
   return (
     <div
-      className="fixed bottom-0 left-0 right-0 bg-background/95 backdrop-blur-md border-t border-border z-40 lg:hidden"
+      data-testid="team-mobile-action-bar"
+      className="fixed bottom-0 left-0 right-0 z-40 border-t border-border bg-background shadow-[0_-10px_28px_rgba(82,58,31,0.10)] lg:hidden"
       style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
     >
       <div className="max-w-7xl mx-auto px-4 py-3">
         {isLeader && <BottomBarLeader ctx={ctx} team={team} location={location} />}
         {!isLeader && isMember && <BottomBarMember ctx={ctx} team={team} />}
         {!isLeader && !isMember && isPending && <BottomBarPending ctx={ctx} team={team} />}
-        {!isLeader && !isMember && !isPending && !userId && <BottomBarNotLoggedIn team={team} />}
+        {!isLeader && !isMember && !isPending && !userId && canJoin && <BottomBarNotLoggedIn team={team} />}
+        {!isLeader && !isMember && !isPending && !userId && !canJoin && <BottomBarCannotJoin ctx={ctx} team={team} />}
         {!isLeader && !isMember && !isPending && userId && canJoin && <BottomBarCanJoin ctx={ctx} team={team} />}
         {!isLeader && !isMember && !isPending && userId && !canJoin && <BottomBarCannotJoin ctx={ctx} team={team} />}
       </div>
@@ -226,12 +228,18 @@ function BottomBarLeader({ ctx, team, location: _location }: { ctx: ReturnType<t
           <span className="font-medium">{t('teams.youAreLeader')}</span>
         </div>
         <div className="flex items-center gap-3">
-          <button onClick={share.openShare} className="w-8 h-8 rounded-full bg-secondary flex items-center justify-center text-muted-foreground/70 hover:bg-amber-50 hover:text-amber-600 transition-colors">
-            <Share2 className="h-4 w-4" />
+          <button
+            type="button"
+            onClick={share.openShare}
+            aria-label={t('teams.shareTeam')}
+            className="flex h-10 w-10 items-center justify-center rounded-full bg-secondary text-muted-foreground/70 transition-[transform,background-color,color] duration-150 active:scale-[0.96] motion-reduce:transform-none [@media(hover:hover)]:hover:bg-amber-50 [@media(hover:hover)]:hover:text-amber-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <Share2 className="h-4 w-4" aria-hidden="true" />
           </button>
           {(team.status === "recruiting" || team.status === "cancelled") && (
-            <button onClick={() => ctx.setShowDeleteConfirm(true)}
-              className="w-8 h-8 rounded-full bg-red-50 flex items-center justify-center text-red-500 hover:bg-red-100 transition-colors"
+            <button type="button" onClick={() => ctx.setShowDeleteConfirm(true)}
+              aria-label={t('teams.deleteTeam')}
+              className="flex h-10 w-10 items-center justify-center rounded-full bg-red-50 text-red-500 transition-[transform,background-color] duration-150 active:scale-[0.96] motion-reduce:transform-none [@media(hover:hover)]:hover:bg-red-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
               title={t('teams.deleteTeam')}>
               <Trash2 className="h-4 w-4" />
             </button>
@@ -272,8 +280,8 @@ function BottomBarMember({ ctx, team }: { ctx: ReturnType<typeof useTeamDetail>;
           <span className="font-medium">{t('teams.statusApproved')}</span>
         </div>
         <div className="flex items-center gap-3">
-          <button onClick={share.openShare} className="w-8 h-8 rounded-full bg-secondary flex items-center justify-center text-muted-foreground/70 hover:bg-amber-50 hover:text-amber-600 transition-colors">
-            <Share2 className="h-4 w-4" />
+          <button type="button" onClick={share.openShare} aria-label={t('teams.shareTeam')} className="flex h-10 w-10 items-center justify-center rounded-full bg-secondary text-muted-foreground/70 transition-[transform,background-color,color] duration-150 active:scale-[0.96] motion-reduce:transform-none [@media(hover:hover)]:hover:bg-amber-50 [@media(hover:hover)]:hover:text-amber-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+            <Share2 className="h-4 w-4" aria-hidden="true" />
           </button>
           <button onClick={() => ctx.setShowLeave(true)} className="flex items-center gap-1 text-xs text-muted-foreground border border-border rounded-full px-3 py-1.5 hover:border-red-300 hover:text-red-500 transition-colors">
             <LogOut className="h-3 w-3" />
@@ -310,8 +318,8 @@ function BottomBarPending({ ctx: _ctx, team }: { ctx: ReturnType<typeof useTeamD
           <span className="font-medium">{t('teams.statusPending')}</span>
         </div>
         <div className="flex items-center gap-3">
-          <button onClick={share.openShare} className="w-8 h-8 rounded-full bg-secondary flex items-center justify-center text-muted-foreground/70 hover:bg-amber-50 hover:text-amber-600 transition-colors">
-            <Share2 className="h-4 w-4" />
+          <button type="button" onClick={share.openShare} aria-label={t('teams.shareTeam')} className="flex h-10 w-10 items-center justify-center rounded-full bg-secondary text-muted-foreground/70 transition-[transform,background-color,color] duration-150 active:scale-[0.96] motion-reduce:transform-none [@media(hover:hover)]:hover:bg-amber-50 [@media(hover:hover)]:hover:text-amber-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+            <Share2 className="h-4 w-4" aria-hidden="true" />
           </button>
           <a href="/my-teams" className="text-xs text-amber-600 flex items-center gap-1">
             {t('teams.viewLink')} <ArrowRight className="h-3 w-3" />
@@ -341,7 +349,7 @@ function BottomBarNotLoggedIn({ team }: { team: Team; }) {
     <div className="flex items-center justify-between min-h-[44px]">
       <span className="text-sm text-muted-foreground">{t('teams.loginToJoinTeam')}</span>
       <a href={`/login?redirect=/teams/${team.id}`}
-        className="px-4 py-2 bg-stone-800 text-white rounded-xl text-sm font-medium hover:bg-stone-900 transition-colors">
+        className="inline-flex min-h-11 shrink-0 items-center rounded-xl bg-stone-900 px-5 text-sm font-semibold text-white transition-[transform,background-color] duration-150 active:scale-[0.96] motion-reduce:transform-none [@media(hover:hover)]:hover:bg-stone-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
         {t('teams.loginBtn')}
       </a>
     </div>
@@ -355,11 +363,11 @@ function BottomBarCanJoin({ ctx, team }: { ctx: ReturnType<typeof useTeamDetail>
   return (
     <>
       <div className="flex items-center gap-2">
-        <button onClick={share.openShare} className="w-11 h-11 rounded-2xl bg-secondary flex items-center justify-center text-muted-foreground hover:bg-amber-50 hover:text-amber-600 border border-border hover:border-amber-200 transition-[transform,background-color,border-color,color,opacity,box-shadow] flex-shrink-0">
-          <Share2 className="h-4 w-4" />
+        <button type="button" onClick={share.openShare} aria-label={t('teams.shareTeam')} className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-border bg-secondary text-muted-foreground transition-[transform,background-color,border-color,color] duration-150 active:scale-[0.96] motion-reduce:transform-none [@media(hover:hover)]:hover:border-amber-200 [@media(hover:hover)]:hover:bg-amber-50 [@media(hover:hover)]:hover:text-amber-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+          <Share2 className="h-4 w-4" aria-hidden="true" />
         </button>
-        <button onClick={() => ctx.setShowJoinModal(true)}
-          className="flex-1 py-3 rounded-2xl font-semibold text-white bg-gradient-to-r from-amber-600 to-amber-500 hover:from-amber-700 hover:to-amber-600 transition-[transform,background-color,border-color,color,opacity,box-shadow] min-h-[44px]">
+        <button type="button" onClick={() => ctx.setShowJoinModal(true)}
+          className="ml-auto inline-flex min-h-11 w-fit items-center justify-center rounded-xl bg-amber-600 px-6 font-semibold text-white transition-[transform,background-color] duration-150 active:scale-[0.96] motion-reduce:transform-none [@media(hover:hover)]:hover:bg-amber-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
           {t('teams.joinTeam')}
         </button>
       </div>
@@ -390,8 +398,8 @@ function BottomBarCannotJoin({ ctx: _ctx, team }: { ctx: ReturnType<typeof useTe
         <div className="text-muted-foreground/70 text-sm">
           {team.status === "completed" ? t('teams.statusEnded') : team.status === "cancelled" ? t('teams.statusCancelled') : t('teams.teamFull')}
         </div>
-        <button onClick={share.openShare} className="w-8 h-8 rounded-full bg-secondary flex items-center justify-center text-muted-foreground/70 hover:bg-amber-50 hover:text-amber-600 transition-colors">
-          <Share2 className="h-4 w-4" />
+        <button type="button" onClick={share.openShare} aria-label={t('teams.shareTeam')} className="flex h-10 w-10 items-center justify-center rounded-full bg-secondary text-muted-foreground/70 transition-[transform,background-color,color] duration-150 active:scale-[0.96] motion-reduce:transform-none [@media(hover:hover)]:hover:bg-amber-50 [@media(hover:hover)]:hover:text-amber-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+          <Share2 className="h-4 w-4" aria-hidden="true" />
         </button>
       </div>
 

--- a/frontend/src/components/features/team-detail/team-detail-content.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-content.tsx
@@ -1,25 +1,18 @@
-import { MapPin, ArrowRight, AlertCircle, Clock, TrendingUp, Mountain } from "lucide-react";
+import { AlertCircle, Users } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
+import { TeamActivityPosts } from "@/components/features/activity-posts";
 import { useTeamDetail } from "./use-team-detail";
-import { getStatusInfo } from "./team-detail-utils";
 import { MemberAvatarGrid } from "./team-detail-members";
 import { TeamActionbookSection } from "./team-actionbook-section";
-import { TeamActivityPosts } from "@/components/features/activity-posts";
-import { formatRouteMetric, normalizeLocationHiking } from "@/components/features/location-detail/route-utils";
-import type { Location, Team } from "@/lib/types";
 
-export function TeamMainContent({ ctx }: { ctx: ReturnType<typeof useTeamDetail>; }) {
-  const { team, location, allMembers, canJoin, isFull, isLeader, isMember, isPending, userId, show, loadTeam } = ctx;
-  const { t } = useI18n(["enums", "teams"]);
+export function TeamMainContent({ ctx }: { ctx: ReturnType<typeof useTeamDetail> }) {
+  const { team, allMembers, isLeader, isMember, userId, show, loadTeam } = ctx;
+  const { t } = useI18n(["teams"]);
 
   if (!team) return null;
 
-  const statusInfo = getStatusInfo(team.status, t);
-
   return (
-    <div className="space-y-6">
-      {location && <LocationCover location={location} statusInfo={statusInfo} />}
-      {/* task #165：Team「行动本」区块——放主内容顶部，spec §3 */}
+    <div className="space-y-7 lg:col-start-1 lg:row-start-1 lg:space-y-8">
       <TeamActionbookSection
         team={team}
         currentUserId={userId}
@@ -29,13 +22,21 @@ export function TeamMainContent({ ctx }: { ctx: ReturnType<typeof useTeamDetail>
         onToast={show}
         refetchTeam={loadTeam}
       />
+
       <RequirementsList requirements={team.requirements} />
+
       {allMembers.length > 0 && (
-        <div className="bg-muted rounded-2xl p-6 space-y-4">
-          <div className="flex items-center justify-between">
-            <h3 className="text-base font-semibold text-foreground">{t('teams.guestList')}</h3>
-            <span className="text-sm text-muted-foreground bg-white px-3 py-1 rounded-full">
-              {allMembers.length} {t('teams.goingCount')}
+        <section
+          aria-labelledby="team-members-title"
+          className="rounded-[20px] bg-card px-5 py-6 shadow-[0_8px_28px_rgba(82,58,31,0.08)] sm:px-7 sm:py-7"
+        >
+          <div className="mb-5 flex items-center justify-between gap-4">
+            <h2 id="team-members-title" className="flex items-center gap-2 text-lg font-bold text-foreground">
+              <Users className="h-5 w-5 text-amber-600" aria-hidden="true" />
+              {t("teams.guestList")}
+            </h2>
+            <span className="shrink-0 rounded-full bg-secondary px-3 py-1 text-sm tabular-nums text-muted-foreground">
+              {allMembers.length} {t("teams.goingCount")}
             </span>
           </div>
           <MemberAvatarGrid
@@ -44,9 +45,9 @@ export function TeamMainContent({ ctx }: { ctx: ReturnType<typeof useTeamDetail>
             teamId={team.id}
             canMessageMembers={isLeader}
           />
-        </div>
+        </section>
       )}
-      <JoinSection ctx={ctx} team={team} canJoin={canJoin} isFull={isFull} isLeader={isLeader} isMember={isMember} isPending={isPending} userId={userId} />
+
       {team.status === "completed" && (
         <TeamActivityPosts teamId={team.id} teamStatus={team.status} isMember={isMember} />
       )}
@@ -54,150 +55,29 @@ export function TeamMainContent({ ctx }: { ctx: ReturnType<typeof useTeamDetail>
   );
 }
 
-function LocationCover({ location, statusInfo }: { location: Location; statusInfo: { label: string }; }) {
-  const { t } = useI18n(["teams"]);
-  return (
-    <a href={`/locations/${location.id}`} className="group block">
-      <div className="relative h-[300px] lg:h-[400px] rounded-2xl overflow-hidden bg-secondary hover:shadow-xl hover:shadow-amber-100/30 transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-300">
-        {location.coverImage ? (
-          <img
-            src={location.coverImage}
-            alt={location.name}
-            loading="lazy"
-            decoding="async"
-            className="w-full h-full object-cover group-hover:scale-[1.02] transition-transform duration-500"
-          />
-        ) : (
-          <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-stone-800 to-stone-900">
-            <Mountain className="h-16 w-16 text-amber-400/60" />
-          </div>
-        )}
-        <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />
-        <div className="absolute top-4 left-4">
-          <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium bg-amber-500/90 text-white backdrop-blur-sm shadow-lg">
-            {statusInfo.label}
-          </span>
-        </div>
-        {location.cityName && (
-          <div className="absolute top-4 right-4">
-            <span className="inline-flex items-center gap-1 px-3 py-1.5 rounded-full text-xs font-medium bg-black/40 text-white backdrop-blur-sm">
-              <MapPin className="w-3.5 h-3.5" />
-              {location.cityName}
-            </span>
-          </div>
-        )}
-        <div className="absolute bottom-0 left-0 right-0 p-6">
-          <div className="flex items-center gap-2 text-white/80 text-sm mb-2">
-            <MapPin className="w-4 h-4" />
-            <span>{t('teams.activityLocation')}</span>
-          </div>
-          <h2 className="text-2xl font-bold text-white mb-2">{location.name}</h2>
-          <LocationRouteInfo location={location} />
-          <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-amber-500/20 hover:bg-amber-500/30 backdrop-blur-sm border border-amber-400/30 text-amber-200 hover:text-white text-sm font-medium transition-[transform,background-color,border-color,color,opacity,box-shadow] duration-150">
-            <span>{t('teams.viewLocationDetail')}</span>
-            <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform duration-200" />
-          </div>
-        </div>
-      </div>
-    </a>
-  );
-}
-
-function LocationRouteInfo({ location }: { location: Location; }) {
-  const { t } = useI18n(["locationDetail"]);
-  // task #152 切源：徒步参数读 location 自身字段（0010 回填），不再读 routes[0]
-  const hiking = normalizeLocationHiking(location);
-  const durationText = formatRouteMetric(hiking?.duration, t);
-  const distanceText = hiking?.distance?.value;
-  if (!durationText && !distanceText) return null;
-  return (
-    <div className="flex items-center gap-4 text-white/70 text-sm mb-3">
-      {durationText && (
-        <span className="flex items-center gap-1">
-          <Clock className="w-4 h-4" />
-          {durationText}
-        </span>
-      )}
-      {distanceText && (
-        <span className="flex items-center gap-1">
-          <TrendingUp className="w-4 h-4" />
-          {distanceText}
-        </span>
-      )}
-    </div>
-  );
-}
-
-function RequirementsList({ requirements }: { requirements: string[]; }) {
+function RequirementsList({ requirements }: { requirements: string[] }) {
   const { t } = useI18n(["teams"]);
   if (!Array.isArray(requirements) || requirements.length === 0) return null;
+
   return (
-    <div className="bg-muted rounded-2xl p-6 space-y-4">
-      <h3 className="text-base font-semibold text-foreground flex items-center gap-2">
-        <AlertCircle className="w-5 h-5 text-amber-500" />
-        {t('teams.requirementsTitle')}
-      </h3>
-      <ul className="space-y-3">
-        {requirements.map((req: string, i: number) => (
-          <li key={i} className="flex items-start gap-3 text-base text-muted-foreground">
-            <span className="w-6 h-6 rounded-full bg-amber-100 text-amber-700 text-sm font-medium flex items-center justify-center mt-0.5 flex-shrink-0">
-              {i + 1}
+    <section
+      aria-labelledby="team-requirements-title"
+      className="rounded-[20px] bg-secondary/70 px-5 py-6 sm:px-7 sm:py-7"
+    >
+      <h2 id="team-requirements-title" className="flex items-center gap-2 text-lg font-bold text-foreground">
+        <AlertCircle className="h-5 w-5 text-amber-600" aria-hidden="true" />
+        {t("teams.requirementsTitle")}
+      </h2>
+      <ol className="mt-5 grid gap-4 sm:grid-cols-2">
+        {requirements.map((requirement, index) => (
+          <li key={`${index}-${requirement}`} className="flex items-start gap-3 text-sm leading-7 text-muted-foreground">
+            <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-amber-100 text-sm font-bold tabular-nums text-amber-800">
+              {index + 1}
             </span>
-            {req}
+            <span className="text-pretty">{requirement}</span>
           </li>
         ))}
-      </ul>
-    </div>
+      </ol>
+    </section>
   );
-}
-
-function JoinSection({ ctx, team, canJoin, isFull, isLeader, isMember, isPending, userId }: {
-  ctx: ReturnType<typeof useTeamDetail>; team: Team;
-  canJoin: boolean; isFull: boolean; isLeader: boolean; isMember: boolean; isPending: boolean; userId: string | null;
-}) {
-  const { t } = useI18n(["teams"]);
-  if (canJoin) {
-    return (
-      <button
-        data-testid="team-join-button"
-        onClick={() => ctx.setShowJoinModal(true)}
-        className="w-full py-4 bg-amber-600 text-white text-lg font-medium rounded-xl hover:bg-amber-700 transition-colors"
-      >
-        {t('teams.joinTeam')}
-      </button>
-    );
-  }
-
-  if (!userId && !isLeader && !isMember && !isPending) {
-    return (
-      <div className="bg-muted rounded-2xl p-6 text-center space-y-3">
-        <p className="text-sm text-muted-foreground">{t('teams.loginToJoinTeam')}</p>
-        <a href={`/login?redirect=/teams/${team.id}`}
-          className="inline-flex items-center gap-2 px-6 py-3 bg-stone-800 text-white rounded-xl text-sm font-medium hover:bg-stone-900 transition-colors">
-          {t('teams.loginBtn')}
-          <ArrowRight className="w-4 h-4" />
-        </a>
-      </div>
-    );
-  }
-
-  if (!canJoin && !isLeader && !isMember && !isPending && team.status === "recruiting" && isFull) {
-    return (
-      <div className="bg-muted rounded-2xl p-6 text-center">
-        <p className="text-base text-muted-foreground/70">{t('teams.teamFullCannotJoin')}</p>
-      </div>
-    );
-  }
-
-  if (!canJoin && !isLeader && !isMember && !isPending && team.status !== "recruiting") {
-    return (
-      <div className="bg-muted rounded-2xl p-6 text-center">
-        <p className="text-base text-muted-foreground/70">
-          {team.status === "completed" ? t('teams.statusEnded') : t('teams.statusCancelled')}
-        </p>
-      </div>
-    );
-  }
-
-  return null;
 }

--- a/frontend/src/components/features/team-detail/team-detail-main.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-main.tsx
@@ -8,13 +8,15 @@ import { TeamMainContent } from "./team-detail-content";
 import { TeamModalsAndFooter } from "./team-detail-bottom-bar";
 import { TeamDetailSkeleton } from "./team-detail-skeleton";
 import { useI18n } from "@/hooks/useI18n";
+import { TeamDepartureBrief } from "./team-detail-overview";
+import { getStatusInfo } from "./team-detail-utils";
 
 interface TeamDetailPartifulProps {
   teamId: string;
 }
 
 export function TeamDetailPartiful({ teamId }: TeamDetailPartifulProps) {
-  const { t } = useI18n(["teams", "common"]);
+  const { t } = useI18n(["teams", "common", "enums"]);
   const ctx = useTeamDetail(teamId);
   const { team, loading, error } = ctx;
 
@@ -37,12 +39,20 @@ export function TeamDetailPartiful({ teamId }: TeamDetailPartifulProps) {
     );
   }
 
+  const statusInfo = getStatusInfo(team.status, t);
+
   return (
     <main className="min-h-screen bg-background flex flex-col">
       <Navbar />
-      {/* pt-20 为固定导航栏预留空间（移动端） */}
-      <div className="flex-1 max-w-7xl mx-auto px-6 pt-20 pb-8 lg:pt-8 lg:pb-12 lg:py-8 pb-24 lg:pb-12">
-        <div className="grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-8 lg:gap-12">
+      <div className="mx-auto w-full max-w-7xl flex-1 px-4 pb-28 pt-20 sm:px-6 lg:pb-16 lg:pt-8">
+        <TeamDepartureBrief
+          team={team}
+          location={ctx.location}
+          statusLabel={statusInfo.label}
+          canMessageLeader={ctx.isMember}
+        />
+
+        <div className="mt-7 grid grid-cols-1 gap-7 lg:mt-10 lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-start lg:gap-10">
           <TeamSidebar ctx={ctx} />
           <TeamMainContent ctx={ctx} />
         </div>

--- a/frontend/src/components/features/team-detail/team-detail-overview.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-overview.tsx
@@ -1,0 +1,205 @@
+import * as React from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Calendar,
+  Clock,
+  Crown,
+  Loader2,
+  MapPin,
+  MessageCircle,
+  Mountain,
+  Timer,
+} from "lucide-react";
+import { useI18n } from "@/hooks/useI18n";
+import { createConversation } from "@/hooks/useMessages";
+import { TeamLeaderMini } from "@/components/features/teams/shared";
+import type { Location, Team } from "@/lib/types";
+import { formatDuration } from "./team-detail-utils";
+
+interface TeamDepartureBriefProps {
+  team: Team;
+  location: Location | null;
+  statusLabel: string;
+  canMessageLeader: boolean;
+}
+
+export function TeamDepartureBrief({
+  team,
+  location,
+  statusLabel,
+  canMessageLeader,
+}: TeamDepartureBriefProps) {
+  const { t } = useI18n(["teams", "common"]);
+  const [isStartingConversation, setIsStartingConversation] = React.useState(false);
+  const [messageError, setMessageError] = React.useState<string | null>(null);
+
+  const handleMessageLeader = async () => {
+    setIsStartingConversation(true);
+    setMessageError(null);
+    try {
+      const conversation = await createConversation(team.id);
+      window.location.href = `/messages/${conversation.id}`;
+    } catch (error) {
+      console.error("Failed to create conversation:", error);
+      setMessageError(t("teams.messageStartFailed"));
+    } finally {
+      setIsStartingConversation(false);
+    }
+  };
+
+  return (
+    <section
+      data-testid="team-departure-brief"
+      className="overflow-hidden rounded-[20px] bg-card shadow-[0_18px_48px_rgba(82,58,31,0.10)] lg:grid lg:grid-cols-[minmax(0,1.15fr)_minmax(22rem,0.85fr)]"
+    >
+      <LocationMedia location={location} />
+
+      <div className="flex flex-col px-5 py-6 sm:px-8 sm:py-8 lg:px-10 lg:py-10">
+        <a
+          href="/teams"
+          className="mb-6 inline-flex min-h-10 w-fit items-center gap-2 rounded-lg px-2 text-sm font-medium text-muted-foreground transition-[transform,color,background-color] duration-150 active:scale-[0.96] motion-reduce:transform-none [@media(hover:hover)]:hover:bg-accent [@media(hover:hover)]:hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+          {t("common.backTeams")}
+        </a>
+
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          <span className="inline-flex min-h-8 items-center rounded-full bg-amber-100 px-3 text-sm font-semibold text-amber-800">
+            {statusLabel}
+          </span>
+          {location?.cityName && (
+            <span className="inline-flex min-h-8 items-center gap-1.5 rounded-full bg-secondary px-3 text-sm text-muted-foreground">
+              <MapPin className="h-3.5 w-3.5" aria-hidden="true" />
+              {location.cityName}
+            </span>
+          )}
+        </div>
+
+        <h1 className="text-balance text-3xl font-bold leading-[1.18] text-foreground sm:text-4xl lg:text-[2.65rem]">
+          {team.title}
+        </h1>
+
+        <ul className="mt-6 grid grid-cols-1 gap-3 border-y border-border py-5 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
+          <MetaItem icon={Calendar} label={team.date} />
+          {team.time && <MetaItem icon={Clock} label={team.time} />}
+          {team.durationMin && team.durationMin > 0 && (
+            <MetaItem
+              icon={Timer}
+              label={`${t("teams.estimatedPrefix")} ${formatDuration(team.durationMin / 60)}`}
+            />
+          )}
+          {location && <MetaItem icon={MapPin} label={location.name} />}
+        </ul>
+
+        {team.description && (
+          <div className="prose prose-stone mt-5 max-w-none text-pretty text-sm leading-7 text-muted-foreground prose-p:my-0">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{team.description}</ReactMarkdown>
+          </div>
+        )}
+
+        {team.leader && (
+          <div className="mt-6 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-5">
+            <a
+              href={`/users/${team.leader.id}`}
+              className="inline-flex min-h-11 items-center gap-3 rounded-xl px-2 transition-[transform,background-color] duration-150 active:scale-[0.96] motion-reduce:transform-none [@media(hover:hover)]:hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-amber-100 text-amber-700">
+                <Crown className="h-4 w-4" aria-hidden="true" />
+              </span>
+              <span>
+                <span className="block text-xs text-muted-foreground">{t("teams.creatorLabel")}</span>
+                <TeamLeaderMini leader={team.leader} showLevel size="sm" />
+              </span>
+            </a>
+
+            {canMessageLeader && (
+              <button
+                type="button"
+                onClick={handleMessageLeader}
+                disabled={isStartingConversation}
+                className="inline-flex min-h-10 items-center gap-2 rounded-xl bg-primary/10 px-4 text-sm font-semibold text-primary transition-[transform,background-color] duration-150 active:scale-[0.96] motion-reduce:transform-none [@media(hover:hover)]:hover:bg-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isStartingConversation ? (
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                ) : (
+                  <MessageCircle className="h-4 w-4" aria-hidden="true" />
+                )}
+                {t("teams.messageLeader")}
+              </button>
+            )}
+          </div>
+        )}
+
+        {messageError && <p className="mt-2 text-sm text-red-600">{messageError}</p>}
+      </div>
+    </section>
+  );
+}
+
+function LocationMedia({ location }: { location: Location | null }) {
+  const { t } = useI18n(["teams"]);
+  const content = (
+    <div className="group relative min-h-72 overflow-hidden bg-stone-900 lg:h-full lg:min-h-[34rem]">
+      {location?.coverImage ? (
+        <img
+          src={location.coverImage}
+          alt={location.name}
+          width={1200}
+          height={900}
+          loading="eager"
+          decoding="async"
+          className="h-full w-full object-cover transition-transform duration-300 motion-reduce:transform-none [@media(hover:hover)]:group-hover:scale-[1.015]"
+        />
+      ) : (
+        <div className="flex h-full min-h-72 items-center justify-center bg-stone-900 text-amber-300/70">
+          <Mountain className="h-16 w-16" aria-hidden="true" />
+        </div>
+      )}
+
+      {location && (
+        <div className="absolute inset-x-0 bottom-0 bg-stone-950/75 p-5 text-white sm:p-6">
+          <span className="mb-1 flex items-center gap-1.5 text-xs text-white/75">
+            <MapPin className="h-3.5 w-3.5" aria-hidden="true" />
+            {t("teams.activityLocation")}
+          </span>
+          <div className="flex items-end justify-between gap-4">
+            <span className="text-2xl font-bold leading-tight sm:text-3xl">{location.name}</span>
+            <span className="inline-flex min-h-10 shrink-0 items-center gap-2 rounded-xl bg-amber-500 px-3.5 text-sm font-semibold text-stone-950 transition-transform duration-150 group-active:scale-[0.96] motion-reduce:transform-none">
+              <span className="hidden sm:inline">{t("teams.viewLocationDetail")}</span>
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+
+  if (!location) return content;
+
+  return (
+    <a
+      href={`/locations/${location.id}`}
+      className="block min-h-72 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring lg:min-h-full"
+    >
+      {content}
+    </a>
+  );
+}
+
+function MetaItem({
+  icon: Icon,
+  label,
+}: {
+  icon: React.ComponentType<{ className?: string; "aria-hidden"?: boolean | "true" | "false" }>;
+  label: string;
+}) {
+  return (
+    <li className="flex min-h-8 items-center gap-2 text-sm text-foreground/80">
+      <Icon className="h-4 w-4 shrink-0 text-amber-600" aria-hidden="true" />
+      <span className="font-medium tabular-nums">{label}</span>
+    </li>
+  );
+}

--- a/frontend/src/components/features/team-detail/team-detail-sidebar.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-sidebar.tsx
@@ -1,14 +1,10 @@
-import { MapPin, ArrowRight, Calendar, Clock, Timer, AlertCircle, CheckCircle, Crown, Share2, Loader2, Users, Trash2, Pencil, MessageCircle } from "lucide-react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { ArrowRight, Clock, AlertCircle, CheckCircle, Share2, Loader2, Users, Trash2, Pencil } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
-import type { Team, Location } from "@/lib/types";
+import type { Team } from "@/lib/types";
 import { useTeamDetail } from "./use-team-detail";
-import { formatDuration } from "./team-detail-utils";
 import { TeamApplicationsSection } from "./team-detail-applications";
-import { TeamProgress, TeamLeaderMini } from "@/components/features/teams/shared";
+import { TeamProgress } from "@/components/features/teams/shared";
 import * as React from "react";
-import { createConversation } from "@/hooks/useMessages";
 
 // 懒加载分享相关组件
 const ShareOptionsSheet = React.lazy(() => import("./share-options-sheet").then(m => ({ default: m.ShareOptionsSheet })));
@@ -58,30 +54,36 @@ function useTeamShare(team: Team | null) {
 }
 
 export function TeamSidebar({ ctx }: { ctx: ReturnType<typeof useTeamDetail>; }) {
-  const { team, location, isLeader, isMember, isPending, statusLoadFailed, applications, isFull } = ctx;
+  const { team, isLeader, isMember, isPending, statusLoadFailed, applications, isFull } = ctx;
   const share = useTeamShare(team);
 
   if (!team) return null;
 
   return (
-    <aside className="lg:sticky lg:top-24 lg:self-start space-y-6">
-      <h1 className="text-2xl lg:text-3xl font-bold text-foreground leading-tight">{team.title}</h1>
-      <TeamTimeInfo team={team} />
-      {location && <MobileLocationLink location={location} />}
-      {team.description && (
-        <div className="border-t border-border pt-4">
-          <div className="text-sm text-muted-foreground leading-relaxed prose-sm">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{team.description}</ReactMarkdown>
-          </div>
+    <aside data-testid="team-decision-panel" className="space-y-5 lg:sticky lg:top-24 lg:col-start-2 lg:row-start-1 lg:self-start">
+      <div className="rounded-[20px] bg-card p-5 shadow-[0_8px_28px_rgba(82,58,31,0.08)] sm:p-6">
+        <TeamCapacity team={team} canJoin={ctx.canJoin} remaining={ctx.remaining} />
+
+        <div className="mt-5 hidden lg:block">
+          <TeamDecisionPrimaryAction
+            team={team}
+            userId={ctx.userId}
+            canJoin={ctx.canJoin}
+            isFull={ctx.isFull}
+            isLeader={ctx.isLeader}
+            isMember={ctx.isMember}
+            isPending={ctx.isPending}
+            onJoin={() => ctx.setShowJoinModal(true)}
+          />
         </div>
-      )}
-      <TeamCapacity team={team} canJoin={ctx.canJoin} remaining={ctx.remaining} />
-      {team.leader && <LeaderCard leader={team.leader} teamId={team.id} canMessage={isMember} />}
-      <ShareButton onClick={share.openShare} />
-      {isLeader && <LeaderActions ctx={ctx} team={team} />}
-      {isMember && <MemberStatusIndicator onLeave={() => ctx.setShowLeave(true)} />}
-      {isPending && <PendingStatusIndicator />}
-      {statusLoadFailed && <StatusLoadError onRetry={ctx.loadTeam} />}
+
+        <ShareButton onClick={share.openShare} />
+        {isLeader && <LeaderActions ctx={ctx} team={team} />}
+        {isMember && <MemberStatusIndicator onLeave={() => ctx.setShowLeave(true)} />}
+        {isPending && <PendingStatusIndicator />}
+        {statusLoadFailed && <StatusLoadError onRetry={ctx.loadTeam} />}
+      </div>
+
       {isLeader && (
         <TeamApplicationsSection
           applications={applications}
@@ -112,47 +114,10 @@ export function TeamSidebar({ ctx }: { ctx: ReturnType<typeof useTeamDetail>; })
   );
 }
 
-function TeamTimeInfo({ team }: { team: Team; }) {
-  const { t } = useI18n(["teams"]);
-  return (
-    <div className="space-y-2">
-      <div className="flex items-center gap-2 text-base text-foreground/70">
-        <Calendar className="w-4 h-4 text-amber-500" />
-        <span className="font-medium">{team.date}</span>
-      </div>
-      {team.time && (
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <Clock className="w-4 h-4" />
-          <span>{team.time}</span>
-        </div>
-      )}
-      {team.durationMin && team.durationMin > 0 && (
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <Timer className="w-4 h-4" />
-          <span>{t('teams.estimatedPrefix')} {formatDuration(team.durationMin / 60)}</span>
-        </div>
-      )}
-    </div>
-  );
-}
-
-function MobileLocationLink({ location }: { location: Location; }) {
-  return (
-    <div className="lg:hidden">
-      <a href={`/locations/${location.id}`}
-        className="flex items-center gap-2 px-3 py-2 bg-muted rounded-lg text-foreground/70 hover:bg-amber-50 hover:text-amber-700 transition-colors">
-        <MapPin className="w-4 h-4" />
-        <span className="font-medium text-sm">{location.name}</span>
-        <ArrowRight className="w-3 h-3 ml-auto" />
-      </a>
-    </div>
-  );
-}
-
 function TeamCapacity({ team, canJoin, remaining }: { team: Team; canJoin: boolean; remaining: number; }) {
   const { t } = useI18n(["teams"]);
   return (
-    <div className="bg-amber-50 rounded-xl p-4 space-y-3">
+    <div className="rounded-xl bg-amber-50 p-4 space-y-3">
       <TeamProgress
         current={team.currentMembers}
         max={team.maxMembers}
@@ -161,7 +126,7 @@ function TeamCapacity({ team, canJoin, remaining }: { team: Team; canJoin: boole
         size="md"
       />
       {canJoin && remaining > 0 && (
-        <p className="text-xs text-amber-600 mt-2 font-medium text-center">
+        <p className="mt-2 text-center text-xs font-medium text-amber-800">
           {remaining === 1 ? t('teams.spotsRemainingOne') : t('teams.spotsRemainingCount').replace('{remaining}', String(remaining))}
         </p>
       )}
@@ -169,60 +134,80 @@ function TeamCapacity({ team, canJoin, remaining }: { team: Team; canJoin: boole
   );
 }
 
-function LeaderCard({ leader, teamId, canMessage }: { leader: Team["leader"]; teamId: string; canMessage: boolean; }) {
+export function TeamDecisionPrimaryAction({
+  team,
+  userId,
+  canJoin,
+  isFull,
+  isLeader,
+  isMember,
+  isPending,
+  onJoin,
+}: {
+  team: Team;
+  userId: string | null;
+  canJoin: boolean;
+  isFull: boolean;
+  isLeader: boolean;
+  isMember: boolean;
+  isPending: boolean;
+  onJoin: () => void;
+}) {
   const { t } = useI18n(["teams"]);
-  const [isStarting, setIsStarting] = React.useState(false);
-  const [error, setError] = React.useState<string | null>(null);
 
-  const handleMessage = async () => {
-    setIsStarting(true);
-    setError(null);
-    try {
-      const conversation = await createConversation(teamId);
-      window.location.href = `/messages/${conversation.id}`;
-    } catch (err) {
-      console.error("Failed to create conversation:", err);
-      setError(t("teams.messageStartFailed"));
-    } finally {
-      setIsStarting(false);
-    }
-  };
+  if (isLeader || isMember || isPending) return null;
+
+  if (!canJoin) {
+    const unavailableMessage = isFull
+      ? t("teams.teamFullCannotJoin")
+      : team.status === "completed"
+        ? t("teams.statusEnded")
+        : team.status === "formed"
+          ? t("teams.statusFormed")
+          : t("teams.statusCancelled");
+
+    return <p className="text-sm leading-6 text-muted-foreground">{unavailableMessage}</p>;
+  }
+
+  if (!userId) {
+    return (
+      <div className="space-y-3">
+        <p className="text-pretty text-sm leading-6 text-muted-foreground">
+          {t("teams.loginToJoinTeam")}
+        </p>
+        <a
+          href={`/login?redirect=/teams/${team.id}`}
+          className="inline-flex min-h-11 w-fit items-center gap-2 rounded-xl bg-stone-900 px-5 text-sm font-semibold text-white transition-[transform,background-color] duration-150 active:scale-[0.96] motion-reduce:transform-none [@media(hover:hover)]:hover:bg-stone-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          {t("teams.loginBtn")}
+          <ArrowRight className="h-4 w-4" aria-hidden="true" />
+        </a>
+      </div>
+    );
+  }
 
   return (
-    <div className="border-t border-border pt-4">
-      <div className="flex items-center gap-2 text-xs text-muted-foreground mb-3">
-        <Crown className="w-3.5 h-3.5" />
-        <span className="font-medium">{t('teams.creatorLabel')}</span>
-      </div>
-      <a href={`/users/${leader.id}`}
-        className="flex items-center gap-3 p-3 bg-muted rounded-xl hover:bg-amber-50 transition-colors">
-        <TeamLeaderMini leader={leader} showLevel={true} size="md" />
-      </a>
-      {canMessage && (
-        <div className="mt-2 space-y-2">
-          <button
-            type="button"
-            onClick={handleMessage}
-            disabled={isStarting}
-            className="w-full flex items-center justify-center gap-2 rounded-lg bg-primary/10 px-3 py-2 text-sm font-medium text-primary transition-colors hover:bg-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {isStarting ? <Loader2 className="w-4 h-4 animate-spin" /> : <MessageCircle className="w-4 h-4" />}
-            {t("teams.messageLeader")}
-          </button>
-          {error && <p className="text-xs text-red-600 text-center">{error}</p>}
-        </div>
-      )}
-    </div>
+    <button
+      type="button"
+      data-testid="team-join-button"
+      onClick={onJoin}
+      className="inline-flex min-h-12 w-fit items-center justify-center rounded-xl bg-amber-600 px-6 text-base font-semibold text-white transition-[transform,background-color] duration-150 active:scale-[0.96] motion-reduce:transform-none [@media(hover:hover)]:hover:bg-amber-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+    >
+      {t("teams.joinTeam")}
+    </button>
   );
 }
 
 function ShareButton({ onClick }: { onClick: () => void; }) {
   const { t } = useI18n(["teams"]);
   return (
-    <div className="border-t border-border pt-4">
-      <button onClick={onClick}
-        className="w-full flex items-center gap-2 px-3 py-2 text-sm text-foreground/70 hover:bg-accent rounded-lg transition-colors">
-        <Share2 className="w-4 h-4" />
+    <div className="mt-5 border-t border-border pt-4">
+      <button
+        type="button"
+        onClick={onClick}
+        className="flex min-h-10 w-full items-center gap-2 rounded-lg px-3 text-sm text-foreground/70 transition-[transform,background-color,color] duration-150 active:scale-[0.96] motion-reduce:transform-none [@media(hover:hover)]:hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <Share2 className="h-4 w-4" aria-hidden="true" />
         {t('teams.shareTeam')}
       </button>
     </div>

--- a/frontend/src/components/features/team-detail/team-detail-skeleton.tsx
+++ b/frontend/src/components/features/team-detail/team-detail-skeleton.tsx
@@ -1,24 +1,29 @@
 import { Navbar } from "@/components/layout/navbar";
-import { Footer } from "@/components/layout/footer";
 
 export function TeamDetailSkeleton() {
   return (
     <main className="min-h-screen bg-background flex flex-col">
       <Navbar />
-      <div className="flex-1 max-w-7xl mx-auto px-6 py-8 lg:py-12 w-full">
-        <div className="grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-8 lg:gap-12">
-          <aside className="space-y-6">
-            <div className="h-8 w-3/4 bg-secondary/70 rounded-lg animate-pulse" />
-            <div className="h-20 bg-secondary/70 rounded-xl animate-pulse" />
-            <div className="h-32 bg-secondary/70 rounded-xl animate-pulse" />
+      <div className="mx-auto w-full max-w-7xl flex-1 px-4 pb-28 pt-20 sm:px-6 lg:pb-16 lg:pt-8" aria-busy="true">
+        <div className="overflow-hidden rounded-[20px] bg-card shadow-[0_18px_48px_rgba(82,58,31,0.10)] lg:grid lg:grid-cols-[minmax(0,1.15fr)_minmax(22rem,0.85fr)]">
+          <div className="min-h-72 animate-pulse bg-secondary/80 lg:min-h-[34rem]" />
+          <div className="space-y-6 px-5 py-6 sm:px-8 sm:py-8 lg:px-10 lg:py-10">
+            <div className="h-10 w-32 animate-pulse rounded-lg bg-secondary/80" />
+            <div className="h-20 w-4/5 animate-pulse rounded-xl bg-secondary/80" />
+            <div className="h-28 animate-pulse rounded-xl bg-secondary/80" />
+            <div className="h-24 animate-pulse rounded-xl bg-secondary/80" />
+          </div>
+        </div>
+        <div className="mt-7 grid gap-7 lg:mt-10 lg:grid-cols-[minmax(0,1fr)_22rem] lg:gap-10">
+          <aside className="lg:col-start-2 lg:row-start-1">
+            <div className="h-64 animate-pulse rounded-[20px] bg-secondary/80" />
           </aside>
-          <div className="space-y-6">
-            <div className="h-48 bg-secondary/70 rounded-2xl animate-pulse" />
-            <div className="h-64 bg-secondary/70 rounded-2xl animate-pulse" />
+          <div className="space-y-7 lg:col-start-1 lg:row-start-1">
+            <div className="h-64 animate-pulse rounded-[20px] bg-secondary/80" />
+            <div className="h-48 animate-pulse rounded-[20px] bg-secondary/80" />
           </div>
         </div>
       </div>
-      <Footer />
     </main>
   );
 }


### PR DESCRIPTION
## 目的

把队伍详情页从分散的左右信息栏重构为以加入决策为中心的响应式出发简报，同时修复未登录访客重复看到申请与登录操作的问题。

## 改动一览

| 文件 / 模块 | 改动 |
| ----------- | ---- |
| `team-detail-overview.tsx` | 新增地点照片、状态、标题、时间、说明和发起人一体化的出发简报 |
| `team-detail-main/content/sidebar` | 桌面端采用主内容加粘性决策栏，移动端按决策顺序单列展示，移除重复地点与加入区块 |
| `team-detail-bottom-bar.tsx` | 移动端只保留一个身份相关主操作，支持安全区、44px 触控区域和按压反馈 |
| `team-detail-responsive-layout.test.tsx` | 覆盖出发简报顺序、未登录、已登录及已结束队伍的操作状态 |

## 验收方式（怎么验对）

- [x] `pnpm --filter @gomate/frontend test`: 43 个测试文件、231 项测试通过
- [x] `pnpm i18n:build && pnpm --filter @gomate/frontend i18n:validate`: 3 种语言校验通过，0 error
- [x] `pnpm --filter @gomate/frontend type-check`: 0 error
- [x] `pnpm --filter @gomate/frontend build`: Cloudflare SSR 生产构建通过
- [x] Chrome 实测 320、375、1280 视口，中文、英文、日文均无横向溢出
- [x] 未登录访问真实队伍详情，公开 team/session 请求均为 200，Console 0 error/warn
- [x] Lighthouse snapshot: Accessibility 100、Best Practices 100、SEO 100
- [x] 回归确认：队长/成员操作、行动本、成员列表、分享弹层与活动回顾的数据和接口未改

## 文件后缀清单 + 运行环境

| 文件 | 后缀 | 运行环境 | 风险 |
| ---- | ---- | -------- | ---- |
| `frontend/src/components/features/team-detail/*` | `.tsx` | Astro React Island / 浏览器 | 响应式布局与身份状态渲染 |
| `frontend/src/__tests__/team-detail-responsive-layout.test.tsx` | `.tsx` | Vitest + jsdom | 仅测试代码 |

## 「不改某某文件」声明 + 页面层 CSS 扫描

- 本 PR 明确不改 API、数据库 schema、Cloudflare 配置、环境变量、依赖与 i18n 文案文件
- 已扫描本次页面组件，无 `transition-all`、glass blur、渐变文字、宽侧边强调线或页面级 `:global(body)`
- CSS 策略保持 Tailwind only，使用现有语义色变量

## Wen 需验证的场景

- [ ] Safari / Firefox 视觉对齐
- [x] Chrome 320 / 375 / 1280 响应式布局
- [x] 中文 / 英文 / 日文长文案无横向溢出
- [x] Lighthouse a11y 100
- [x] reduced-motion 使用 `motion-reduce` 禁用按压与图片缩放
- [ ] 合并部署后线上回归队伍详情、登录跳转、加入弹层和分享弹层

## 回滚路径

- `git revert 0e3bbf1` 可完整回滚，无 schema、依赖、配置或数据副作用

## 关联

- 无 API、生产资源或外部服务变更