### PR TITLE
fix: prevent time-dependent frontend deploy failures

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -51,6 +51,8 @@ jobs:
         run: pnpm --filter @gomate/frontend type-check
       - name: i18n Key Validation
         run: pnpm --filter @gomate/frontend i18n:validate
+      - name: Tests
+        run: pnpm --filter @gomate/frontend test
       - name: Build
         run: pnpm --filter @gomate/frontend build
         env:

--- a/frontend/src/__tests__/home-member-experience.test.tsx
+++ b/frontend/src/__tests__/home-member-experience.test.tsx
@@ -1,10 +1,12 @@
 import { render, screen, within } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Team } from "@/lib/types";
 import { selectNextMemberTeam } from "../components/features/home/member-home-utils";
 import { HomeMemberExperience } from "../components/features/home/home-member-experience";
 
-const { useMemberHomeMock } = vi.hoisted(() => ({ useMemberHomeMock: vi.fn() }));
+const { useMemberHomeMock } = vi.hoisted(() => ({
+  useMemberHomeMock: vi.fn(),
+}));
 
 vi.mock("../components/features/home/use-member-home", () => ({
   useMemberHome: (...args: unknown[]) => useMemberHomeMock(...args),
@@ -73,7 +75,11 @@ describe("selectNextMemberTeam", () => {
     const result = selectNextMemberTeam(
       [
         team({ id: "later", startTime: "2026-08-12T00:00:00.000Z" }),
-        team({ id: "completed", startTime: "2026-08-08T00:00:00.000Z", status: "completed" }),
+        team({
+          id: "completed",
+          startTime: "2026-08-08T00:00:00.000Z",
+          status: "completed",
+        }),
       ],
       [team({ id: "next", startTime: "2026-08-09T00:30:00.000Z" })],
       new Date("2026-08-07T00:00:00.000Z"),
@@ -102,6 +108,15 @@ describe("selectNextMemberTeam", () => {
 });
 
 describe("HomeMemberExperience", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-07T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("shows the signed-in user's next departure", () => {
     useMemberHomeMock.mockReturnValue({
       teams: [team({})],
@@ -110,11 +125,22 @@ describe("HomeMemberExperience", () => {
       retry: vi.fn(),
     });
 
-    render(<HomeMemberExperience currentUser={{ id: "user-1", name: "Victor", nickname: "Victor" } as never} publicTeams={[]} />);
+    render(
+      <HomeMemberExperience
+        currentUser={
+          { id: "user-1", name: "Victor", nickname: "Victor" } as never
+        }
+        publicTeams={[]}
+      />,
+    );
 
     expect(screen.getByTestId("member-next-trip")).toBeInTheDocument();
-    expect(screen.getByText("home.memberDashboard.upcomingStatus")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "home.memberDashboard.viewTrip" })).toHaveAttribute("href", "/teams/team-1");
+    expect(
+      screen.getByText("home.memberDashboard.upcomingStatus"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "home.memberDashboard.viewTrip" }),
+    ).toHaveAttribute("href", "/teams/team-1");
   });
 
   it("shows a useful exploration state when the member has no active trip", () => {
@@ -125,10 +151,21 @@ describe("HomeMemberExperience", () => {
       retry: vi.fn(),
     });
 
-    render(<HomeMemberExperience currentUser={{ id: "user-1", name: "Victor", nickname: "Victor" } as never} publicTeams={[]} />);
+    render(
+      <HomeMemberExperience
+        currentUser={
+          { id: "user-1", name: "Victor", nickname: "Victor" } as never
+        }
+        publicTeams={[]}
+      />,
+    );
 
     const emptyState = screen.getByTestId("member-no-trip");
     expect(emptyState).toBeInTheDocument();
-    expect(within(emptyState).getByRole("link", { name: "home.memberDashboard.findTeams" })).toHaveAttribute("href", "/teams");
+    expect(
+      within(emptyState).getByRole("link", {
+        name: "home.memberDashboard.findTeams",
+      }),
+    ).toHaveAttribute("href", "/teams");
   });
 });


### PR DESCRIPTION
## Summary

- freeze the member-home component test clock so its fixed departure fixture cannot expire as wall-clock time advances
- run the frontend unit-test suite in `PR Validation` before changes can merge

## Root cause

`home-member-experience.test.tsx` used an August 9, 2026 departure while `HomeMemberExperience` compared it with the real current time. Once that date passed, the component correctly rendered `member-no-trip`, but the test still expected `member-next-trip`, blocking the post-merge frontend deployment.

The frontend PR validation job did not run unit tests, while the production deployment job did. That allowed the failure to appear only after PR #549 had merged, leaving the previous frontend deployment live.

## Impact

- no frontend or API runtime behavior changes
- frontend PR validation now runs the same unit-test command used by deployment
- expected CI cost is approximately 6 seconds of test execution after dependencies are installed

## Validation

- reproduced before the fix: 1 failed test (`member-next-trip` not found)
- focused test: 4/4 passed
- complete frontend suite: 45 files, 246/246 tests passed
- i18n validation: 0 errors
- frontend type check: 0 errors
- frontend lint: 0 errors
- production frontend build passed
- workflow YAML syntax and Prettier checks passed
- pre-commit and pre-push hooks passed

## Rollback

Revert this PR. That removes the deterministic clock setup and the added PR test step; the deployment workflow itself is unchanged.