### PR TITLE
优化首页地图回退与访客地点推荐

### DIFF
--- a/frontend/src/__tests__/china-map.test.tsx
+++ b/frontend/src/__tests__/china-map.test.tsx
@@ -33,6 +33,7 @@ describe("ChinaMap", () => {
   });
 
   it("clicking a province focuses the map and writes a restorable URL state", async () => {
+    const historyBack = vi.spyOn(window.history, "back").mockImplementation(() => undefined);
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ text: async () => provinceSvg }));
     mockFetchAPI.mockResolvedValue({
       json: async () => ({
@@ -72,5 +73,9 @@ describe("ChinaMap", () => {
     await waitFor(() => {
       expect(screen.queryByLabelText("四姑娘山")).not.toBeInTheDocument();
     });
+
+    fireEvent.click(guangdong);
+
+    expect(historyBack).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/__tests__/home-location-stack.test.tsx
+++ b/frontend/src/__tests__/home-location-stack.test.tsx
@@ -12,7 +12,7 @@ vi.mock("@/hooks/useI18n", () => ({
   }),
 }));
 
-const locations = ["麦理浩径", "香港", "澳门", "南山"].map((name, index) => ({
+const locations = ["香港", "麦理浩径", "大理", "牛奶排", "澳门"].map((name, index) => ({
   id: `location-${index}`,
   name,
   slug: name,
@@ -29,19 +29,23 @@ const locations = ["麦理浩径", "香港", "澳门", "南山"].map((name, inde
 } as unknown as Location));
 
 describe("HomeLocationStack", () => {
-  it("展示最多三张重叠地点卡片并链接到详情", () => {
+  it("按牛奶排、大理、香港的顺序展示三张地点卡片并链接到详情", () => {
     render(<HomeLocationStack locations={locations} />);
 
     expect(screen.getByTestId("home-location-stack")).toBeInTheDocument();
-    expect(screen.getAllByTestId("home-location-stack-card")).toHaveLength(3);
-    expect(screen.getByRole("link", { name: /麦理浩径/ })).toHaveAttribute(
+    const cards = screen.getAllByTestId("home-location-stack-card");
+    expect(cards).toHaveLength(3);
+    expect(cards.map((card) => card.textContent)).toEqual([
+      expect.stringContaining("牛奶排"),
+      expect.stringContaining("大理"),
+      expect.stringContaining("香港"),
+    ]);
+    expect(screen.getByRole("link", { name: /牛奶排/ })).toHaveAttribute(
       "href",
-      "/locations/location-0",
+      "/locations/location-3",
     );
-    expect(screen.getAllByTestId("home-location-stack-card")[1]).toHaveClass(
-      "lg:z-30",
-    );
-    expect(screen.queryByText("南山")).not.toBeInTheDocument();
+    expect(cards[1]).toHaveClass("lg:z-30");
+    expect(screen.queryByText("麦理浩径")).not.toBeInTheDocument();
   });
 
   it("没有地点时显示占位状态", () => {

--- a/frontend/src/components/features/home/china-map.tsx
+++ b/frontend/src/components/features/home/china-map.tsx
@@ -164,8 +164,23 @@ export function ChinaMap({ className }: { className?: string }) {
   );
   const focusedCount = focusedProvince ? provinceCount.get(focusedProvince) ?? 0 : 0;
 
+  const leaveProvince = () => {
+    setTooltip(null);
+    if (pushedMapState.current) {
+      pushedMapState.current = false;
+      window.history.back();
+      return;
+    }
+    updateMapUrl(null, "replace");
+    setFocusedProvince(null);
+  };
+
   const focusProvince = (name: string) => {
     if (!PROVINCE_CENTERS[name]) return;
+    if (focusedProvince === name) {
+      leaveProvince();
+      return;
+    }
     setTooltip(null);
     setIsTransitioning(true);
     if (!focusedProvince) {
@@ -177,17 +192,6 @@ export function ChinaMap({ className }: { className?: string }) {
     setFocusedProvince(name);
     if (transitionTimer.current !== null) window.clearTimeout(transitionTimer.current);
     transitionTimer.current = window.setTimeout(() => setIsTransitioning(false), 560);
-  };
-
-  const leaveProvince = () => {
-    setTooltip(null);
-    if (pushedMapState.current) {
-      pushedMapState.current = false;
-      window.history.back();
-      return;
-    }
-    updateMapUrl(null, "replace");
-    setFocusedProvince(null);
   };
 
   const handleProvinceEnter = (name: string) => {

--- a/frontend/src/components/features/home/guest-featured-locations.ts
+++ b/frontend/src/components/features/home/guest-featured-locations.ts
@@ -1,0 +1,14 @@
+import type { Location } from "@/lib/types";
+
+export const GUEST_FEATURED_LOCATION_NAMES = ["牛奶排", "大理", "香港"] as const;
+
+export function selectGuestFeaturedLocations(locations: Location[]): Location[] {
+  const featured = GUEST_FEATURED_LOCATION_NAMES.flatMap((name) => {
+    const location = locations.find((candidate) => candidate.name === name);
+    return location ? [location] : [];
+  });
+  const featuredIds = new Set(featured.map((location) => location.id));
+  const fallback = locations.filter((location) => !featuredIds.has(location.id));
+
+  return [...featured, ...fallback].slice(0, GUEST_FEATURED_LOCATION_NAMES.length);
+}

--- a/frontend/src/components/features/home/home-location-stack.tsx
+++ b/frontend/src/components/features/home/home-location-stack.tsx
@@ -2,6 +2,7 @@ import { ArrowUpRight, Compass, MapPin } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import { LocationCoverImage } from "@/components/ui/lazy-image";
 import type { Location } from "@/lib/types";
+import { selectGuestFeaturedLocations } from "./guest-featured-locations";
 
 const CARD_STYLES = [
   {
@@ -26,7 +27,7 @@ const CARD_STYLES = [
 
 export function HomeLocationStack({ locations }: { locations: Location[] }) {
   const { t } = useI18n(["home", "common", "locations"]);
-  const featuredLocations = locations.slice(0, 3);
+  const featuredLocations = selectGuestFeaturedLocations(locations);
 
   if (featuredLocations.length === 0) {
     return (

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -9,6 +9,10 @@ import { API_BASE } from "../lib/api";
 import type { HomeInitialData } from "../components/features/home/use-home-data";
 import type { LocationsResponse } from "../hooks/use-locations";
 import type { Team } from "../lib/types";
+import {
+  GUEST_FEATURED_LOCATION_NAMES,
+  selectGuestFeaturedLocations,
+} from "../components/features/home/guest-featured-locations";
 
 declareI18nNs(Astro.locals, ["home", "locations", "locationDetail", "teams", "enums", "content", "onboarding"]);
 
@@ -22,8 +26,41 @@ async function fetchJson<T>(path: string): Promise<T | null> {
   }
 }
 
+async function fetchGuestFeaturedLocations(): Promise<LocationsResponse | null> {
+  const responses = await Promise.all(
+    GUEST_FEATURED_LOCATION_NAMES.map((name) =>
+      fetchJson<LocationsResponse>(
+        `/locations?page=1&pageSize=1&view=card&search=${encodeURIComponent(name)}`,
+      ),
+    ),
+  );
+  const requestedLocations = responses.flatMap((response) => response?.locations ?? []);
+  let locations = selectGuestFeaturedLocations(requestedLocations);
+
+  if (locations.length < GUEST_FEATURED_LOCATION_NAMES.length) {
+    const fallback = await fetchJson<LocationsResponse>("/locations?page=1&pageSize=6&view=card");
+    locations = selectGuestFeaturedLocations([
+      ...requestedLocations,
+      ...(fallback?.locations ?? []),
+    ]);
+  }
+
+  if (locations.length === 0) return null;
+
+  return {
+    success: true,
+    locations,
+    pagination: {
+      page: 1,
+      pageSize: 6,
+      total: locations.length,
+      totalPages: 1,
+    },
+  };
+}
+
 const [locationsData, teamsData] = await Promise.all([
-  fetchJson<LocationsResponse>("/locations?page=1&pageSize=6&view=card"),
+  fetchGuestFeaturedLocations(),
   fetchJson<{ success: boolean; teams: Team[] }>("/teams?status=recruiting&pageSize=4"),
 ]);
 


### PR DESCRIPTION
## 变更内容

- 首页「从地图找下一站」支持再次点击已放大的省份，回退到放大前的全国视图。
- 未登录首页的三张地点卡固定优先展示：牛奶排、大理、香港。
- 首页 SSR 并行定向获取三条轻量地点数据；定向请求不完整时回退到原首屏列表，避免少卡。
- 添加地图回退与访客地点排序的回归测试。

## 原因与影响

地图此前会在第一次点击省份后放大，但再次点击同一省份仍重复写入聚焦状态，无法直接恢复。访客地点卡此前直接使用列表接口前 3 条，内容受数据库默认顺序影响。

本次改动只影响未登录首页展示和首页地图交互，不修改 API、登录用户首页或生产资源。

## 验证

- `vitest run src/__tests__/china-map.test.tsx src/__tests__/home-location-stack.test.tsx`：3 tests passed
- `pnpm i18n:build`：通过
- `pnpm --filter @gomate/frontend type-check`：通过（0 errors）
- `pnpm --filter @gomate/frontend lint`：0 errors；2 条仓库既有 warning
- `pnpm --filter @gomate/frontend build`：通过
- Git pre-commit / pre-push hooks：通过

## 已知验证限制

- 完整前端测试套件仍有一个与本改动无关的日期依赖失败：`home-member-experience.test.tsx` 使用的出发日期已过期。
- 当前 worktree 缺少 `api/.dev.vars`，且会话未配置 Chrome DevTools MCP，因此未完成最终本地浏览器交互截图；针对性组件测试已覆盖两项行为。