### PR TITLE
fix: harden database integrity and atomic writes

### DIFF
--- a/api/db/migrations/0019_database_integrity.sql
+++ b/api/db/migrations/0019_database_integrity.sql
@@ -1,0 +1,388 @@
+-- Database integrity hardening.
+-- Rebuilds teams with the foreign keys lost in 0013, normalizes legacy statuses,
+-- removes redundant indexes, and moves derived-state maintenance into SQLite triggers.
+
+CREATE TABLE IF NOT EXISTS `_0019_integrity_guard` (
+  `ok` integer NOT NULL CHECK (`ok` = 1)
+);--> statement-breakpoint
+DELETE FROM `_0019_integrity_guard`;--> statement-breakpoint
+INSERT INTO `_0019_integrity_guard` (`ok`)
+SELECT CASE WHEN EXISTS (
+  SELECT 1
+  FROM `teams` t
+  LEFT JOIN `locations` l ON l.id = t.location_id
+  LEFT JOIN `users` u ON u.id = t.leader_id
+  WHERE l.id IS NULL
+     OR u.id IS NULL
+     OR t.duration_min < 0
+     OR t.duration_min > 1440
+     OR t.max_members < 2
+     OR t.max_members > 50
+     OR t.end_time < t.start_time
+     OR t.status NOT IN (
+       'recruiting', 'full', 'formed', 'cancelled', 'completed',
+       'confirmed', 'ongoing', 'ended'
+     )
+) THEN 0 ELSE 1 END;--> statement-breakpoint
+DROP TABLE IF EXISTS `_0019_integrity_guard`;--> statement-breakpoint
+
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `__new_teams` (
+  `id` text PRIMARY KEY NOT NULL,
+  `location_id` text NOT NULL,
+  `leader_id` text NOT NULL,
+  `title` text NOT NULL,
+  `description` text,
+  `start_time` integer NOT NULL,
+  `end_time` integer NOT NULL,
+  `duration_min` integer DEFAULT 240 NOT NULL,
+  `max_members` integer DEFAULT 10 NOT NULL,
+  `requirements` text,
+  `icon` text DEFAULT '⛰️' NOT NULL,
+  `status` text DEFAULT 'recruiting' NOT NULL,
+  `checklist` text,
+  `created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+  `updated_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+  `actor_api_key_id` text,
+  CONSTRAINT `teams_location_id_locations_id_fk`
+    FOREIGN KEY (`location_id`) REFERENCES `locations`(`id`) ON UPDATE no action ON DELETE restrict,
+  CONSTRAINT `teams_leader_id_users_id_fk`
+    FOREIGN KEY (`leader_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE restrict,
+  CONSTRAINT `teams_status_check`
+    CHECK (`status` IN ('recruiting', 'full', 'formed', 'cancelled', 'completed')),
+  CONSTRAINT `teams_duration_min_check` CHECK (`duration_min` BETWEEN 0 AND 1440),
+  CONSTRAINT `teams_max_members_check` CHECK (`max_members` BETWEEN 2 AND 50),
+  CONSTRAINT `teams_time_range_check` CHECK (`end_time` >= `start_time`)
+);--> statement-breakpoint
+DELETE FROM `__new_teams`;--> statement-breakpoint
+INSERT INTO `__new_teams` (
+  `id`, `location_id`, `leader_id`, `title`, `description`, `start_time`, `end_time`,
+  `duration_min`, `max_members`, `requirements`, `icon`, `status`, `checklist`,
+  `created_at`, `updated_at`, `actor_api_key_id`
+)
+SELECT
+  `id`, `location_id`, `leader_id`, `title`, `description`, `start_time`, `end_time`,
+  `duration_min`, `max_members`, `requirements`, `icon`,
+  CASE
+    WHEN `status` IN ('confirmed', 'ongoing') THEN 'formed'
+    WHEN `status` = 'ended' THEN 'completed'
+    ELSE `status`
+  END,
+  `checklist`, `created_at`, `updated_at`, `actor_api_key_id`
+FROM `teams`;--> statement-breakpoint
+DROP TABLE IF EXISTS `teams`;--> statement-breakpoint
+ALTER TABLE `__new_teams` RENAME TO `teams`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `teams_location_idx` ON `teams` (`location_id`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `teams_leader_idx` ON `teams` (`leader_id`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `teams_status_idx` ON `teams` (`status`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `teams_start_time_idx` ON `teams` (`start_time`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `teams_title_idx` ON `teams` (`title`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `teams_status_created_at_idx` ON `teams` (`status`, `created_at`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `teams_status_start_time_idx` ON `teams` (`status`, `start_time`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `teams_status_end_time_idx` ON `teams` (`status`, `end_time`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `teams_actor_api_key_id_idx` ON `teams` (`actor_api_key_id`);--> statement-breakpoint
+
+DROP INDEX IF EXISTS `users_email_idx`;--> statement-breakpoint
+DROP INDEX IF EXISTS `sessions_token_idx`;--> statement-breakpoint
+DROP INDEX IF EXISTS `cities_adcode_idx`;--> statement-breakpoint
+DROP INDEX IF EXISTS `locations_slug_idx`;--> statement-breakpoint
+DROP INDEX IF EXISTS `tags_name_idx`;--> statement-breakpoint
+DROP INDEX IF EXISTS `password_resets_token_idx`;--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `users_city_idx` ON `users` (`city`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `locations_actor_api_key_id_idx` ON `locations` (`actor_api_key_id`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `team_members_actor_api_key_id_idx` ON `team_members` (`actor_api_key_id`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `stories_actor_api_key_id_idx` ON `stories` (`actor_api_key_id`);--> statement-breakpoint
+
+UPDATE `locations`
+SET `city_name` = (SELECT c.name FROM cities c WHERE c.id = locations.city_id)
+WHERE EXISTS (SELECT 1 FROM cities c WHERE c.id = locations.city_id);--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `locations_city_name_after_insert`
+AFTER INSERT ON `locations`
+BEGIN
+  UPDATE `locations`
+  SET `city_name` = (SELECT c.name FROM `cities` c WHERE c.id = NEW.city_id)
+  WHERE id = NEW.id;
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `locations_city_name_after_city_update`
+AFTER UPDATE OF `city_id` ON `locations`
+BEGIN
+  UPDATE `locations`
+  SET `city_name` = (SELECT c.name FROM `cities` c WHERE c.id = NEW.city_id)
+  WHERE id = NEW.id;
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `locations_city_name_after_city_rename`
+AFTER UPDATE OF `name` ON `cities`
+BEGIN
+  UPDATE `locations` SET `city_name` = NEW.name WHERE `city_id` = NEW.id;
+END;--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `users_city_validate_insert`
+BEFORE INSERT ON `users`
+WHEN NEW.city IS NOT NULL AND NOT EXISTS (SELECT 1 FROM `cities` WHERE id = NEW.city)
+BEGIN
+  SELECT RAISE(ABORT, 'users.city must reference cities.id');
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `users_city_validate_update`
+BEFORE UPDATE OF `city` ON `users`
+WHEN NEW.city IS NOT NULL AND NOT EXISTS (SELECT 1 FROM `cities` WHERE id = NEW.city)
+BEGIN
+  SELECT RAISE(ABORT, 'users.city must reference cities.id');
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `cities_users_restrict_delete`
+BEFORE DELETE ON `cities`
+WHEN EXISTS (SELECT 1 FROM `users` WHERE city = OLD.id)
+BEGIN
+  SELECT RAISE(ABORT, 'city is referenced by users');
+END;--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `entity_to_tags_validate_insert`
+BEFORE INSERT ON `entity_to_tags`
+WHEN NEW.entity_type NOT IN ('location', 'activity', 'story')
+  OR (NEW.entity_type = 'location' AND NOT EXISTS (SELECT 1 FROM `locations` WHERE id = NEW.entity_id))
+  OR (NEW.entity_type = 'activity' AND NOT EXISTS (SELECT 1 FROM `teams` WHERE id = NEW.entity_id))
+  OR (NEW.entity_type = 'story' AND NOT EXISTS (SELECT 1 FROM `stories` WHERE id = NEW.entity_id))
+BEGIN
+  SELECT RAISE(ABORT, 'entity_to_tags references an invalid entity');
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `entity_to_tags_validate_update`
+BEFORE UPDATE OF `entity_type`, `entity_id` ON `entity_to_tags`
+WHEN NEW.entity_type NOT IN ('location', 'activity', 'story')
+  OR (NEW.entity_type = 'location' AND NOT EXISTS (SELECT 1 FROM `locations` WHERE id = NEW.entity_id))
+  OR (NEW.entity_type = 'activity' AND NOT EXISTS (SELECT 1 FROM `teams` WHERE id = NEW.entity_id))
+  OR (NEW.entity_type = 'story' AND NOT EXISTS (SELECT 1 FROM `stories` WHERE id = NEW.entity_id))
+BEGIN
+  SELECT RAISE(ABORT, 'entity_to_tags references an invalid entity');
+END;--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `user_favorites_validate_insert`
+BEFORE INSERT ON `user_favorites`
+WHEN NEW.entity_type NOT IN ('location', 'story')
+  OR (NEW.entity_type = 'location' AND NOT EXISTS (SELECT 1 FROM `locations` WHERE id = NEW.entity_id))
+  OR (NEW.entity_type = 'story' AND NOT EXISTS (SELECT 1 FROM `stories` WHERE id = NEW.entity_id))
+BEGIN
+  SELECT RAISE(ABORT, 'user_favorites references an invalid entity');
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `user_favorites_validate_update`
+BEFORE UPDATE OF `entity_type`, `entity_id` ON `user_favorites`
+WHEN NEW.entity_type NOT IN ('location', 'story')
+  OR (NEW.entity_type = 'location' AND NOT EXISTS (SELECT 1 FROM `locations` WHERE id = NEW.entity_id))
+  OR (NEW.entity_type = 'story' AND NOT EXISTS (SELECT 1 FROM `stories` WHERE id = NEW.entity_id))
+BEGIN
+  SELECT RAISE(ABORT, 'user_favorites references an invalid entity');
+END;--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `locations_polymorphic_cleanup`
+AFTER DELETE ON `locations`
+BEGIN
+  DELETE FROM `entity_to_tags` WHERE entity_type = 'location' AND entity_id = OLD.id;
+  DELETE FROM `user_favorites` WHERE entity_type = 'location' AND entity_id = OLD.id;
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `stories_polymorphic_cleanup`
+AFTER DELETE ON `stories`
+BEGIN
+  DELETE FROM `entity_to_tags` WHERE entity_type = 'story' AND entity_id = OLD.id;
+  DELETE FROM `user_favorites` WHERE entity_type = 'story' AND entity_id = OLD.id;
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `teams_polymorphic_cleanup`
+AFTER DELETE ON `teams`
+BEGIN
+  DELETE FROM `entity_to_tags` WHERE entity_type = 'activity' AND entity_id = OLD.id;
+END;--> statement-breakpoint
+
+UPDATE `stories`
+SET `like_count` = (
+  SELECT COUNT(*) FROM `user_story_likes` likes WHERE likes.story_id = stories.id
+);--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `user_story_likes_count_after_insert`
+AFTER INSERT ON `user_story_likes`
+BEGIN
+  UPDATE `stories`
+  SET `like_count` = COALESCE(`like_count`, 0) + 1,
+      `updated_at` = (unixepoch() * 1000)
+  WHERE id = NEW.story_id;
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `user_story_likes_count_after_delete`
+AFTER DELETE ON `user_story_likes`
+BEGIN
+  UPDATE `stories`
+  SET `like_count` = MAX(0, COALESCE(`like_count`, 0) - 1),
+      `updated_at` = (unixepoch() * 1000)
+  WHERE id = OLD.story_id;
+END;--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `messages_summary_after_insert`
+AFTER INSERT ON `messages`
+BEGIN
+  UPDATE `conversations`
+  SET `last_message_content` = SUBSTR(NEW.content, 1, 100),
+      `last_message_at` = NEW.created_at,
+      `updated_at` = NEW.created_at
+  WHERE id = NEW.conversation_id;
+END;--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `team_members_validate_insert`
+BEFORE INSERT ON `team_members`
+WHEN NEW.status NOT IN ('pending', 'approved', 'rejected', 'leave_pending', 'cancelled')
+  OR (
+    NEW.status = 'approved'
+    AND (SELECT COUNT(*) FROM `team_members`
+         WHERE team_id = NEW.team_id AND status IN ('approved', 'leave_pending'))
+        >= (SELECT max_members FROM `teams` WHERE id = NEW.team_id)
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'invalid membership status or team capacity exceeded');
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `team_members_validate_update`
+BEFORE UPDATE OF `status` ON `team_members`
+WHEN NEW.status NOT IN ('pending', 'approved', 'rejected', 'leave_pending', 'cancelled')
+  OR (
+    NEW.status = 'approved'
+    AND OLD.status NOT IN ('approved', 'leave_pending')
+    AND (SELECT COUNT(*) FROM `team_members`
+         WHERE team_id = NEW.team_id AND status IN ('approved', 'leave_pending'))
+        >= (SELECT max_members FROM `teams` WHERE id = NEW.team_id)
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'invalid membership status or team capacity exceeded');
+END;--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `team_members_status_after_insert`
+AFTER INSERT ON `team_members`
+BEGIN
+  UPDATE `teams`
+  SET `status` = CASE
+        WHEN `status` IN ('recruiting', 'full') AND (
+          SELECT COUNT(*) FROM `team_members`
+          WHERE team_id = NEW.team_id AND status IN ('approved', 'leave_pending')
+        ) >= `max_members` THEN 'full'
+        WHEN `status` IN ('recruiting', 'full') THEN 'recruiting'
+        ELSE `status`
+      END,
+      `updated_at` = (unixepoch() * 1000)
+  WHERE id = NEW.team_id;
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `team_members_status_after_update`
+AFTER UPDATE OF `status` ON `team_members`
+BEGIN
+  UPDATE `teams`
+  SET `status` = CASE
+        WHEN `status` IN ('recruiting', 'full') AND (
+          SELECT COUNT(*) FROM `team_members`
+          WHERE team_id = NEW.team_id AND status IN ('approved', 'leave_pending')
+        ) >= `max_members` THEN 'full'
+        WHEN `status` IN ('recruiting', 'full') THEN 'recruiting'
+        ELSE `status`
+      END,
+      `updated_at` = (unixepoch() * 1000)
+  WHERE id = NEW.team_id;
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `team_members_status_after_delete`
+AFTER DELETE ON `team_members`
+BEGIN
+  UPDATE `teams`
+  SET `status` = CASE
+        WHEN `status` IN ('recruiting', 'full') AND (
+          SELECT COUNT(*) FROM `team_members`
+          WHERE team_id = OLD.team_id AND status IN ('approved', 'leave_pending')
+        ) >= `max_members` THEN 'full'
+        WHEN `status` IN ('recruiting', 'full') THEN 'recruiting'
+        ELSE `status`
+      END,
+      `updated_at` = (unixepoch() * 1000)
+  WHERE id = OLD.team_id;
+END;--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `users_domain_validate_insert`
+BEFORE INSERT ON `users`
+WHEN NEW.role NOT IN ('user', 'admin')
+  OR NEW.status NOT IN ('active', 'suspended', 'banned', 'deleted')
+  OR NEW.level NOT IN ('beginner', 'intermediate', 'advanced', 'expert')
+  OR (NEW.gender IS NOT NULL AND NEW.gender NOT IN ('male', 'female', 'other'))
+  OR (NEW.completed_hikes IS NOT NULL AND NEW.completed_hikes < 0)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid users domain value');
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `users_domain_validate_update`
+BEFORE UPDATE OF `role`, `status`, `level`, `gender`, `completed_hikes` ON `users`
+WHEN NEW.role NOT IN ('user', 'admin')
+  OR NEW.status NOT IN ('active', 'suspended', 'banned', 'deleted')
+  OR NEW.level NOT IN ('beginner', 'intermediate', 'advanced', 'expert')
+  OR (NEW.gender IS NOT NULL AND NEW.gender NOT IN ('male', 'female', 'other'))
+  OR (NEW.completed_hikes IS NOT NULL AND NEW.completed_hikes < 0)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid users domain value');
+END;--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `locations_domain_validate_insert`
+BEFORE INSERT ON `locations`
+WHEN (NEW.difficulty IS NOT NULL AND NEW.difficulty NOT IN ('easy', 'moderate', 'hard', 'expert'))
+  OR (NEW.duration_min IS NOT NULL AND NEW.duration_min < 0)
+  OR (NEW.duration_max IS NOT NULL AND NEW.duration_max < 0)
+  OR (NEW.duration_min IS NOT NULL AND NEW.duration_max IS NOT NULL AND NEW.duration_max < NEW.duration_min)
+  OR (NEW.parking_available IS NOT NULL AND NEW.parking_available NOT IN (0, 1))
+  OR NOT json_valid(NEW.best_season)
+  OR NOT json_valid(NEW.images)
+  OR NOT json_valid(NEW.coordinates)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid locations domain value');
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `locations_domain_validate_update`
+BEFORE UPDATE OF `difficulty`, `duration_min`, `duration_max`, `parking_available`, `best_season`, `images`, `coordinates` ON `locations`
+WHEN (NEW.difficulty IS NOT NULL AND NEW.difficulty NOT IN ('easy', 'moderate', 'hard', 'expert'))
+  OR (NEW.duration_min IS NOT NULL AND NEW.duration_min < 0)
+  OR (NEW.duration_max IS NOT NULL AND NEW.duration_max < 0)
+  OR (NEW.duration_min IS NOT NULL AND NEW.duration_max IS NOT NULL AND NEW.duration_max < NEW.duration_min)
+  OR (NEW.parking_available IS NOT NULL AND NEW.parking_available NOT IN (0, 1))
+  OR NOT json_valid(NEW.best_season)
+  OR NOT json_valid(NEW.images)
+  OR NOT json_valid(NEW.coordinates)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid locations domain value');
+END;--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `tags_domain_validate_insert`
+BEFORE INSERT ON `tags`
+WHEN NEW.type NOT IN ('location', 'activity', 'story')
+BEGIN
+  SELECT RAISE(ABORT, 'invalid tag type');
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `tags_domain_validate_update`
+BEFORE UPDATE OF `type` ON `tags`
+WHEN NEW.type NOT IN ('location', 'activity', 'story')
+BEGIN
+  SELECT RAISE(ABORT, 'invalid tag type');
+END;--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `stories_domain_validate_insert`
+BEFORE INSERT ON `stories`
+WHEN NEW.status NOT IN ('draft', 'published', 'hidden')
+  OR COALESCE(NEW.view_count, 0) < 0
+  OR COALESCE(NEW.like_count, 0) < 0
+BEGIN
+  SELECT RAISE(ABORT, 'invalid story domain value');
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `stories_domain_validate_update`
+BEFORE UPDATE OF `status`, `view_count`, `like_count` ON `stories`
+WHEN NEW.status NOT IN ('draft', 'published', 'hidden')
+  OR COALESCE(NEW.view_count, 0) < 0
+  OR COALESCE(NEW.like_count, 0) < 0
+BEGIN
+  SELECT RAISE(ABORT, 'invalid story domain value');
+END;--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `activity_posts_domain_validate_insert`
+BEFORE INSERT ON `activity_posts`
+WHEN NEW.status NOT IN ('visible', 'hidden', 'deleted') OR NOT json_valid(NEW.images)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid activity post domain value');
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `activity_posts_domain_validate_update`
+BEFORE UPDATE OF `status`, `images` ON `activity_posts`
+WHEN NEW.status NOT IN ('visible', 'hidden', 'deleted') OR NOT json_valid(NEW.images)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid activity post domain value');
+END;

--- a/api/db/migrations/0019_database_integrity.sql
+++ b/api/db/migrations/0019_database_integrity.sql
@@ -6,6 +6,31 @@ CREATE TABLE IF NOT EXISTS `_0019_integrity_guard` (
   `ok` integer NOT NULL CHECK (`ok` = 1)
 );--> statement-breakpoint
 DELETE FROM `_0019_integrity_guard`;--> statement-breakpoint
+
+-- Normalize the legacy users.city representation before enforcing city-id semantics.
+UPDATE `users`
+SET `city` = NULL
+WHERE `city` = '';--> statement-breakpoint
+UPDATE `users`
+SET `city` = (
+  SELECT c.id FROM `cities` c WHERE c.name = users.city ORDER BY c.id LIMIT 1
+)
+WHERE `city` IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM `cities` c WHERE c.id = users.city)
+  AND EXISTS (SELECT 1 FROM `cities` c WHERE c.name = users.city);--> statement-breakpoint
+
+-- Polymorphic relations cannot use native FKs; remove already-orphaned legacy rows
+-- before installing validation/cleanup triggers for all future writes.
+DELETE FROM `entity_to_tags`
+WHERE `entity_type` NOT IN ('location', 'activity', 'story')
+   OR (`entity_type` = 'location' AND NOT EXISTS (SELECT 1 FROM `locations` WHERE id = entity_to_tags.entity_id))
+   OR (`entity_type` = 'activity' AND NOT EXISTS (SELECT 1 FROM `teams` WHERE id = entity_to_tags.entity_id))
+   OR (`entity_type` = 'story' AND NOT EXISTS (SELECT 1 FROM `stories` WHERE id = entity_to_tags.entity_id));--> statement-breakpoint
+DELETE FROM `user_favorites`
+WHERE `entity_type` NOT IN ('location', 'story')
+   OR (`entity_type` = 'location' AND NOT EXISTS (SELECT 1 FROM `locations` WHERE id = user_favorites.entity_id))
+   OR (`entity_type` = 'story' AND NOT EXISTS (SELECT 1 FROM `stories` WHERE id = user_favorites.entity_id));--> statement-breakpoint
+
 INSERT INTO `_0019_integrity_guard` (`ok`)
 SELECT CASE WHEN EXISTS (
   SELECT 1
@@ -24,6 +49,24 @@ SELECT CASE WHEN EXISTS (
        'confirmed', 'ongoing', 'ended'
      )
 ) THEN 0 ELSE 1 END;--> statement-breakpoint
+INSERT INTO `_0019_integrity_guard` (`ok`)
+SELECT CASE WHEN
+  EXISTS (
+    SELECT 1 FROM `users` u
+    WHERE u.city IS NOT NULL AND NOT EXISTS (SELECT 1 FROM `cities` c WHERE c.id = u.city)
+  )
+  OR EXISTS (
+    SELECT 1 FROM `team_members` tm
+    WHERE tm.status NOT IN ('pending', 'approved', 'rejected', 'leave_pending', 'cancelled')
+  )
+  OR EXISTS (
+    SELECT 1 FROM `teams` t
+    WHERE (
+      SELECT COUNT(*) FROM `team_members` tm
+      WHERE tm.team_id = t.id AND tm.status IN ('approved', 'leave_pending')
+    ) > t.max_members
+  )
+THEN 0 ELSE 1 END;--> statement-breakpoint
 DROP TABLE IF EXISTS `_0019_integrity_guard`;--> statement-breakpoint
 
 PRAGMA foreign_keys=OFF;--> statement-breakpoint
@@ -108,7 +151,8 @@ BEGIN
   WHERE id = NEW.id;
 END;--> statement-breakpoint
 CREATE TRIGGER IF NOT EXISTS `locations_city_name_after_city_update`
-AFTER UPDATE OF `city_id` ON `locations`
+AFTER UPDATE OF `city_id`, `city_name` ON `locations`
+WHEN NEW.city_name IS NOT (SELECT c.name FROM `cities` c WHERE c.id = NEW.city_id)
 BEGIN
   UPDATE `locations`
   SET `city_name` = (SELECT c.name FROM `cities` c WHERE c.id = NEW.city_id)
@@ -237,8 +281,9 @@ BEGIN
   SELECT RAISE(ABORT, 'invalid membership status or team capacity exceeded');
 END;--> statement-breakpoint
 CREATE TRIGGER IF NOT EXISTS `team_members_validate_update`
-BEFORE UPDATE OF `status` ON `team_members`
+BEFORE UPDATE OF `status`, `team_id` ON `team_members`
 WHEN NEW.status NOT IN ('pending', 'approved', 'rejected', 'leave_pending', 'cancelled')
+  OR NEW.team_id <> OLD.team_id
   OR (
     NEW.status = 'approved'
     AND OLD.status NOT IN ('approved', 'leave_pending')
@@ -248,6 +293,16 @@ WHEN NEW.status NOT IN ('pending', 'approved', 'rejected', 'leave_pending', 'can
   )
 BEGIN
   SELECT RAISE(ABORT, 'invalid membership status or team capacity exceeded');
+END;--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `teams_capacity_validate_update`
+BEFORE UPDATE OF `max_members` ON `teams`
+WHEN NEW.max_members < (
+  SELECT COUNT(*) FROM `team_members`
+  WHERE team_id = NEW.id AND status IN ('approved', 'leave_pending')
+)
+BEGIN
+  SELECT RAISE(ABORT, 'team max_members cannot be below current members');
 END;--> statement-breakpoint
 
 CREATE TRIGGER IF NOT EXISTS `team_members_status_after_insert`

--- a/api/db/migrations/0019_database_integrity.sql
+++ b/api/db/migrations/0019_database_integrity.sql
@@ -69,7 +69,39 @@ SELECT CASE WHEN
 THEN 0 ELSE 1 END;--> statement-breakpoint
 DROP TABLE IF EXISTS `_0019_integrity_guard`;--> statement-breakpoint
 
-PRAGMA foreign_keys=OFF;--> statement-breakpoint
+-- D1 keeps foreign keys enabled inside migrations. Preserve every child row before
+-- rebuilding the parent table because DROP TABLE still executes ON DELETE CASCADE.
+PRAGMA defer_foreign_keys=ON;--> statement-breakpoint
+DROP TRIGGER IF EXISTS `teams_polymorphic_cleanup`;--> statement-breakpoint
+DROP TRIGGER IF EXISTS `entity_to_tags_validate_insert`;--> statement-breakpoint
+DROP TRIGGER IF EXISTS `entity_to_tags_validate_update`;--> statement-breakpoint
+DROP TRIGGER IF EXISTS `team_members_validate_insert`;--> statement-breakpoint
+DROP TRIGGER IF EXISTS `team_members_validate_update`;--> statement-breakpoint
+DROP TRIGGER IF EXISTS `teams_capacity_validate_update`;--> statement-breakpoint
+DROP TRIGGER IF EXISTS `team_members_status_after_insert`;--> statement-breakpoint
+DROP TRIGGER IF EXISTS `team_members_status_after_update`;--> statement-breakpoint
+DROP TRIGGER IF EXISTS `team_members_status_after_delete`;--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `_0019_team_members_backup` AS
+SELECT * FROM `team_members` WHERE 0;--> statement-breakpoint
+DELETE FROM `_0019_team_members_backup`;--> statement-breakpoint
+INSERT INTO `_0019_team_members_backup` SELECT * FROM `team_members`;--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `_0019_conversations_backup` AS
+SELECT * FROM `conversations` WHERE 0;--> statement-breakpoint
+DELETE FROM `_0019_conversations_backup`;--> statement-breakpoint
+INSERT INTO `_0019_conversations_backup` SELECT * FROM `conversations`;--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `_0019_messages_backup` AS
+SELECT * FROM `messages` WHERE 0;--> statement-breakpoint
+DELETE FROM `_0019_messages_backup`;--> statement-breakpoint
+INSERT INTO `_0019_messages_backup` SELECT * FROM `messages`;--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `_0019_activity_posts_backup` AS
+SELECT * FROM `activity_posts` WHERE 0;--> statement-breakpoint
+DELETE FROM `_0019_activity_posts_backup`;--> statement-breakpoint
+INSERT INTO `_0019_activity_posts_backup` SELECT * FROM `activity_posts`;--> statement-breakpoint
+
 CREATE TABLE IF NOT EXISTS `__new_teams` (
   `id` text PRIMARY KEY NOT NULL,
   `location_id` text NOT NULL,
@@ -115,7 +147,17 @@ SELECT
 FROM `teams`;--> statement-breakpoint
 DROP TABLE IF EXISTS `teams`;--> statement-breakpoint
 ALTER TABLE `__new_teams` RENAME TO `teams`;--> statement-breakpoint
-PRAGMA foreign_keys=ON;--> statement-breakpoint
+
+INSERT INTO `team_members` SELECT * FROM `_0019_team_members_backup`;--> statement-breakpoint
+INSERT INTO `conversations` SELECT * FROM `_0019_conversations_backup`;--> statement-breakpoint
+INSERT INTO `messages` SELECT * FROM `_0019_messages_backup`;--> statement-breakpoint
+INSERT INTO `activity_posts` SELECT * FROM `_0019_activity_posts_backup`;--> statement-breakpoint
+
+DROP TABLE IF EXISTS `_0019_team_members_backup`;--> statement-breakpoint
+DROP TABLE IF EXISTS `_0019_conversations_backup`;--> statement-breakpoint
+DROP TABLE IF EXISTS `_0019_messages_backup`;--> statement-breakpoint
+DROP TABLE IF EXISTS `_0019_activity_posts_backup`;--> statement-breakpoint
+PRAGMA defer_foreign_keys=OFF;--> statement-breakpoint
 
 CREATE INDEX IF NOT EXISTS `teams_location_idx` ON `teams` (`location_id`);--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS `teams_leader_idx` ON `teams` (`leader_id`);--> statement-breakpoint

--- a/api/db/migrations/meta/_journal.json
+++ b/api/db/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1785300000000,
       "tag": "0018_add_actor_api_key_id",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "6",
+      "when": 1786867200000,
+      "tag": "0019_database_integrity",
+      "breakpoints": true
     }
   ]
 }

--- a/api/package.json
+++ b/api/package.json
@@ -35,6 +35,7 @@
     "@cloudflare/workers-types": "^4.20260409.1",
     "@eslint/js": "9",
     "@types/better-sqlite3": "^7.6.0",
+    "@types/node": "^25.0.0",
     "@types/qrcode": "^1.5.6",
     "@types/react": "^18.3.0",
     "@vitest/coverage-v8": "^2.0.0",

--- a/api/scripts/check-migrations-sync.mjs
+++ b/api/scripts/check-migrations-sync.mjs
@@ -15,6 +15,7 @@
 import { readFileSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
 
 const apiRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const migrationsDir = join(apiRoot, "db", "migrations");
@@ -90,6 +91,105 @@ for (const t of liveTables) {
     errors.push(`迁移创建的表 "${t}" 在 api/src/db/schema.ts 中无 sqliteTable 定义（schema 落后于 migration，运行时 adapter 会 500）`);
   }
 }
+
+// 7. 在内存 SQLite 中完整重放 migration，核对 schema.ts 声明的外键与索引。
+// 仅比较表名无法发现「重建表时漏写 FOREIGN KEY」或「手工 migration 索引未回写 schema」；
+// 这两类漂移都会让 Drizzle 类型与生产 D1 的真实约束不一致。
+const sqlite = new Database(":memory:");
+sqlite.pragma("foreign_keys = ON");
+
+try {
+  for (const f of readdirSync(migrationsDir).filter((name) => name.endsWith(".sql")).sort()) {
+    const migrationSql = readFileSync(join(migrationsDir, f), "utf8")
+      .replaceAll("--> statement-breakpoint", "");
+    sqlite.exec(migrationSql);
+  }
+} catch (err) {
+  errors.push(`migration 无法从空库完整重放：${err.message}`);
+}
+
+const tableDefinitions = [...schemaSrc.matchAll(
+  /export const (\w+) = sqliteTable\(\s*["'`]([^"'`]+)["'`]([\s\S]*?)(?=export const \w+ = sqliteTable\(|$)/g,
+)];
+const variableToTable = new Map(tableDefinitions.map((match) => [match[1], match[2]]));
+const propertyToColumn = new Map();
+
+for (const match of tableDefinitions) {
+  const [, variableName, , definition] = match;
+  const fields = new Map(
+    [...definition.matchAll(/(\w+):\s*(?:text|integer|real)\(["'`]([^"'`]+)["'`]/g)]
+      .map((field) => [field[1], field[2]]),
+  );
+  propertyToColumn.set(variableName, fields);
+}
+
+for (const match of tableDefinitions) {
+  const [, , tableName, definition] = match;
+  const expectedForeignKeys = [...definition.matchAll(
+    /(\w+):\s*(?:text|integer|real)\(["'`]([^"'`]+)["'`][^\n]*?\.references\(\(\) => (\w+)\.(\w+)(?:,\s*\{\s*onDelete:\s*["'`]([^"'`]+)["'`]\s*\})?/g,
+  )].map((foreignKey) => ({
+    from: foreignKey[2],
+    table: variableToTable.get(foreignKey[3]),
+    to: propertyToColumn.get(foreignKey[3])?.get(foreignKey[4]),
+    onDelete: (foreignKey[5] ?? "no action").toUpperCase(),
+  }));
+  const actualForeignKeys = sqlite.prepare(`PRAGMA foreign_key_list('${tableName}')`).all();
+
+  for (const expected of expectedForeignKeys) {
+    const exists = actualForeignKeys.some((actual) =>
+      actual.from === expected.from &&
+      actual.table === expected.table &&
+      actual.to === expected.to &&
+      String(actual.on_delete).toUpperCase() === expected.onDelete
+    );
+    if (!exists) {
+      errors.push(
+        `表 "${tableName}" 缺少 schema.ts 声明的外键：${expected.from} -> ${expected.table}.${expected.to} ON DELETE ${expected.onDelete}`,
+      );
+    }
+  }
+}
+
+const declaredIndexes = new Set(
+  [...schemaSrc.matchAll(/(?:uniqueIndex|index)\(["'`]([^"'`]+)["'`]\)/g)].map((match) => match[1]),
+);
+const implicitUniqueIndexes = new Set();
+for (const match of tableDefinitions) {
+  const [, , tableName, definition] = match;
+  for (const field of definition.matchAll(/\w+:\s*(?:text|integer|real)\(["'`]([^"'`]+)["'`][^\n]*?\.unique\(\)/g)) {
+    implicitUniqueIndexes.add(`${tableName}_${field[1]}_unique`);
+  }
+}
+
+const actualIndexes = sqlite.prepare(
+  "SELECT name, tbl_name FROM sqlite_master WHERE type = 'index' AND sql IS NOT NULL",
+).all();
+for (const indexRow of actualIndexes) {
+  if (!declaredIndexes.has(indexRow.name) && !implicitUniqueIndexes.has(indexRow.name)) {
+    errors.push(`数据库索引 "${indexRow.name}" 未声明在 schema.ts 中`);
+  }
+}
+
+for (const tableName of liveTables) {
+  const indexRows = sqlite.prepare(`PRAGMA index_list('${tableName}')`).all();
+  const columnsToIndexes = new Map();
+  for (const indexRow of indexRows) {
+    if (indexRow.origin === "pk") continue;
+    const columns = sqlite.prepare(`PRAGMA index_info('${indexRow.name}')`).all()
+      .map((column) => column.name)
+      .join(",");
+    const names = columnsToIndexes.get(columns) ?? [];
+    names.push(indexRow.name);
+    columnsToIndexes.set(columns, names);
+  }
+  for (const [columns, names] of columnsToIndexes) {
+    if (names.length > 1) {
+      errors.push(`表 "${tableName}" 的列 (${columns}) 存在重复索引：${names.sort().join(", ")}`);
+    }
+  }
+}
+
+sqlite.close();
 
 if (errors.length > 0) {
   console.error("✗ 迁移一致性校验失败：");

--- a/api/scripts/check-migrations-sync.mjs
+++ b/api/scripts/check-migrations-sync.mjs
@@ -189,6 +189,52 @@ for (const tableName of liveTables) {
   }
 }
 
+// 这些触发器承载无法用 SQLite 外键/Drizzle schema 表达的跨表完整性。
+// 若后续重建表时被意外删除，应用仍可编译，但派生计数和多态关系会静默失真。
+const REQUIRED_INTEGRITY_TRIGGERS = [
+  "locations_city_name_after_insert",
+  "locations_city_name_after_city_update",
+  "locations_city_name_after_city_rename",
+  "users_city_validate_insert",
+  "users_city_validate_update",
+  "cities_users_restrict_delete",
+  "entity_to_tags_validate_insert",
+  "entity_to_tags_validate_update",
+  "user_favorites_validate_insert",
+  "user_favorites_validate_update",
+  "locations_polymorphic_cleanup",
+  "stories_polymorphic_cleanup",
+  "teams_polymorphic_cleanup",
+  "user_story_likes_count_after_insert",
+  "user_story_likes_count_after_delete",
+  "messages_summary_after_insert",
+  "team_members_validate_insert",
+  "team_members_validate_update",
+  "teams_capacity_validate_update",
+  "team_members_status_after_insert",
+  "team_members_status_after_update",
+  "team_members_status_after_delete",
+  "users_domain_validate_insert",
+  "users_domain_validate_update",
+  "locations_domain_validate_insert",
+  "locations_domain_validate_update",
+  "tags_domain_validate_insert",
+  "tags_domain_validate_update",
+  "stories_domain_validate_insert",
+  "stories_domain_validate_update",
+  "activity_posts_domain_validate_insert",
+  "activity_posts_domain_validate_update",
+];
+const actualTriggers = new Set(
+  sqlite.prepare("SELECT name FROM sqlite_master WHERE type = 'trigger'").all()
+    .map((trigger) => trigger.name),
+);
+for (const triggerName of REQUIRED_INTEGRITY_TRIGGERS) {
+  if (!actualTriggers.has(triggerName)) {
+    errors.push(`数据库缺少必要完整性触发器 "${triggerName}"`);
+  }
+}
+
 sqlite.close();
 
 if (errors.length > 0) {

--- a/api/scripts/database-integrity.test.mjs
+++ b/api/scripts/database-integrity.test.mjs
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import Database from "better-sqlite3";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const apiRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const migrationsDir = join(apiRoot, "db", "migrations");
+
+function applyMigrations(db, files) {
+  for (const file of files) {
+    db.exec(readFileSync(join(migrationsDir, file), "utf8").replaceAll("--> statement-breakpoint", ""));
+  }
+}
+
+function createMigratedDatabase(files = readdirSync(migrationsDir).filter((name) => name.endsWith(".sql")).sort()) {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  applyMigrations(db, files);
+  return db;
+}
+
+function seedCore(db) {
+  const now = Date.now();
+  db.prepare(`
+    INSERT INTO cities (id, adcode, name, is_hot, created_at, updated_at)
+    VALUES ('city-1', '440300', '深圳', 1, ?, ?)
+  `).run(now, now);
+  db.prepare(`
+    INSERT INTO users (id, name, email, email_verified, level, role, status, created_at, updated_at)
+    VALUES (?, ?, ?, 0, 'beginner', 'user', 'active', ?, ?)
+  `).run("leader", "Leader", "leader@example.com", now, now);
+  db.prepare(`
+    INSERT INTO users (id, name, email, email_verified, level, role, status, created_at, updated_at)
+    VALUES (?, ?, ?, 0, 'beginner', 'user', 'active', ?, ?)
+  `).run("member", "Member", "member@example.com", now, now);
+  db.prepare(`
+    INSERT INTO users (id, name, email, email_verified, level, role, status, created_at, updated_at)
+    VALUES (?, ?, ?, 0, 'beginner', 'user', 'active', ?, ?)
+  `).run("waiting", "Waiting", "waiting@example.com", now, now);
+  db.prepare(`
+    INSERT INTO locations (
+      id, name, slug, description, city_id, city_name, best_season,
+      cover_image, images, coordinates, created_at, updated_at
+    ) VALUES ('location-1', '南山', 'nanshan', 'test', 'city-1', '错误名', '[]', 'cover', '[]', '{}', ?, ?)
+  `).run(now, now);
+  return now;
+}
+
+function seedTeam(db, now, maxMembers = 2) {
+  db.prepare(`
+    INSERT INTO teams (
+      id, location_id, leader_id, title, start_time, end_time,
+      duration_min, max_members, icon, status, created_at, updated_at
+    ) VALUES ('team-1', 'location-1', 'leader', '测试队伍', ?, ?, 60, ?, '⛰️', 'recruiting', ?, ?)
+  `).run(now + 60_000, now + 120_000, maxMembers, now, now);
+}
+
+describe("replayed migration database integrity", () => {
+  let db;
+
+  beforeEach(() => {
+    db = createMigratedDatabase();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("restores teams foreign keys and uses restrictive parent deletion", () => {
+    const now = seedCore(db);
+    seedTeam(db, now);
+
+    const foreignKeys = db.prepare("PRAGMA foreign_key_list('teams')").all();
+    expect(foreignKeys).toEqual(expect.arrayContaining([
+      expect.objectContaining({ from: "location_id", table: "locations", on_delete: "RESTRICT" }),
+      expect.objectContaining({ from: "leader_id", table: "users", on_delete: "RESTRICT" }),
+    ]));
+    expect(() => db.prepare("DELETE FROM locations WHERE id = 'location-1'").run())
+      .toThrow(/FOREIGN KEY constraint failed/u);
+  });
+
+  it("keeps city references and denormalized city names canonical", () => {
+    seedCore(db);
+
+    expect(db.prepare("SELECT city_name FROM locations WHERE id = 'location-1'").get().city_name)
+      .toBe("深圳");
+    db.prepare("UPDATE cities SET name = '深圳市' WHERE id = 'city-1'").run();
+    expect(db.prepare("SELECT city_name FROM locations WHERE id = 'location-1'").get().city_name)
+      .toBe("深圳市");
+
+    expect(() => db.prepare("UPDATE users SET city = 'missing-city' WHERE id = 'member'").run())
+      .toThrow(/users\.city must reference cities\.id/u);
+  });
+
+  it("normalizes legacy city names and removes pre-existing polymorphic orphans", () => {
+    db.close();
+    const allFiles = readdirSync(migrationsDir).filter((name) => name.endsWith(".sql")).sort();
+    const integrityFile = allFiles.at(-1);
+    expect(integrityFile).toBe("0019_database_integrity.sql");
+    db = createMigratedDatabase(allFiles.slice(0, -1));
+    const now = Date.now();
+    db.prepare(`
+      INSERT INTO cities (id, adcode, name, is_hot, created_at, updated_at)
+      VALUES ('city-legacy', '440300', '深圳', 1, ?, ?)
+    `).run(now, now);
+    db.prepare(`
+      INSERT INTO users (id, name, email, email_verified, level, role, status, city, created_at, updated_at)
+      VALUES ('legacy-user', 'Legacy', 'legacy@example.com', 0, 'beginner', 'user', 'active', '深圳', ?, ?)
+    `).run(now, now);
+    db.prepare("INSERT INTO tags (id, name, type, created_at) VALUES ('tag-1', '徒步', 'activity', ?)")
+      .run(now);
+    db.prepare(`
+      INSERT INTO entity_to_tags (id, entity_id, entity_type, tag_id, created_at)
+      VALUES ('relation-1', 'missing-story', 'story', 'tag-1', ?)
+    `).run(now);
+    db.prepare(`
+      INSERT INTO user_favorites (id, user_id, entity_type, entity_id, created_at)
+      VALUES ('favorite-1', 'legacy-user', 'story', 'missing-story', ?)
+    `).run(now);
+
+    applyMigrations(db, [integrityFile]);
+
+    expect(db.prepare("SELECT city FROM users WHERE id = 'legacy-user'").get().city).toBe("city-legacy");
+    expect(db.prepare("SELECT COUNT(*) AS count FROM entity_to_tags").get().count).toBe(0);
+    expect(db.prepare("SELECT COUNT(*) AS count FROM user_favorites").get().count).toBe(0);
+  });
+
+  it("derives story like_count from unique like rows", () => {
+    const now = seedCore(db);
+    db.prepare(`
+      INSERT INTO stories (
+        id, author_id, title, summary, content, status, view_count, like_count, created_at, updated_at
+      ) VALUES ('story-1', 'leader', '标题', '摘要', '内容', 'published', 0, 0, ?, ?)
+    `).run(now, now);
+
+    db.prepare("INSERT INTO user_story_likes (user_id, story_id) VALUES ('member', 'story-1')").run();
+    expect(db.prepare("SELECT like_count FROM stories WHERE id = 'story-1'").get().like_count).toBe(1);
+    db.prepare("DELETE FROM user_story_likes WHERE user_id = 'member' AND story_id = 'story-1'").run();
+    expect(db.prepare("SELECT like_count FROM stories WHERE id = 'story-1'").get().like_count).toBe(0);
+  });
+
+  it("enforces member capacity and synchronizes recruiting/full status", () => {
+    const now = seedCore(db);
+    seedTeam(db, now, 2);
+    const insertMember = db.prepare(`
+      INSERT INTO team_members (id, team_id, user_id, status, joined_at, created_at)
+      VALUES (?, 'team-1', ?, ?, ?, ?)
+    `);
+    insertMember.run("membership-leader", "leader", "approved", now, now);
+    insertMember.run("membership-member", "member", "approved", now, now);
+    insertMember.run("membership-waiting", "waiting", "pending", null, now);
+
+    expect(db.prepare("SELECT status FROM teams WHERE id = 'team-1'").get().status).toBe("full");
+    expect(() => db.prepare("UPDATE team_members SET status = 'approved' WHERE id = 'membership-waiting'").run())
+      .toThrow(/team capacity exceeded/u);
+    expect(() => db.prepare("UPDATE teams SET max_members = 1 WHERE id = 'team-1'").run())
+      .toThrow(/max_members cannot be below current members/u);
+
+    db.prepare("DELETE FROM team_members WHERE id = 'membership-member'").run();
+    expect(db.prepare("SELECT status FROM teams WHERE id = 'team-1'").get().status).toBe("recruiting");
+  });
+
+  it("updates conversation summaries in the same database write as messages", () => {
+    const now = seedCore(db);
+    seedTeam(db, now);
+    db.prepare(`
+      INSERT INTO conversations (id, team_id, user_id, leader_id, initiator_id, created_at, updated_at)
+      VALUES ('conversation-1', 'team-1', 'member', 'leader', 'member', ?, ?)
+    `).run(now, now);
+    db.prepare(`
+      INSERT INTO messages (id, conversation_id, sender_id, content, is_read, created_at)
+      VALUES ('message-1', 'conversation-1', 'member', '第一条消息', 0, ?)
+    `).run(now + 1);
+
+    expect(db.prepare(`
+      SELECT last_message_content, last_message_at FROM conversations WHERE id = 'conversation-1'
+    `).get()).toMatchObject({
+      last_message_content: "第一条消息",
+      last_message_at: now + 1,
+    });
+  });
+});

--- a/api/scripts/database-integrity.test.mjs
+++ b/api/scripts/database-integrity.test.mjs
@@ -13,6 +13,14 @@ function applyMigrations(db, files) {
   }
 }
 
+function applyMigrationWithD1ForeignKeySemantics(db, file) {
+  const sql = readFileSync(join(migrationsDir, file), "utf8")
+    .replaceAll("--> statement-breakpoint", "")
+    // D1 ignores attempts to disable foreign keys inside its implicit migration transaction.
+    .replace(/PRAGMA\s+foreign_keys\s*=\s*(?:OFF|ON)\s*;/giu, "");
+  db.exec(sql);
+}
+
 function createMigratedDatabase(files = readdirSync(migrationsDir).filter((name) => name.endsWith(".sql")).sort()) {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
@@ -78,6 +86,48 @@ describe("replayed migration database integrity", () => {
     ]));
     expect(() => db.prepare("DELETE FROM locations WHERE id = 'location-1'").run())
       .toThrow(/FOREIGN KEY constraint failed/u);
+  });
+
+  it("preserves team child rows when D1 keeps foreign keys enabled during the rebuild", () => {
+    db.close();
+    const allFiles = readdirSync(migrationsDir).filter((name) => name.endsWith(".sql")).sort();
+    const integrityFile = allFiles.at(-1);
+    db = createMigratedDatabase(allFiles.slice(0, -1));
+    const now = seedCore(db);
+    seedTeam(db, now);
+
+    db.prepare(`
+      INSERT INTO team_members (id, team_id, user_id, status, joined_at, created_at)
+      VALUES ('membership-1', 'team-1', 'member', 'approved', ?, ?)
+    `).run(now, now);
+    db.prepare(`
+      INSERT INTO conversations (id, team_id, user_id, leader_id, initiator_id, created_at, updated_at)
+      VALUES ('conversation-1', 'team-1', 'member', 'leader', 'member', ?, ?)
+    `).run(now, now);
+    db.prepare(`
+      INSERT INTO messages (id, conversation_id, sender_id, content, is_read, created_at)
+      VALUES ('message-1', 'conversation-1', 'member', '保留消息', 0, ?)
+    `).run(now);
+    db.prepare(`
+      INSERT INTO activity_posts (
+        id, team_id, location_id, author_id, content, images, status, created_at, updated_at
+      ) VALUES ('post-1', 'team-1', 'location-1', 'member', '保留动态', '[]', 'visible', ?, ?)
+    `).run(now, now);
+
+    const expectChildrenPreserved = () => {
+      expect(db.prepare("SELECT id FROM team_members WHERE id = 'membership-1'").get()).toBeTruthy();
+      expect(db.prepare("SELECT id FROM conversations WHERE id = 'conversation-1'").get()).toBeTruthy();
+      expect(db.prepare("SELECT id FROM messages WHERE id = 'message-1'").get()).toBeTruthy();
+      expect(db.prepare("SELECT id FROM activity_posts WHERE id = 'post-1'").get()).toBeTruthy();
+      expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+    };
+
+    applyMigrationWithD1ForeignKeySemantics(db, integrityFile);
+    expectChildrenPreserved();
+
+    // 迁移文件本身也必须可安全重放，不能只依赖 D1 migration ledger。
+    applyMigrationWithD1ForeignKeySemantics(db, integrityFile);
+    expectChildrenPreserved();
   });
 
   it("keeps city references and denormalized city names canonical", () => {

--- a/api/src/__tests__/helpers/db.ts
+++ b/api/src/__tests__/helpers/db.ts
@@ -131,8 +131,8 @@ export function createTestDb() {
 
     CREATE TABLE IF NOT EXISTS teams (
       id TEXT PRIMARY KEY,
-      location_id TEXT NOT NULL REFERENCES locations(id) ON DELETE CASCADE,
-      leader_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      location_id TEXT NOT NULL REFERENCES locations(id) ON DELETE RESTRICT,
+      leader_id TEXT NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
       title TEXT NOT NULL,
       description TEXT,
       start_time INTEGER NOT NULL,
@@ -237,6 +237,157 @@ export function createTestDb() {
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     );
+
+    CREATE TRIGGER IF NOT EXISTS user_story_likes_count_after_insert
+    AFTER INSERT ON user_story_likes
+    BEGIN
+      UPDATE stories
+      SET like_count = COALESCE(like_count, 0) + 1,
+          updated_at = (unixepoch() * 1000)
+      WHERE id = NEW.story_id;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS user_story_likes_count_after_delete
+    AFTER DELETE ON user_story_likes
+    BEGIN
+      UPDATE stories
+      SET like_count = MAX(0, COALESCE(like_count, 0) - 1),
+          updated_at = (unixepoch() * 1000)
+      WHERE id = OLD.story_id;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS locations_city_name_after_insert
+    AFTER INSERT ON locations
+    BEGIN
+      UPDATE locations
+      SET city_name = (SELECT name FROM cities WHERE id = NEW.city_id)
+      WHERE id = NEW.id;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS locations_city_name_after_city_update
+    AFTER UPDATE OF city_id, city_name ON locations
+    WHEN NEW.city_name IS NOT (SELECT name FROM cities WHERE id = NEW.city_id)
+    BEGIN
+      UPDATE locations
+      SET city_name = (SELECT name FROM cities WHERE id = NEW.city_id)
+      WHERE id = NEW.id;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS locations_city_name_after_city_rename
+    AFTER UPDATE OF name ON cities
+    BEGIN
+      UPDATE locations SET city_name = NEW.name WHERE city_id = NEW.id;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS users_city_validate_insert
+    BEFORE INSERT ON users
+    WHEN NEW.city IS NOT NULL AND NOT EXISTS (SELECT 1 FROM cities WHERE id = NEW.city)
+    BEGIN
+      SELECT RAISE(ABORT, 'users.city must reference cities.id');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS users_city_validate_update
+    BEFORE UPDATE OF city ON users
+    WHEN NEW.city IS NOT NULL AND NOT EXISTS (SELECT 1 FROM cities WHERE id = NEW.city)
+    BEGIN
+      SELECT RAISE(ABORT, 'users.city must reference cities.id');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS messages_summary_after_insert
+    AFTER INSERT ON messages
+    BEGIN
+      UPDATE conversations
+      SET last_message_content = SUBSTR(NEW.content, 1, 100),
+          last_message_at = NEW.created_at,
+          updated_at = NEW.created_at
+      WHERE id = NEW.conversation_id;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS team_members_validate_insert
+    BEFORE INSERT ON team_members
+    WHEN NEW.status NOT IN ('pending', 'approved', 'rejected', 'leave_pending', 'cancelled')
+      OR (
+        NEW.status = 'approved'
+        AND (SELECT COUNT(*) FROM team_members
+             WHERE team_id = NEW.team_id AND status IN ('approved', 'leave_pending'))
+            >= (SELECT max_members FROM teams WHERE id = NEW.team_id)
+      )
+    BEGIN
+      SELECT RAISE(ABORT, 'invalid membership status or team capacity exceeded');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS team_members_validate_update
+    BEFORE UPDATE OF status, team_id ON team_members
+    WHEN NEW.status NOT IN ('pending', 'approved', 'rejected', 'leave_pending', 'cancelled')
+      OR NEW.team_id <> OLD.team_id
+      OR (
+        NEW.status = 'approved'
+        AND OLD.status NOT IN ('approved', 'leave_pending')
+        AND (SELECT COUNT(*) FROM team_members
+             WHERE team_id = NEW.team_id AND status IN ('approved', 'leave_pending'))
+            >= (SELECT max_members FROM teams WHERE id = NEW.team_id)
+      )
+    BEGIN
+      SELECT RAISE(ABORT, 'invalid membership status or team capacity exceeded');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS teams_capacity_validate_update
+    BEFORE UPDATE OF max_members ON teams
+    WHEN NEW.max_members < (
+      SELECT COUNT(*) FROM team_members
+      WHERE team_id = NEW.id AND status IN ('approved', 'leave_pending')
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'team max_members cannot be below current members');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS team_members_status_after_insert
+    AFTER INSERT ON team_members
+    BEGIN
+      UPDATE teams
+      SET status = CASE
+            WHEN status IN ('recruiting', 'full') AND (
+              SELECT COUNT(*) FROM team_members
+              WHERE team_id = NEW.team_id AND status IN ('approved', 'leave_pending')
+            ) >= max_members THEN 'full'
+            WHEN status IN ('recruiting', 'full') THEN 'recruiting'
+            ELSE status
+          END,
+          updated_at = (unixepoch() * 1000)
+      WHERE id = NEW.team_id;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS team_members_status_after_update
+    AFTER UPDATE OF status ON team_members
+    BEGIN
+      UPDATE teams
+      SET status = CASE
+            WHEN status IN ('recruiting', 'full') AND (
+              SELECT COUNT(*) FROM team_members
+              WHERE team_id = NEW.team_id AND status IN ('approved', 'leave_pending')
+            ) >= max_members THEN 'full'
+            WHEN status IN ('recruiting', 'full') THEN 'recruiting'
+            ELSE status
+          END,
+          updated_at = (unixepoch() * 1000)
+      WHERE id = NEW.team_id;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS team_members_status_after_delete
+    AFTER DELETE ON team_members
+    BEGIN
+      UPDATE teams
+      SET status = CASE
+            WHEN status IN ('recruiting', 'full') AND (
+              SELECT COUNT(*) FROM team_members
+              WHERE team_id = OLD.team_id AND status IN ('approved', 'leave_pending')
+            ) >= max_members THEN 'full'
+            WHEN status IN ('recruiting', 'full') THEN 'recruiting'
+            ELSE status
+          END,
+          updated_at = (unixepoch() * 1000)
+      WHERE id = OLD.team_id;
+    END;
   `);
 
   const db = drizzle(sqlite, { schema });

--- a/api/src/__tests__/integration/favorites.test.ts
+++ b/api/src/__tests__/integration/favorites.test.ts
@@ -134,6 +134,20 @@ describe("Favorites API 集成测试", () => {
       });
       expect(res.status).toBe(409);
     });
+
+    it("收藏不存在的故事返回 404 且不创建悬空关系", async () => {
+      setSession({ id: user.id, email: user.email, name: user.name });
+
+      const res = await req(app, "/favorites", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ entityType: "story", entityId: "missing-story" }),
+      });
+
+      expect(res.status).toBe(404);
+      const favorites = await testDb.select().from(schema.userFavorites);
+      expect(favorites).toHaveLength(0);
+    });
   });
 
   describe("DELETE /favorites - 取消收藏", () => {

--- a/api/src/__tests__/integration/locations.test.ts
+++ b/api/src/__tests__/integration/locations.test.ts
@@ -53,6 +53,21 @@ describe("Locations API 集成测试", () => {
     city = await seedCity(testDb, { name: "深圳" });
   });
 
+  it("cityName 始终跟随 cities.name，不接受冗余字段漂移", async () => {
+    const canonicalCity = await seedCity(testDb, { name: "深圳" });
+    const canonicalLocation = await seedLocation(testDb, canonicalCity.id, { cityName: "错误城市名" });
+
+    const [afterInsert] = await testDb.select().from(schema.locations)
+      .where(eq(schema.locations.id, canonicalLocation.id));
+    expect(afterInsert.cityName).toBe("深圳");
+
+    await testDb.update(schema.cities).set({ name: "深圳市" })
+      .where(eq(schema.cities.id, canonicalCity.id));
+    const [afterRename] = await testDb.select().from(schema.locations)
+      .where(eq(schema.locations.id, canonicalLocation.id));
+    expect(afterRename.cityName).toBe("深圳市");
+  });
+
   describe("GET /locations - 地点列表", () => {
     it("获取地点列表返回分页数据", async () => {
       await seedLocation(testDb, city.id, { name: "梧桐山" });

--- a/api/src/__tests__/integration/messages.test.ts
+++ b/api/src/__tests__/integration/messages.test.ts
@@ -297,6 +297,16 @@ describe("Messages API 集成测试", () => {
       });
       expect(sendRes.status).toBe(201);
 
+      const [summarizedConversation] = await db
+        .select({
+          lastMessageContent: schema.conversations.lastMessageContent,
+          lastMessageAt: schema.conversations.lastMessageAt,
+        })
+        .from(schema.conversations)
+        .where(eq(schema.conversations.id, conversationId));
+      expect(summarizedConversation.lastMessageContent).toBe("Hello leader");
+      expect(summarizedConversation.lastMessageAt).not.toBeNull();
+
       const unreadRes = await app.request("/messages/unread-count", {
         method: "GET",
         headers: authHeaders(leader.id),

--- a/api/src/__tests__/integration/stories.test.ts
+++ b/api/src/__tests__/integration/stories.test.ts
@@ -208,6 +208,21 @@ describe("Stories API 集成测试", () => {
       expect(json.data.title).toBe("测试故事");
     });
 
+    it("并发查看公开故事不会丢失浏览计数", async () => {
+      const story = await seedStory(testDb, user.id, { title: "浏览计数", status: "published" });
+
+      const responses = await Promise.all(
+        Array.from({ length: 5 }, () => req(app, `/stories/${story.id}`)),
+      );
+      responses.forEach((response) => expect(response.status).toBe(200));
+
+      const persisted = await testDb.query.stories.findFirst({
+        where: eq(schema.stories.id, story.id),
+        columns: { viewCount: true },
+      });
+      expect(persisted?.viewCount).toBe(5);
+    });
+
     it("故事不存在返回 404", async () => {
       const res = await req(app, "/stories/non-existent-id");
       expect(res.status).toBe(404);
@@ -670,12 +685,11 @@ describe("Stories API 集成测试", () => {
       );
       expect(likeRecords.length).toBeLessThanOrEqual(1);
 
-      // likeCount 应该 >= 0 且不会离谱（允许极端并发下的少量偏差）
+      // 派生计数必须与唯一点赞记录严格一致，不能接受并发漂移。
       const dbStory = await testDb.query.stories.findFirst({
         where: eq(schema.stories.id, story.id),
       });
-      expect((dbStory?.likeCount ?? 0)).toBeGreaterThanOrEqual(0);
-      expect((dbStory?.likeCount ?? 0)).toBeLessThanOrEqual(5);
+      expect(dbStory?.likeCount).toBe(likeRecords.length);
     });
   });
 

--- a/api/src/__tests__/integration/tags.test.ts
+++ b/api/src/__tests__/integration/tags.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import { createTestDb } from "../helpers/db";
+import { seedUser } from "../helpers/seed";
+
+let currentSession: { user: { id: string; email: string; name: string } } | null = null;
+let testDb: ReturnType<typeof createTestDb>["db"];
+
+vi.mock("../../lib/auth", () => ({
+  createAuth: () => ({
+    api: {
+      getSession: async () => currentSession,
+    },
+  }),
+}));
+
+vi.mock("../../db", () => ({
+  createDb: () => testDb,
+}));
+
+const { tagsRoute } = await import("../../routes/tags");
+
+function createApp() {
+  const app = new Hono<{ Bindings: { DB: unknown } }>();
+  app.route("/tags", tagsRoute);
+  return app;
+}
+
+describe("Tags API 集成测试", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    testDb = createTestDb().db;
+    app = createApp();
+
+    const admin = await seedUser(testDb, {
+      name: "管理员",
+      role: "admin",
+      email: "admin@test.com",
+    });
+    currentSession = {
+      user: { id: admin.id, email: admin.email, name: admin.name },
+    };
+  });
+
+  it("非法标签类型在进入数据库前返回 400", async () => {
+    const response = await app.fetch(
+      new Request("http://localhost/tags", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "错误类型", type: "route" }),
+      }),
+      { DB: {} },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ success: false });
+  });
+
+  it.each(["location", "activity", "story"])("允许 %s 标签类型", async (type) => {
+    const response = await app.fetch(
+      new Request("http://localhost/tags", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: `${type}-标签`, type }),
+      }),
+      { DB: {} },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      existing: false,
+    });
+  });
+});

--- a/api/src/__tests__/integration/teams.test.ts
+++ b/api/src/__tests__/integration/teams.test.ts
@@ -178,6 +178,27 @@ describe("Teams API 集成测试", () => {
     });
   });
 
+  describe("PUT /teams/:id - 更新队伍", () => {
+    it("不能把人数上限调低到当前成员数以下", async () => {
+      const thirdMember = await seedUser(testDb, { name: "第三位成员", wechat: "third_wechat" });
+      const team = await seedTeam(testDb, leader.id, location.id, { maxMembers: 5 });
+      await seedTeamMember(testDb, team.id, leader.id, "approved");
+      await seedTeamMember(testDb, team.id, member.id, "approved");
+      await seedTeamMember(testDb, team.id, thirdMember.id, "approved");
+      setSession({ id: leader.id, email: leader.email, name: leader.name });
+
+      const res = await req(app, `/teams/${team.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ maxMembers: 2 }),
+      });
+
+      expect(res.status).toBe(400);
+      const [persisted] = await testDb.select().from(schema.teams).where(eq(schema.teams.id, team.id));
+      expect(persisted.maxMembers).toBe(5);
+    });
+  });
+
   // ===== GET /teams/:id - 获取队伍详情 =====
   describe("GET /teams/:id - 获取队伍详情", () => {
     it("获取存在的队伍详情返回 200", async () => {
@@ -415,6 +436,30 @@ describe("Teams API 集成测试", () => {
         method: "POST",
       });
       expect(res.status).toBe(200);
+
+      const [updatedTeam] = await testDb.select().from(schema.teams).where(eq(schema.teams.id, team.id));
+      expect(updatedTeam.status).toBe("full");
+    });
+
+    it("并发批准不会突破队伍人数上限", async () => {
+      const secondMember = await seedUser(testDb, { name: "第二位申请者", wechat: "second_wechat" });
+      const team = await seedTeam(testDb, leader.id, location.id, { maxMembers: 2 });
+      await seedTeamMember(testDb, team.id, leader.id, "approved");
+      await seedTeamMember(testDb, team.id, member.id, "pending");
+      await seedTeamMember(testDb, team.id, secondMember.id, "pending");
+      setSession({ id: leader.id, email: leader.email, name: leader.name });
+
+      const responses = await Promise.all([
+        req(app, `/teams/${team.id}/members/${member.id}/approve`, { method: "POST" }),
+        req(app, `/teams/${team.id}/members/${secondMember.id}/approve`, { method: "POST" }),
+      ]);
+
+      expect(responses.map((response) => response.status).sort()).toEqual([200, 400]);
+      const approved = await testDb.select().from(schema.teamMembers).where(and(
+        eq(schema.teamMembers.teamId, team.id),
+        eq(schema.teamMembers.status, "approved"),
+      ));
+      expect(approved).toHaveLength(2);
 
       const [updatedTeam] = await testDb.select().from(schema.teams).where(eq(schema.teams.id, team.id));
       expect(updatedTeam.status).toBe("full");

--- a/api/src/__tests__/integration/users.test.ts
+++ b/api/src/__tests__/integration/users.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Hono } from "hono";
 import { createTestDb } from "../helpers/db";
-import { seedUser } from "../helpers/seed";
+import { seedCity, seedUser } from "../helpers/seed";
 import * as schema from "../../db/schema";
 
 // ===== Mock 策略 =====
@@ -109,7 +109,8 @@ describe("用户 API 集成测试", () => {
      */
     it("获取用户信息 → 包含 city 字段（cityId）", async () => {
       // Arrange
-      const user = await seedUser(testDb, { city: "test-city-id-456" });
+      const city = await seedCity(testDb);
+      const user = await seedUser(testDb, { city: city.id });
 
       // Act
       const res = await req(app, `/users?id=${user.id}`);
@@ -117,7 +118,7 @@ describe("用户 API 集成测试", () => {
       // Assert
       expect(res.status).toBe(200);
       const data = await res.json() as { user: Record<string, unknown> };
-      expect(data.user.city).toBe("test-city-id-456");
+      expect(data.user.city).toBe(city.id);
     });
   });
 
@@ -201,6 +202,7 @@ describe("用户 API 集成测试", () => {
     it("更新 city 字段（cityId）→ 200；再传 null → 清空", async () => {
       // Arrange
       const user = await seedUser(testDb);
+      const city = await seedCity(testDb);
       currentSession = { user: { id: user.id, email: user.email, name: user.name } };
       const { eq } = await import("drizzle-orm");
 
@@ -208,13 +210,13 @@ describe("用户 API 集成测试", () => {
       const res1 = await req(app, "/users/update", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ userId: user.id, city: "test-city-id-123" }),
+        body: JSON.stringify({ userId: user.id, city: city.id }),
       });
 
       // Assert 1
       expect(res1.status).toBe(200);
       const [u1] = await testDb.select().from(schema.users).where(eq(schema.users.id, user.id));
-      expect(u1.city).toBe("test-city-id-123");
+      expect(u1.city).toBe(city.id);
 
       // Act 2: 传 null 清空
       const res2 = await req(app, "/users/update", {
@@ -227,6 +229,19 @@ describe("用户 API 集成测试", () => {
       expect(res2.status).toBe(200);
       const [u2] = await testDb.select().from(schema.users).where(eq(schema.users.id, user.id));
       expect(u2.city).toBeNull();
+    });
+
+    it("更新为不存在的 cityId → 400", async () => {
+      const user = await seedUser(testDb);
+      currentSession = { user: { id: user.id, email: user.email, name: user.name } };
+
+      const res = await req(app, "/users/update", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId: user.id, city: "missing-city" }),
+      });
+
+      expect(res.status).toBe(400);
     });
 
     /**

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -505,7 +505,7 @@ export type UserLevel = "beginner" | "intermediate" | "advanced" | "expert";
 export type UserStatus = "active" | "suspended" | "banned" | "deleted";
 export type UserGender = "male" | "female" | "other";
 export type CityLevel = "city" | "district";
-export type TagType = "location" | "activity";
+export type TagType = "location" | "activity" | "story";
 export type EntityType = "location" | "activity" | "story";
 
 // 活动后分享状态

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -6,6 +6,7 @@ import {
   index,
   uniqueIndex,
   primaryKey,
+  check,
 } from "drizzle-orm/sqlite-core";
 import { relations, sql } from "drizzle-orm";
 import type { TeamChecklist } from "@gomate/types";
@@ -41,9 +42,9 @@ export const users = sqliteTable(
     deletedAt: integer("deleted_at", { mode: "timestamp_ms" }),
   },
   (table) => ({
-    emailIdx: index("users_email_idx").on(table.email),
     nameIdx: index("users_name_idx").on(table.name),
     nicknameIdx: index("users_nickname_idx").on(table.nickname),
+    cityIdx: index("users_city_idx").on(table.city),
   })
 );
 
@@ -62,7 +63,6 @@ export const sessions = sqliteTable(
   },
   (table) => ({
     userIdx: index("sessions_user_idx").on(table.userId),
-    tokenIdx: index("sessions_token_idx").on(table.token),
   })
 );
 
@@ -123,7 +123,6 @@ export const cities = sqliteTable(
     updatedAt: integer("updated_at", { mode: "timestamp_ms" }).$defaultFn(() => new Date()).notNull(),
   },
   (table) => ({
-    adcodeIdx: uniqueIndex("cities_adcode_idx").on(table.adcode),
     isHotIdx: index("cities_is_hot_idx").on(table.isHot),
   })
 );
@@ -165,11 +164,11 @@ export const locations = sqliteTable(
     actorApiKeyId: text("actor_api_key_id"),
   },
   (table) => ({
-    slugIdx: uniqueIndex("locations_slug_idx").on(table.slug),
     nameIdx: index("locations_name_idx").on(table.name),
     cityIdx: index("locations_city_idx").on(table.cityId),
     typeIdx: index("locations_type_idx").on(table.type),
     createdAtIdx: index("locations_created_at_idx").on(table.createdAt),
+    actorApiKeyIdx: index("locations_actor_api_key_id_idx").on(table.actorApiKeyId),
   })
 );
 
@@ -183,7 +182,6 @@ export const tags = sqliteTable(
     createdAt: integer("created_at", { mode: "timestamp_ms" }).$defaultFn(() => new Date()).notNull(),
   },
   (table) => ({
-    nameIdx: uniqueIndex("tags_name_idx").on(table.name),
     typeIdx: index("tags_type_idx").on(table.type),
   })
 );
@@ -211,8 +209,8 @@ export const teams = sqliteTable(
   "teams",
   {
     id: text("id").primaryKey(),
-    locationId: text("location_id").references(() => locations.id, { onDelete: "cascade" }).notNull(),
-    leaderId: text("leader_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
+    locationId: text("location_id").references(() => locations.id, { onDelete: "restrict" }).notNull(),
+    leaderId: text("leader_id").references(() => users.id, { onDelete: "restrict" }).notNull(),
     title: text("title").notNull(),
     description: text("description"),
     startTime: integer("start_time", { mode: "timestamp_ms" }).notNull(),
@@ -225,8 +223,8 @@ export const teams = sqliteTable(
     // task #163：Team「行动本」checklist（JSON，nullable = 队长未填）
     // 结构见 packages/types TeamChecklist；单字段 <2KB，D1 batch 写入简单
     checklist: text("checklist", { mode: "json" }).$type<TeamChecklist>(),
-    createdAt: integer("created_at", { mode: "timestamp_ms" }).$defaultFn(() => new Date()).notNull(),
-    updatedAt: integer("updated_at", { mode: "timestamp_ms" }).$defaultFn(() => new Date()).notNull(),
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).default(sql`(unixepoch() * 1000)`).notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" }).default(sql`(unixepoch() * 1000)`).notNull(),
     // #219 P2-3：API key 创建/加入时记录来源 key（nullable，session 用户无 key）
     actorApiKeyId: text("actor_api_key_id"),
   },
@@ -238,6 +236,15 @@ export const teams = sqliteTable(
     titleIdx: index("teams_title_idx").on(table.title),
     statusCreatedAtIdx: index("teams_status_created_at_idx").on(table.status, table.createdAt),
     statusStartTimeIdx: index("teams_status_start_time_idx").on(table.status, table.startTime),
+    statusEndTimeIdx: index("teams_status_end_time_idx").on(table.status, table.endTime),
+    actorApiKeyIdx: index("teams_actor_api_key_id_idx").on(table.actorApiKeyId),
+    statusCheck: check(
+      "teams_status_check",
+      sql`${table.status} in ('recruiting', 'full', 'formed', 'cancelled', 'completed')`,
+    ),
+    durationCheck: check("teams_duration_min_check", sql`${table.durationMin} between 0 and 1440`),
+    capacityCheck: check("teams_max_members_check", sql`${table.maxMembers} between 2 and 50`),
+    timeRangeCheck: check("teams_time_range_check", sql`${table.endTime} >= ${table.startTime}`),
   })
 );
 
@@ -261,6 +268,7 @@ export const teamMembers = sqliteTable(
     userIdx: index("team_members_user_idx").on(table.userId),
     teamStatusIdx: index("team_members_team_status_idx").on(table.teamId, table.status),
     uniqueTeamUser: uniqueIndex("team_members_team_user_idx").on(table.teamId, table.userId),
+    actorApiKeyIdx: index("team_members_actor_api_key_id_idx").on(table.actorApiKeyId),
   })
 );
 
@@ -277,7 +285,6 @@ export const passwordResets = sqliteTable(
     createdAt: integer("created_at", { mode: "timestamp_ms" }).$defaultFn(() => new Date()).notNull(),
   },
   (table) => ({
-    tokenIdx: index("password_resets_token_idx").on(table.token),
     userIdx: index("password_resets_user_idx").on(table.userId),
     emailIdx: index("password_resets_email_idx").on(table.email),
   })
@@ -299,6 +306,11 @@ export const userFavorites = sqliteTable(
     uniqueFavorite: uniqueIndex("user_favorites_unique_idx").on(table.userId, table.entityType, table.entityId),
     // 0009 已建的复合索引（补充声明，对齐 DB 现状，零 DB 变更）
     userCreatedIdx: index("user_favorites_user_created_idx").on(table.userId, table.createdAt),
+    entityTypeEntityCreatedIdx: index("user_favorites_entity_type_entity_id_created_at_idx").on(
+      table.entityType,
+      table.entityId,
+      table.createdAt,
+    ),
   })
 );
 
@@ -455,6 +467,10 @@ export const activityPosts = sqliteTable(
     authorIdx: index("activity_posts_author_idx").on(table.authorId),
     statusIdx: index("activity_posts_status_idx").on(table.status),
     createdAtIdx: index("activity_posts_created_at_idx").on(table.createdAt),
+    locationCreatedAtIdx: index("activity_posts_location_created_at_idx").on(
+      table.locationId,
+      table.createdAt,
+    ),
   })
 );
 
@@ -518,6 +534,7 @@ export const stories = sqliteTable(
     createdAtIdx: index("stories_created_at_idx").on(table.createdAt),
     // 0009 已建的复合索引（补充声明，对齐 DB 现状，零 DB 变更）
     statusCreatedAtIdx: index("stories_status_created_at_idx").on(table.status, table.createdAt),
+    actorApiKeyIdx: index("stories_actor_api_key_id_idx").on(table.actorApiKeyId),
   })
 );
 

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -273,6 +273,10 @@ export const teamMembers = sqliteTable(
 );
 
 // 密码重置令牌表
+/**
+ * @deprecated Better Auth 已统一使用 verifications 表处理密码重置。
+ * 保留该映射仅用于兼容现有生产表；删除条件见 notes/password-resets-deprecation.md。
+ */
 export const passwordResets = sqliteTable(
   "password_resets",
   {

--- a/api/src/lib/audit.test.ts
+++ b/api/src/lib/audit.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { hashApiKeyForLookup } from "./audit";
+
+describe("hashApiKeyForLookup", () => {
+  it("matches Better Auth's SHA-256 base64url format", async () => {
+    expect(await hashApiKeyForLookup("gm_live_test-key"))
+      .toBe("gkpIVHM93AsWO0GmFbOx919vRA5239rIL9asNmMmNeA");
+  });
+
+  it("produces distinct lookup values for different keys", async () => {
+    const [first, second] = await Promise.all([
+      hashApiKeyForLookup("gm_live_first"),
+      hashApiKeyForLookup("gm_live_second"),
+    ]);
+    expect(first).not.toBe(second);
+  });
+});

--- a/api/src/lib/audit.ts
+++ b/api/src/lib/audit.ts
@@ -9,7 +9,7 @@
  */
 
 import { Context } from "hono";
-import { eq, desc } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { createDb } from "../db";
 import { apiKeys } from "../db/schema";
 import { createAuth, type Env } from "./auth";
@@ -22,6 +22,16 @@ export interface AuditActor {
   actorType: "user" | "apiKey";
   /** 用户 ID（已认证请求必有） */
   userId: string | null;
+}
+
+/** 与 @better-auth/api-key 的 defaultKeyHasher 保持一致。 */
+export async function hashApiKeyForLookup(rawKey: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(rawKey),
+  );
+  const binary = Array.from(new Uint8Array(digest), (byte) => String.fromCharCode(byte)).join("");
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/u, "");
 }
 
 /**
@@ -56,15 +66,19 @@ export async function resolveAuditActor(
     const xApiKey = c.req.header("x-api-key");
 
     if (xApiKey) {
-      // 请求通过 apiKey 鉴权 → 查 apiKeys 表获取 id
-      // 用 referenceId(userId) + lastRequest 排序取最近使用的 key
+      // 请求通过 apiKey 鉴权 → 用原始 key 的 SHA-256 精确定位审计来源。
+      // 不能按 lastRequest 猜测：同一用户可有多个 key，并发请求会串错归属。
       try {
         const db = createDb(c.env.DB);
+        const hashedKey = await hashApiKeyForLookup(xApiKey);
         const [key] = await db
           .select({ id: apiKeys.id })
           .from(apiKeys)
-          .where(eq(apiKeys.referenceId, userId))
-          .orderBy(desc(apiKeys.lastRequest), desc(apiKeys.createdAt))
+          .where(and(
+            eq(apiKeys.referenceId, userId),
+            eq(apiKeys.key, hashedKey),
+            eq(apiKeys.enabled, true),
+          ))
           .limit(1);
 
         if (key?.id) {

--- a/api/src/lib/validation.ts
+++ b/api/src/lib/validation.ts
@@ -71,7 +71,9 @@ export const createActivityPostSchema = z.object({
  */
 export const createTagSchema = z.object({
   name: z.string().min(1, "标签名称不能为空").max(50, "标签名称不能超过50字"),
-  type: z.string().min(1, "标签类型不能为空").max(50, "标签类型不能超过50字"),
+  type: z.enum(["location", "activity", "story"], {
+    message: "标签类型必须是 location、activity 或 story",
+  }),
   icon: z.string().max(100, "图标不能超过100字").optional(),
 });
 
@@ -105,4 +107,3 @@ export const paginationSchema = z.object({
 export const idParamSchema = z.object({
   id: z.string().min(1, "ID不能为空"),
 });
-

--- a/api/src/routes/favorites.ts
+++ b/api/src/routes/favorites.ts
@@ -143,13 +143,13 @@ favorites.post("/", async (c) => {
 
     if (existing.length > 0) return c.json(APIErrors.conflict("已经收藏过了"), 409);
 
-    if (entityType === "location") {
-      const loc = await db
-        .select({ id: schema.locations.id })
-        .from(schema.locations)
-        .where(eq(schema.locations.id, entityId))
-        .limit(1);
-      if (!loc.length) return c.json(APIErrors.notFound("地点不存在"), 404);
+    const target = entityType === "location"
+      ? await db.select({ id: schema.locations.id }).from(schema.locations)
+          .where(eq(schema.locations.id, entityId)).limit(1)
+      : await db.select({ id: schema.stories.id }).from(schema.stories)
+          .where(eq(schema.stories.id, entityId)).limit(1);
+    if (!target.length) {
+      return c.json(APIErrors.notFound(entityType === "location" ? "地点不存在" : "故事不存在"), 404);
     }
 
     const id = generateId();

--- a/api/src/routes/locations/mutations.ts
+++ b/api/src/routes/locations/mutations.ts
@@ -30,11 +30,16 @@ mutations.post("/", async (c) => {
     const data = parsed.data;
     const id = generateId();
     const slug = data.slug || data.name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+    const city = await db.query.cities.findFirst({
+      where: eq(schema.cities.id, data.cityId),
+      columns: { name: true },
+    });
+    if (!city) return c.json(APIErrors.badRequest("城市不存在"), 400);
 
     await db.insert(schema.locations).values({
       id, name: data.name, slug, type: data.type || null, subtitle: data.subtitle || null,
       description: data.description, address: data.address || null,
-      cityId: data.cityId, cityName: data.cityName || null,
+      cityId: data.cityId, cityName: city.name,
       bestSeason: JSON.stringify(data.bestSeason || []),
       coverImage: data.coverImage,
       images: JSON.stringify(data.images || []),
@@ -76,6 +81,14 @@ mutations.put("/", async (c) => {
 
     const { id, ...updateData } = parsed.data;
 
+    if (updateData.cityId !== undefined) {
+      const city = await db.query.cities.findFirst({
+        where: eq(schema.cities.id, updateData.cityId),
+        columns: { id: true },
+      });
+      if (!city) return c.json(APIErrors.badRequest("城市不存在"), 400);
+    }
+
     const dataToUpdate: Record<string, unknown> = { updatedAt: new Date() };
     if (updateData.name !== undefined) dataToUpdate.name = updateData.name;
     if (updateData.slug !== undefined) dataToUpdate.slug = updateData.slug;
@@ -84,7 +97,6 @@ mutations.put("/", async (c) => {
     if (updateData.description !== undefined) dataToUpdate.description = updateData.description;
     if (updateData.address !== undefined) dataToUpdate.address = updateData.address || null;
     if (updateData.cityId !== undefined) dataToUpdate.cityId = updateData.cityId;
-    if (updateData.cityName !== undefined) dataToUpdate.cityName = updateData.cityName || null;
     if (updateData.bestSeason !== undefined) dataToUpdate.bestSeason = JSON.stringify(updateData.bestSeason);
     if (updateData.coverImage !== undefined) dataToUpdate.coverImage = updateData.coverImage;
     if (updateData.images !== undefined) dataToUpdate.images = JSON.stringify(updateData.images);
@@ -149,8 +161,7 @@ mutations.put("/:id/tags", async (c) => {
     const { tagIds } = await c.req.json<{ tagIds: string[] }>();
     const db = createDb(c.env.DB);
 
-    // 删除旧关联
-    await db
+    const deleteExistingTags = db
       .delete(schema.entityToTags)
       .where(
         and(
@@ -159,9 +170,8 @@ mutations.put("/:id/tags", async (c) => {
         )
       );
 
-    // 批量插入新关联
     if (tagIds && tagIds.length > 0) {
-      await db.insert(schema.entityToTags).values(
+      const insertNewTags = db.insert(schema.entityToTags).values(
         tagIds.map((tagId) => ({
           id: generateId(),
           entityId: id,
@@ -169,6 +179,9 @@ mutations.put("/:id/tags", async (c) => {
           tagId,
         }))
       );
+      await db.batch([deleteExistingTags, insertNewTags]);
+    } else {
+      await deleteExistingTags;
     }
 
     return c.json({ success: true });

--- a/api/src/routes/messages.ts
+++ b/api/src/routes/messages.ts
@@ -569,16 +569,6 @@ app.post("/:id", async (c) => {
       createdAt: now,
     });
 
-    // 更新对话最后消息
-    await db
-      .update(conversations)
-      .set({
-        lastMessageAt: now,
-        lastMessageContent: content.substring(0, 100),
-        updatedAt: now,
-      })
-      .where(eq(conversations.id, conversationId));
-
     return c.json({ success: true, data: { id: messageId } }, 201);
   } catch (error) {
     if (error instanceof z.ZodError) {

--- a/api/src/routes/stories.ts
+++ b/api/src/routes/stories.ts
@@ -345,11 +345,14 @@ stories.get("/:id", async (c) => {
 
     // Increment view count（draft 不计，避免作者编辑时自增）
     const currentViewCount = story.viewCount ?? 0;
+    let responseViewCount = currentViewCount;
     if (story.status === "published") {
-      await db
+      const [updatedView] = await db
         .update(schema.stories)
-        .set({ viewCount: currentViewCount + 1 })
-        .where(eq(schema.stories.id, id));
+        .set({ viewCount: sql`${schema.stories.viewCount} + 1` })
+        .where(eq(schema.stories.id, id))
+        .returning({ viewCount: schema.stories.viewCount });
+      responseViewCount = updatedView?.viewCount ?? currentViewCount;
     }
 
     // 检查当前用户是否已点赞（仅登录用户）
@@ -381,7 +384,7 @@ stories.get("/:id", async (c) => {
       success: true,
       data: {
         ...story,
-        viewCount: story.status === "published" ? currentViewCount + 1 : currentViewCount,
+        viewCount: responseViewCount,
         isLiked,
         tags: tagRows,
         author: author
@@ -663,8 +666,8 @@ stories.delete("/:id", async (c) => {
 /**
  * POST /stories/:id/like
  * 点赞/取消点赞故事（toggle）
- * 已点赞 → 取消点赞（likeCount -1）
- * 未点赞 → 点赞（likeCount +1）
+ * 已点赞 → 取消点赞；未点赞 → 点赞。
+ * likeCount 由数据库触发器依据点赞关系维护，避免并发请求导致计数漂移。
  */
 stories.post("/:id/like", async (c) => {
   try {
@@ -697,7 +700,6 @@ stories.post("/:id/like", async (c) => {
       columns: { userId: true },
     });
 
-    let liked: boolean;
     if (existingLike) {
       // 已点赞 → 取消点赞
       await db.delete(schema.userStoryLikes).where(
@@ -706,38 +708,29 @@ stories.post("/:id/like", async (c) => {
           eq(schema.userStoryLikes.storyId, id)
         )
       );
-      // 原子递减：SQL 层面条件判断，避免负数
-      await db.update(schema.stories)
-        .set({
-          likeCount: sql`MAX(0, ${schema.stories.likeCount} - 1)`,
-          updatedAt: new Date(),
-        })
-        .where(and(
-          eq(schema.stories.id, id),
-          sql`${schema.stories.likeCount} > 0`
-        ));
-      liked = false;
     } else {
       // 未点赞 → 点赞：先插入（PRIMARY KEY 约束 + onConflictDoNothing 防重复）
       await db.insert(schema.userStoryLikes).values({
         userId,
         storyId: id,
       }).onConflictDoNothing();
-      // 原子递增
-      await db.update(schema.stories)
-        .set({
-          likeCount: sql`${schema.stories.likeCount} + 1`,
-          updatedAt: new Date(),
-        })
-        .where(eq(schema.stories.id, id));
-      liked = true;
     }
 
-    // 返回最新 likeCount，以便前端修正乐观计算的偏差
-    const updated = await db.query.stories.findFirst({
-      where: eq(schema.stories.id, id),
-      columns: { likeCount: true },
-    });
+    // 并发 toggle 后以数据库最终状态为准，修正前端乐观状态。
+    const [updated, finalLike] = await Promise.all([
+      db.query.stories.findFirst({
+        where: eq(schema.stories.id, id),
+        columns: { likeCount: true },
+      }),
+      db.query.userStoryLikes.findFirst({
+        where: and(
+          eq(schema.userStoryLikes.userId, userId),
+          eq(schema.userStoryLikes.storyId, id)
+        ),
+        columns: { userId: true },
+      }),
+    ]);
+    const liked = Boolean(finalLike);
 
     return c.json({
       success: true,

--- a/api/src/routes/tags.ts
+++ b/api/src/routes/tags.ts
@@ -28,7 +28,7 @@ async function checkAdmin(c: { env: Env; req: { raw: Request } }) {
 
 /**
  * GET /tags
- * 获取标签列表，支持 ?type=location|route|activity 筛选
+ * 获取标签列表，支持 ?type=location|activity|story 筛选
  */
 tags.get("/", async (c) => {
   try {

--- a/api/src/routes/teams/membership.ts
+++ b/api/src/routes/teams/membership.ts
@@ -115,9 +115,6 @@ membership.post("/members/:userId/approve", requireTeamLeader(), async (c) => {
     if (!teamId) return c.json(APIErrors.badRequest("缺少队伍ID"), 400);
     if (!targetUserId) return c.json(APIErrors.badRequest("缺少用户ID"), 400);
 
-    // Get team from context (set by requireTeamLeader middleware)
-    const team = c.get("team") as typeof schema.teams.$inferSelect;
-
     const members = await db.query.teamMembers.findMany({
       where: and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.userId, targetUserId), eq(schema.teamMembers.status, "pending")),
       limit: 1,
@@ -125,26 +122,19 @@ membership.post("/members/:userId/approve", requireTeamLeader(), async (c) => {
     const membership = members[0];
     if (!membership) return c.json(APIErrors.notFound("未找到该成员的申请"), 404);
 
-    const [{ approvedCount }] = await db
-      .select({ approvedCount: sql<number>`count(*)` })
-      .from(schema.teamMembers)
-      .where(and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.status, "approved")));
-
-    if (approvedCount >= team.maxMembers) return c.json(APIErrors.badRequest("队伍已满，无法批准新成员"), 400);
-
     const now = new Date();
-    const newCount = approvedCount + 1;
-    const newStatus = newCount >= team.maxMembers ? "full" : "recruiting";
-
     await db.update(schema.teamMembers)
       .set({ status: "approved", joinedAt: now, statusUpdatedAt: now })
-      .where(eq(schema.teamMembers.id, membership.id));
-    await db.update(schema.teams)
-      .set({ status: newStatus, updatedAt: now })
-      .where(eq(schema.teams.id, teamId));
+      .where(and(
+        eq(schema.teamMembers.id, membership.id),
+        eq(schema.teamMembers.status, "pending")
+      ));
 
     return c.json({ success: true, message: "已通过申请" });
   } catch (error) {
+    if ((error as Error).message.includes("team capacity exceeded")) {
+      return c.json(APIErrors.badRequest("队伍已满，无法批准新成员"), 400);
+    }
     logger.error("Approve member error:", error);
     return c.json(APIErrors.internalError("批准申请失败"), 500);
   }
@@ -170,9 +160,6 @@ membership.post("/members/:userId/reject", requireTeamLeader(), async (c) => {
     const body = await c.req.json<{ reason?: string }>().catch(() => ({} as { reason?: string }));
     const { reason } = body;
 
-    // Get team from context (set by requireTeamLeader middleware)
-    const team = c.get("team") as typeof schema.teams.$inferSelect;
-
     const members = await db.query.teamMembers.findMany({
       where: and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.userId, targetUserId), eq(schema.teamMembers.status, "pending")),
       limit: 1,
@@ -186,13 +173,6 @@ membership.post("/members/:userId/reject", requireTeamLeader(), async (c) => {
     await db.update(schema.teamMembers)
       .set({ status: "rejected", statusUpdatedAt: now, extra })
       .where(eq(schema.teamMembers.id, membership.id));
-
-    // 检查并更新队伍状态：如果已满则恢复为招募中
-    if (team.status === "full") {
-      await db.update(schema.teams)
-        .set({ status: "recruiting", updatedAt: now })
-        .where(eq(schema.teams.id, teamId));
-    }
 
     return c.json({ success: true, message: "已拒绝申请" });
   } catch (error) {
@@ -231,15 +211,6 @@ membership.post("/members/:userId/remove", async (c) => {
     if (!membership) return c.json(APIErrors.notFound("该用户不是队伍成员"), 404);
 
     await db.delete(schema.teamMembers).where(eq(schema.teamMembers.id, membership.id));
-
-    const [{ remainingCount }] = await db
-      .select({ remainingCount: sql<number>`count(*)` })
-      .from(schema.teamMembers)
-      .where(and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.status, "approved")));
-
-    await db.update(schema.teams)
-      .set({ status: remainingCount < team.maxMembers ? "recruiting" : team.status, updatedAt: new Date() })
-      .where(eq(schema.teams.id, teamId));
 
     return c.json({ success: true, message: "已移除成员" });
   } catch (error) {

--- a/api/src/routes/teams/mutations.ts
+++ b/api/src/routes/teams/mutations.ts
@@ -80,17 +80,18 @@ mutations.post("/", async (c) => {
     const now = new Date();
     const teamIcon = getRandomTeamIcon();
 
-    await db.insert(schema.teams).values({
+    const createTeam = db.insert(schema.teams).values({
       id: teamId, locationId, leaderId: userId, title,
       description: description || null, startTime, endTime,
       durationMin: durationMinutes, maxMembers,
       requirements: requirements ? JSON.stringify(requirements) : null,
       icon: teamIcon, status: "recruiting", createdAt: now, updatedAt: now,
     });
-    await db.insert(schema.teamMembers).values({
+    const createLeaderMembership = db.insert(schema.teamMembers).values({
       id: memberId, teamId, userId, status: "approved",
       joinedAt: now, createdAt: now,
     });
+    await db.batch([createTeam, createLeaderMembership]);
 
     // 清除相关缓存（Cache API 不支持通配删除，需显式列出常用键）
     // TODO: 改用 KV 缓存版本号或标签缓存，避免遗漏
@@ -177,6 +178,9 @@ mutations.put("/:id", async (c) => {
 
     return c.json({ success: true, message: "队伍信息已更新" });
   } catch (error) {
+    if ((error as Error).message.includes("max_members cannot be below current members")) {
+      return c.json(APIErrors.badRequest("队伍人数上限不能低于当前成员数"), 400);
+    }
     logger.error("Update team error:", error);
     return c.json(APIErrors.internalError("更新队伍失败"), 500);
   }

--- a/api/src/routes/teams/status.ts
+++ b/api/src/routes/teams/status.ts
@@ -1,7 +1,7 @@
 import { APIErrors } from "../../lib/api-errors";
 import { logger } from "../../lib/logger";
 import { Hono } from "hono";
-import { eq, and, sql } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { createAuth } from "../../lib/auth";
 import { createDb } from "../../db";
 import * as schema from "../../db/schema";
@@ -40,15 +40,6 @@ status.post("/leave", async (c) => {
     if (team.status === "formed") return c.json(APIErrors.badRequest("队伍已组建，请通过退出申请流程离开"), 400);
 
     await db.delete(schema.teamMembers).where(eq(schema.teamMembers.id, membership.id));
-
-    const [{ remainingCount }] = await db
-      .select({ remainingCount: sql<number>`count(*)` })
-      .from(schema.teamMembers)
-      .where(and(eq(schema.teamMembers.teamId, teamId as string), eq(schema.teamMembers.status, "approved")));
-
-    await db.update(schema.teams)
-      .set({ status: remainingCount < team.maxMembers ? "recruiting" : team.status, updatedAt: new Date() })
-      .where(eq(schema.teams.id, teamId as string));
 
     return c.json({ success: true, message: "已成功退出队伍" });
   } catch (error) {
@@ -108,9 +99,6 @@ status.post("/members/:userId/approve-leave", requireTeamLeader(), async (c) => 
     if (!teamId) return c.json(APIErrors.badRequest("缺少队伍ID"), 400);
     if (!targetUserId) return c.json(APIErrors.badRequest("缺少用户ID"), 400);
 
-    // Get team from context (set by requireTeamLeader middleware)
-    const team = c.get("team") as typeof schema.teams.$inferSelect;
-
     const members = await db.query.teamMembers.findMany({
       where: and(eq(schema.teamMembers.teamId, teamId as string), eq(schema.teamMembers.userId, targetUserId), eq(schema.teamMembers.status, "leave_pending")),
       limit: 1,
@@ -119,15 +107,6 @@ status.post("/members/:userId/approve-leave", requireTeamLeader(), async (c) => 
     if (!membership) return c.json(APIErrors.notFound("未找到该成员的退出申请"), 404);
 
     await db.delete(schema.teamMembers).where(eq(schema.teamMembers.id, membership.id));
-
-    const [{ remainingCount }] = await db
-      .select({ remainingCount: sql<number>`count(*)` })
-      .from(schema.teamMembers)
-      .where(and(eq(schema.teamMembers.teamId, teamId as string), eq(schema.teamMembers.status, "approved")));
-
-    await db.update(schema.teams)
-      .set({ status: remainingCount < team.maxMembers ? "recruiting" : team.status, updatedAt: new Date() })
-      .where(eq(schema.teams.id, teamId as string));
 
     return c.json({ success: true, message: "已批准退出申请" });
   } catch (error) {

--- a/api/src/routes/users/mutations.ts
+++ b/api/src/routes/users/mutations.ts
@@ -30,6 +30,16 @@ mutations.patch("/update", async (c) => {
 
     if (!userId) return c.json(APIErrors.badRequest("User ID is required"), 400);
 
+    const normalizedCity = city === undefined ? undefined : city || null;
+    if (normalizedCity) {
+      const cityExists = await db
+        .select({ id: schema.cities.id })
+        .from(schema.cities)
+        .where(eq(schema.cities.id, normalizedCity))
+        .limit(1);
+      if (!cityExists.length) return c.json(APIErrors.badRequest("城市不存在"), 400);
+    }
+
     const updateData: Partial<typeof schema.users.$inferInsert> = {};
     if (name !== undefined) updateData.name = name;
     if (nickname !== undefined) updateData.nickname = nickname;
@@ -43,7 +53,7 @@ mutations.patch("/update", async (c) => {
     }
     // #181: city = cityId（CitySelect 产出），非城市名；格式一致性见 schema.ts users.city 注释
     // （防休眠 2.0：绕过 CitySelect 的写入也必须存 cityId，否则 neighbor query u.city=userCity 相等失效）
-    if (city !== undefined) updateData.city = city || null; // CR N2：空串归一 NULL，避免 city="" 落库
+    if (normalizedCity !== undefined) updateData.city = normalizedCity; // CR N2：空串归一 NULL，避免 city="" 落库
     if (extra !== undefined) {
       if (!validateUserExtra(extra)) return c.json(APIErrors.badRequest("Invalid extra field format"), 400);
       updateData.extra = JSON.stringify(extra);

--- a/api/src/routes/v1/write/teams.ts
+++ b/api/src/routes/v1/write/teams.ts
@@ -85,7 +85,7 @@ writeTeams.post("/", idempotencyMiddleware, async (c) => {
     const now = new Date();
     const teamIcon = "⛰️";
 
-    await db.insert(schema.teams).values({
+    const createTeam = db.insert(schema.teams).values({
       id: teamId,
       locationId,
       leaderId: actorId,
@@ -103,7 +103,7 @@ writeTeams.post("/", idempotencyMiddleware, async (c) => {
       actorApiKeyId: actorApiKeyId ?? null,
     });
 
-    await db.insert(schema.teamMembers).values({
+    const createLeaderMembership = db.insert(schema.teamMembers).values({
       id: memberId,
       teamId,
       userId: actorId,
@@ -112,6 +112,7 @@ writeTeams.post("/", idempotencyMiddleware, async (c) => {
       createdAt: now,
       actorApiKeyId: actorApiKeyId ?? null,
     });
+    await db.batch([createTeam, createLeaderMembership]);
 
     return c.json({
       success: true,

--- a/docs/backend-api.md
+++ b/docs/backend-api.md
@@ -1,6 +1,6 @@
 # GoMate 后端 API 文档
 
-> 最后更新：2026-08-01
+> 最后更新：2026-08-16
 > 框架：Hono 4 + Cloudflare Workers + Drizzle ORM
 
 ## 基础信息
@@ -190,7 +190,7 @@ Better Auth 代理，处理注册、登录、登出、会话刷新等所有认�
 
 - **认证：** 是（仅队长）
 - **响应：** `{ "success": true, "message": "已通过申请" }`
-- **说明：** 人满时队伍状态自动置为 `full`（反之保持 `recruiting`）；已满拒绝批准返回 400
+- **说明：** 人满时队伍状态自动置为 `full`（反之保持 `recruiting`）；容量由数据库原子校验，并发批准也不会超过 `maxMembers`，已满返回 400
 
 ### POST `/teams/:id/members/:userId/reject`
 
@@ -357,7 +357,7 @@ Better Auth 代理，处理注册、登录、登出、会话刷新等所有认�
 创建地点
 
 - **认证：** 是（仅管理员）
-- **Body：** `{ "name", "slug", "subtitle", "description", "address", "cityId", "cityName", "type", "coverImage", "images", "bestSeason", "coordinates", "extra", "parkingAvailable", "parkingInfo", "gearEssential", "gearOptional" }`
+- **Body：** `{ "name", "slug", "subtitle", "description", "address", "cityId", "cityName", "type", "coverImage", "images", "bestSeason", "coordinates", "extra", "parkingAvailable", "parkingInfo", "gearEssential", "gearOptional" }`；`cityId` 必须存在，兼容接收的 `cityName` 不作为权威值，响应/存储名称始终跟随 `cities.name`
 - **响应：** `{ "success": true, "location": { "id", "slug" } }`
 
 ### PUT `/locations`
@@ -365,7 +365,7 @@ Better Auth 代理，处理注册、登录、登出、会话刷新等所有认�
 更新地点
 
 - **认证：** 是（仅管理员）
-- **Body：** 与创建相同，需包含 `id` 字段（`type` 可选，nullable）
+- **Body：** 与创建相同，需包含 `id` 字段（`type` 可选，nullable）；修改 `cityId` 时自动同步规范城市名
 
 ### DELETE `/locations/:id`
 
@@ -427,7 +427,7 @@ Better Auth 代理，处理注册、登录、登出、会话刷新等所有认�
 更新用户信息
 
 - **认证：** 是（普通用户只能改自己；`userId` 必填，支持 id 或邮箱；管理员可改他人）
-- **Body：** `{ "userId", "name", "nickname", "bio", "level", "image", "wechat", "gender", "birthday", "extra", "city" }`（`city` 为 cityId）
+- **Body：** `{ "userId", "name", "nickname", "bio", "level", "image", "wechat", "gender", "birthday", "extra", "city" }`（`city` 为已存在的 cityId；未知 cityId 返回 400；`null`/空串清空）
 - **响应：** `{ "success": true, "user": {...} }`
 
 ### GET `/users/pending-approvals`
@@ -567,6 +567,7 @@ R2 文件代理（本地开发专用，顶层挂载）
 - **认证：** 否
 - **响应：** `data` 含故事字段 + `author` + `location` + `isLiked` + `tags: [{ id, name }]`（标签关联，编辑表单回显依赖此字段；无标签时为 `[]`）
 - **可见性（task #156）：** `published` 公开可读；`draft` 仅作者本人或管理员可读（其余 404，不泄露存在性），且 draft 访问不计浏览数；`hidden` 一律 404
+- **计数：** published 浏览数使用数据库原子自增，并发请求不会覆盖彼此
 
 ### PUT `/stories/:id`
 
@@ -586,7 +587,7 @@ R2 文件代理（本地开发专用，顶层挂载）
 点赞/取消点赞故事（toggle）
 
 - **认证：** 是（登录用户）
-- **行为：** 已点赞 → 取消点赞；未点赞 → 点赞
+- **行为：** 已点赞 → 取消点赞；未点赞 → 点赞；`likeCount` 由唯一点赞关系在数据库内同步维护
 - **响应：** `{ "success": true, "liked": boolean, "likeCount": number, "message": string }`
 - **错误：** 401 未登录 / 404 故事不存在 / 500 服务器错误
 
@@ -615,6 +616,7 @@ R2 文件代理（本地开发专用，顶层挂载）
 
 - **认证：** 是
 - **Body：** `{ "entityType": "location", "entityId": "loc-xxx" }`
+- **错误：** 目标地点/故事不存在时返回 404，不创建悬空收藏
 
 ### DELETE `/favorites?entityType={type}&entityId={id}`
 
@@ -697,7 +699,7 @@ R2 文件代理（本地开发专用，顶层挂载）
 | `POST /messages`             | 是   | 创建会话，Body `{ "teamId", "userId"? }`（队长可指定目标成员；成员只能找队长） |
 | `GET /messages/unread-count` | 是   | 未读数                                                                         |
 | `GET /messages/:id`          | 是   | 会话消息（`cursor` / `since` / `limit` 分页）                                  |
-| `POST /messages/:id`         | 是   | 发送消息，Body `{ "content" }`（≤1000 字）                                     |
+| `POST /messages/:id`         | 是   | 发送消息，Body `{ "content" }`（≤1000 字）；会话摘要与消息同次数据库写入维护   |
 
 ---
 

--- a/docs/backend-api.md
+++ b/docs/backend-api.md
@@ -652,7 +652,7 @@ R2 文件代理（本地开发专用，顶层挂载）
 获取标签列表
 
 - **认证：** 否
-- **Query：** `type`（location\|activity）、`page`（默认 1）、`pageSize`（默认 50，最大 100）
+- **Query：** `type`（location\|activity\|story）、`page`（默认 1）、`pageSize`（默认 50，最大 100）
 - **响应：** `{ "success": true, "tags": [{ "id", "name", "type" }] }`
 
 ### POST `/tags`
@@ -660,7 +660,7 @@ R2 文件代理（本地开发专用，顶层挂载）
 创建标签（同名标签返回已有标签）
 
 - **认证：** 是（仅管理员）
-- **Body：** `{ "name", "type", "description" }`
+- **Body：** `{ "name", "type", "icon" }`；`type` 仅允许 `location`、`activity`、`story`，非法值返回 400
 - **响应：** `{ "success": true, "tagId": "tag-xxx", "existing": false }`
 
 ---

--- a/docs/prod-change-policy.md
+++ b/docs/prod-change-policy.md
@@ -12,7 +12,7 @@
 - **禁止** `wrangler d1 execute` 手工执行 DDL——这会绕过 `d1_migrations` 账本和 drizzle `_journal.json`，造成双账本漂移（#451 事故的根因）
 - 手工 DML（数据修复、清测试数据）允许，但按下方「prod 变更声明制」先报备
 
-### 2. 迁移必须幂等
+### 2. 迁移必须可安全重放
 
 所有新迁移默认使用幂等写法：
 
@@ -23,7 +23,9 @@ DROP TABLE IF EXISTS ...
 INSERT OR IGNORE INTO ...
 ```
 
-幂等迁移让流水线/手工重放永远安全，环境间账本漂移时可自愈。**自 0018 起强制执行**，历史迁移（0000–0017）不回填。
+SQLite 的部分 DDL（例如 `ALTER TABLE ... ADD COLUMN`）没有 `IF NOT EXISTS`。遇到这类语句时，必须改用可重放的建临时表/复制/重命名方案，或在 migration 说明中明确账本前置条件并提供结构预检，不能把 D1 migration 账本本身误当作 SQL 幂等性。
+
+`0018_add_actor_api_key_id.sql` 是已应用且不可改写的 ledger-only 例外；从 0019 起不再新增无保护的 `ALTER TABLE ... ADD COLUMN`。环境追平仍通过 pipeline 和 `d1_migrations` 账本完成，不手工绕过账本重复执行 migration 文件。
 
 ### 3. 双账本同步（CI 门禁）
 

--- a/notes/password-resets-deprecation.md
+++ b/notes/password-resets-deprecation.md
@@ -1,0 +1,21 @@
+# password_resets 退役记录
+
+## 结论
+
+`password_resets` 是旧认证实现遗留表。当前密码重置由 Better Auth 的 `verifications` 表承载；仓库业务代码没有对 `password_resets` 的读写，只有 Drizzle 映射和测试建表仍保留。
+
+本轮采用 expand/contract 的退役方式：先把表标记为 deprecated，不直接在完整性迁移中删除。原因是仓库静态检索只能证明当前代码未使用，不能证明生产库没有历史数据，也不能排除尚未升级的调用方。
+
+## Contract 阶段准入条件
+
+删除 `password_resets` 前必须同时满足：
+
+1. 生产 D1 执行只读核验，确认表中没有未过期且未使用的记录；
+2. 至少经过一个正常发布观察窗口，认证日志中没有访问该表的错误；
+3. 获得生产变更显式批准；
+4. 用独立 migration `DROP TABLE IF EXISTS password_resets`，并同步删除 `schema.ts` 映射和测试建表；
+5. 验证忘记密码、重置密码以及迁移全量重放。
+
+## 回滚
+
+Contract migration 合并前无需回滚：旧表仍保持原状。删除后如发现兼容调用，先通过新 migration 恢复表结构，再回滚调用方；不要修改已应用 migration。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       "@types/better-sqlite3":
         specifier: ^7.6.0
         version: 7.6.13
+      "@types/node":
+        specifier: ^25.0.0
+        version: 25.9.1
       "@types/qrcode":
         specifier: ^1.5.6
         version: 1.5.6


### PR DESCRIPTION
## Summary

- add migration `0019_database_integrity.sql` to restore `teams` foreign keys, enforce domain and polymorphic integrity, remove redundant indexes, and add query indexes
- move derived story-like, conversation-summary, city-name, and team-capacity state into database triggers; use D1 atomic batches for multi-write creation/update paths
- make API-key audit attribution exact, validate foreign keys at API boundaries, and align tag validation with the database contract
- add migration ledger/schema drift gates, D1 foreign-key semantics regression tests, integration coverage, API documentation, and password-reset deprecation lifecycle notes

## Root cause

Several integrity rules existed only in application code, historical table rebuilding dropped `teams` foreign keys, and concurrent read-modify-write paths could drift derived counters/status. SQLite tests also allowed `PRAGMA foreign_keys=OFF`, while D1 keeps foreign keys enabled inside migrations.

## Production impact

A read-only production preflight on 2026-08-16 found:

- 18 teams, 20 team members, 2 conversations, 4 messages, 0 activity posts
- 0 invalid team references/domain rows, invalid user cities, invalid member statuses, or over-capacity teams
- 84 orphaned polymorphic tag links and 4 orphaned favorites; migration 0019 removes only these targetless relation rows

The D1-safe rebuild backs up and restores all child rows before replacing `teams`. The migration is safe to replay and was verified with foreign keys permanently enabled.

## Validation

- `pnpm --filter @gomate/api lint`
- `pnpm --filter @gomate/api type-check`
- `pnpm --filter @gomate/api build`
- `pnpm --filter @gomate/api test` — 23 files, 284 tests passed
- `pnpm --filter @gomate/api check:migrations` — 28 SQL files / 28 journal entries, 20 live tables aligned
- isolated Wrangler 4.100.0 local D1 replay — team members, conversations, messages, and activity posts preserved; `foreign_key_check` = 0

## Rollout and rollback

Merging triggers the existing `api-deploy.yml` pipeline, which applies migration 0019 before deploying the Worker. Do not edit the migration after it is applied. Application rollback uses the verified prior Worker lineage; schema rollback requires a forward corrective migration. If deleted orphan relations must be recovered, restore D1 to a pre-migration point with Time Travel.

## Security note

`pnpm audit --audit-level high` reports 74 pre-existing dependency findings (2 critical, 32 high); this PR does not introduce the reported vulnerable chains. Dependency remediation should be handled separately to avoid mixing a broad upgrade with the integrity migration.