### PR TITLE
ci: gate V2 binding provisioning

### DIFF
--- a/.github/workflows/provision-v2-bindings.yml
+++ b/.github/workflows/provision-v2-bindings.yml
@@ -1,0 +1,218 @@
+name: Provision unified Worker V2 bindings
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: Type PROVISION_BINDINGS to create the reviewed D1 and KV resources
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: provision-unified-worker-v2-bindings
+  cancel-in-progress: false
+
+jobs:
+  provision:
+    name: Provision reviewed D1 and KV bindings
+    if: inputs.confirm == 'PROVISION_BINDINGS' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    env:
+      CLOUDFLARE_ENV: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.0.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Validate protected environment contract
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          PREVIEW_APP_URL: ${{ secrets.PREVIEW_APP_URL }}
+        run: |
+          node --input-type=module -e '
+            const required = [
+              "CLOUDFLARE_API_TOKEN",
+              "CLOUDFLARE_ACCOUNT_ID",
+              "CLOUDFLARE_ZONE_ID",
+              "BETTER_AUTH_SECRET",
+              "RESEND_API_KEY",
+              "PREVIEW_APP_URL",
+            ];
+            for (const name of required) {
+              if (!process.env[name]?.trim()) {
+                console.error(`Missing protected environment secret: ${name}`);
+                process.exit(1);
+              }
+            }
+            if (
+              process.env.CLOUDFLARE_ACCOUNT_ID !==
+              "e3afbb613458022947cd9dc9f5bd6334"
+            ) {
+              console.error("CLOUDFLARE_ACCOUNT_ID does not match the reviewed account");
+              process.exit(1);
+            }
+            if (
+              process.env.CLOUDFLARE_ZONE_ID !==
+              "0b714cd4257332034b3c4c0c099feb9e"
+            ) {
+              console.error("CLOUDFLARE_ZONE_ID does not match gomate.live");
+              process.exit(1);
+            }
+            if (
+              process.env.PREVIEW_APP_URL !==
+              "https://gomate-production-preview.wujiahong2013.workers.dev"
+            ) {
+              console.error("PREVIEW_APP_URL does not match the reviewed workers.dev origin");
+              process.exit(1);
+            }
+            if (process.env.BETTER_AUTH_SECRET.length < 32) {
+              console.error("BETTER_AUTH_SECRET must contain at least 32 characters");
+              process.exit(1);
+            }
+          '
+
+      - name: Confirm both resource names are unused
+        id: preflight
+        working-directory: frontend
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          pnpm exec wrangler d1 list --json --env production > "$RUNNER_TEMP/d1-before.json"
+          node --input-type=module -e '
+            const { readFileSync } = await import("node:fs");
+            const databases = JSON.parse(readFileSync(process.argv[1], "utf8"));
+            if (databases.some((database) => database.name === "gomate-db-v2")) {
+              console.error("D1 gomate-db-v2 already exists; refusing to create another resource");
+              process.exit(1);
+            }
+          ' "$RUNNER_TEMP/d1-before.json"
+
+          pnpm exec wrangler kv namespace list --env production > "$RUNNER_TEMP/kv-before.json"
+          node --input-type=module -e '
+            const { readFileSync } = await import("node:fs");
+            const namespaces = JSON.parse(readFileSync(process.argv[1], "utf8"));
+            if (namespaces.some((namespace) => namespace.title === "gomate-cache-v2")) {
+              console.error("KV gomate-cache-v2 already exists; refusing to create another resource");
+              process.exit(1);
+            }
+          ' "$RUNNER_TEMP/kv-before.json"
+
+      - name: Create reviewed D1 database
+        id: create_d1
+        working-directory: frontend
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm exec wrangler d1 create gomate-db-v2 --location apac --env production
+
+      - name: Create reviewed KV namespace
+        id: create_kv
+        working-directory: frontend
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm exec wrangler kv namespace create gomate-cache-v2
+
+      - name: Resolve and validate binding IDs
+        id: bindings
+        if: always() && steps.preflight.outcome == 'success'
+        working-directory: frontend
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          D1_CREATE_OUTCOME: ${{ steps.create_d1.outcome }}
+          KV_CREATE_OUTCOME: ${{ steps.create_kv.outcome }}
+        run: |
+          pnpm exec wrangler d1 list --json --env production > "$RUNNER_TEMP/d1-after.json"
+          pnpm exec wrangler kv namespace list --env production > "$RUNNER_TEMP/kv-after.json"
+          node --input-type=module -e '
+            const { appendFileSync, readFileSync, writeFileSync } =
+              await import("node:fs");
+            const databases = JSON.parse(readFileSync(process.argv[1], "utf8"));
+            const namespaces = JSON.parse(readFileSync(process.argv[2], "utf8"));
+            const d1 = databases.filter((database) => database.name === "gomate-db-v2");
+            const kv = namespaces.filter((namespace) => namespace.title === "gomate-cache-v2");
+            const d1IdPattern =
+              /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
+            const kvIdPattern = /^[0-9a-f]{32}$/iu;
+            if (d1.length > 1 || (d1.length === 1 && !d1IdPattern.test(d1[0].uuid ?? ""))) {
+              throw new Error("Provisioned D1 inventory is invalid or ambiguous");
+            }
+            if (kv.length > 1 || (kv.length === 1 && !kvIdPattern.test(kv[0].id ?? ""))) {
+              throw new Error("Provisioned KV inventory is invalid or ambiguous");
+            }
+            const D1_DATABASE_ID = d1[0]?.uuid ?? "";
+            const KV_NAMESPACE_ID = kv[0]?.id ?? "";
+            const bothCreatesSucceeded =
+              process.env.D1_CREATE_OUTCOME === "success" &&
+              process.env.KV_CREATE_OUTCOME === "success";
+            if (bothCreatesSucceeded && (!D1_DATABASE_ID || !KV_NAMESPACE_ID)) {
+              throw new Error("Successful create steps did not resolve both binding IDs");
+            }
+            const PROVISION_STATUS = bothCreatesSucceeded
+              ? "complete"
+              : D1_DATABASE_ID || KV_NAMESPACE_ID
+                ? "partial"
+                : "failed";
+            writeFileSync(
+              process.argv[3],
+              `${JSON.stringify(
+                {
+                  status: PROVISION_STATUS,
+                  stepOutcomes: {
+                    d1: process.env.D1_CREATE_OUTCOME,
+                    kv: process.env.KV_CREATE_OUTCOME,
+                  },
+                  d1: D1_DATABASE_ID
+                    ? { id: D1_DATABASE_ID, location: "apac", name: "gomate-db-v2" }
+                    : null,
+                  kv: KV_NAMESPACE_ID
+                    ? { id: KV_NAMESPACE_ID, name: "gomate-cache-v2" }
+                    : null,
+                },
+                null,
+                2,
+              )}\n`,
+              { mode: 0o600 },
+            );
+            appendFileSync(
+              process.env.GITHUB_OUTPUT,
+              `D1_DATABASE_ID=${D1_DATABASE_ID}\nKV_NAMESPACE_ID=${KV_NAMESPACE_ID}\nPROVISION_STATUS=${PROVISION_STATUS}\n`,
+            );
+          ' "$RUNNER_TEMP/d1-after.json" "$RUNNER_TEMP/kv-after.json" "$RUNNER_TEMP/binding-ids.json"
+
+      - name: Record reviewed resource IDs
+        if: always() && steps.bindings.outcome == 'success'
+        run: |
+          {
+            echo "### Unified Worker V2 binding provisioning: ${{ steps.bindings.outputs.PROVISION_STATUS }}"
+            echo "- D1 \`gomate-db-v2\`: \`${{ steps.bindings.outputs.D1_DATABASE_ID }}\` (APAC location hint)"
+            echo "- KV \`gomate-cache-v2\`: \`${{ steps.bindings.outputs.KV_NAMESPACE_ID }}\`"
+            echo "- No migration, Worker deploy, secret mutation, R2 mutation, custom domain, or route change was performed."
+            echo "- Do not delete a partially-created resource automatically; deletion requires a new explicit approval."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload binding ID evidence
+        if: always() && steps.bindings.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: gomate-v2-binding-ids
+          path: ${{ runner.temp }}/binding-ids.json
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/prod-change-policy.md
+++ b/docs/prod-change-policy.md
@@ -22,19 +22,29 @@ route 切换，都必须：
 3. 通过 GitHub `production` protected environment；
 4. Astro/Vite 构建通过 job 级 `CLOUDFLARE_ENV=production` 固定环境，构建后由
    Wrangler 自动读取 `dist/server/wrangler.json`；仅 D1、类型生成等直接读取源
-   Wrangler 配置的命令显式使用 `--env production`，禁止依赖默认环境；
+   Wrangler 配置的命令显式使用 `--env production`，禁止依赖默认环境。阶段 A 的 KV
+   namespace 创建是唯一例外：工作流仍固定 `CLOUDFLARE_ENV=production`，但不得传
+   `--env production`，否则 Wrangler 会把环境前缀加入经审查的精确 namespace 名称；
 5. 完成后记录资源 ID、Worker version 与验证证据。
 
 ## 3. 两阶段发布
 
 ### 阶段 A：绑定 PR
 
-1. 创建新的 D1 `gomate-db-v2` 与 KV namespace；R2 复用是否可行须单独确认。
-2. 使用 Wrangler `--update-config` 写入资源 ID，或只手工修改
+1. 先创建 GitHub `production` protected environment：deployment branch policy 仅允许
+   `main`，至少配置一名 required reviewer，并把 Cloudflare token/account/zone、Better Auth
+   secret、Resend key 与精确 preview workers.dev origin 六项全部保存为 environment secrets；
+   不得继续依赖 repository secrets 作为生产发布凭据。
+2. 只能从 `main` 手动运行 `Provision unified Worker V2 bindings`，输入
+   `PROVISION_BINDINGS`，在 `production` environment 审批后创建 D1 `gomate-db-v2`
+   （APAC location hint）与 KV `gomate-cache-v2`。工作流必须先确认两个精确名称均不存在，
+   且不得迁移 D1、部署 Worker、修改 secret/R2/route/domain；若只成功创建一个资源，保留它并
+   停止，禁止自动删除，后续清理仍需另一次显式批准。
+3. R2 复用 `gomate`：阶段 A 只记录账号、APAC location 与公开域名的只读证据，不写入或
+   删除对象。
+4. 使用 Wrangler `--update-config` 写入资源 ID，或只手工修改
    `frontend/wrangler.jsonc` 中的 `REPLACE_IN_BINDINGS_PR`。
-3. 以单独 PR 审查精确 ID；该 PR 不加入生产 route。
-4. 配置 GitHub protected environment secrets：Cloudflare token/account/zone、
-   Better Auth secret、Resend key 与精确 preview workers.dev origin。
+5. 以单独 PR 审查精确 ID；该 PR 不加入生产 route，也不执行 migration/deploy。
 
 占位符存在时，`.github/workflows/deploy.yml` 必须 fail closed。
 

--- a/scripts/deployment-guards.test.mjs
+++ b/scripts/deployment-guards.test.mjs
@@ -739,3 +739,123 @@ function spawnCleanup(runnerTemp, secretsFile) {
     env: { ...process.env, RUNNER_TEMP: runnerTemp, SECRETS_FILE: secretsFile },
   });
 }
+
+test("protected binding provisioning workflow is narrowly scoped", () => {
+  const workflow = readFileSync(
+    path.join(
+      PROJECT_ROOT,
+      ".github",
+      "workflows",
+      "provision-v2-bindings.yml",
+    ),
+    "utf8",
+  );
+
+  assert.match(
+    workflow,
+    /workflow_dispatch:[\s\S]*inputs:[\s\S]*PROVISION_BINDINGS/u,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /^ {2}(?:push|pull_request|schedule|workflow_run):/mu,
+  );
+  assert.match(
+    workflow,
+    /if:.*inputs\.confirm\s*==\s*'PROVISION_BINDINGS'.*github\.ref\s*==\s*'refs\/heads\/main'/u,
+  );
+  assert.match(workflow, /environment:\s*production/u);
+  assert.match(workflow, /CLOUDFLARE_ENV:\s*production/u);
+  const jobEnv = workflow.slice(
+    workflow.indexOf("    env:"),
+    workflow.indexOf("    steps:"),
+  );
+  assert.doesNotMatch(
+    jobEnv,
+    /secrets\./u,
+    "production secrets must not be exposed to checkout or dependency installation",
+  );
+  assert.match(
+    workflow,
+    /CLOUDFLARE_API_TOKEN:\s*\$\{\{\s*secrets\.CLOUDFLARE_API_TOKEN\s*\}\}/u,
+  );
+  assert.match(
+    workflow,
+    /CLOUDFLARE_ACCOUNT_ID:\s*\$\{\{\s*secrets\.CLOUDFLARE_ACCOUNT_ID\s*\}\}/u,
+  );
+  for (const secret of [
+    "CLOUDFLARE_ZONE_ID",
+    "BETTER_AUTH_SECRET",
+    "RESEND_API_KEY",
+    "PREVIEW_APP_URL",
+  ]) {
+    assert.match(
+      workflow,
+      new RegExp(
+        `${secret}:\\s*\\$\\{\\{\\s*secrets\\.${secret}\\s*\\}\\}`,
+        "u",
+      ),
+    );
+  }
+
+  const d1List = workflow.search(/wrangler\s+d1\s+list/u);
+  const d1Create = workflow.search(
+    /wrangler\s+d1\s+create\s+gomate-db-v2\s+--location\s+apac/u,
+  );
+  assert.ok(d1List >= 0 && d1List < d1Create);
+  assert.equal(
+    [...workflow.matchAll(/wrangler\s+d1\s+create\s+gomate-db-v2\b/gu)].length,
+    1,
+  );
+  for (const command of workflow.matchAll(/wrangler\s+d1\s+(?:list|create)[^\n]*/gu)) {
+    assert.match(command[0], /--env\s+production/u);
+  }
+  assert.match(
+    workflow.slice(d1List, d1Create),
+    /gomate-db-v2[\s\S]*exit(?:\s+|\()1\)?/u,
+  );
+
+  const kvList = workflow.search(/wrangler\s+kv\s+namespace\s+list/u);
+  const kvCreate = workflow.search(
+    /wrangler\s+kv\s+namespace\s+create\s+gomate-cache-v2/u,
+  );
+  assert.ok(kvList >= 0 && kvList < kvCreate);
+  assert.equal(
+    [
+      ...workflow.matchAll(
+        /wrangler\s+kv\s+namespace\s+create\s+gomate-cache-v2\b/gu,
+      ),
+    ].length,
+    1,
+  );
+  for (const command of workflow.matchAll(
+    /wrangler\s+kv\s+namespace\s+list[^\n]*/gu,
+  )) {
+    assert.match(command[0], /--env\s+production/u);
+  }
+  assert.match(
+    workflow.slice(kvList, kvCreate),
+    /gomate-cache-v2[\s\S]*exit(?:\s+|\()1\)?/u,
+  );
+
+  assert.doesNotMatch(
+    workflow,
+    /wrangler\s+(?:d1\s+(?:migrations?|execute)|deploy|secret|r2|route|domain)/u,
+  );
+  assert.doesNotMatch(workflow, /--update-config/u);
+  assert.doesNotMatch(
+    workflow,
+    /kv\s+namespace\s+create\s+gomate-cache-v2[^\n]*--env/u,
+  );
+  assert.doesNotMatch(workflow, /api\.cloudflare\.com\/client\/v4/u);
+  assert.match(workflow, /D1_DATABASE_ID/u);
+  assert.match(workflow, /KV_NAMESPACE_ID/u);
+  assert.match(workflow, /actions\/upload-artifact@v4/u);
+  assert.match(workflow, /GITHUB_STEP_SUMMARY/u);
+  assert.match(
+    workflow,
+    /Resolve and validate binding IDs[\s\S]*if:\s*always\(\)/u,
+  );
+  assert.match(workflow, /Record reviewed resource IDs[\s\S]*if:\s*always\(\)/u);
+  assert.match(workflow, /Upload binding ID evidence[\s\S]*if:\s*always\(\)/u);
+  assert.match(workflow, /PROVISION_STATUS/u);
+});


### PR DESCRIPTION
## 目的

在执行任何 Cloudflare 生产资源创建前，补齐受 GitHub `production` environment 保护的 V2 binding provisioning 能力。

## 改动一览

| 模块 | 改动 |
| --- | --- |
| Delivery | 新增仅 `main`、仅手动 `PROVISION_BINDINGS`、需 `production` 审批的 provisioning workflow |
| Security | secrets 按步骤最小暴露；checkout/install 不接触生产凭据 |
| Evidence | 完整或部分创建均通过 always inventory 记录 D1/KV ID artifact 与 summary |
| Docs | 固化 environment secrets、APAC D1、精确 KV 命名及部分失败处理规约 |

## 行为边界

- 只允许创建 D1 `gomate-db-v2 --location apac` 和 KV `gomate-cache-v2`。
- 创建前先确认两个精确名称均不存在。
- 禁止 migration、Worker deploy、secret mutation、R2 mutation、custom domain 和 route 操作。
- 不使用 `--update-config`；本 PR 不写 Wrangler binding ID。
- D1/KV 任一部分失败时不自动删除；保留证据并让 job 保持失败。

## 验证证据

- RED：workflow 不存在时 focused guard 失败。
- GREEN：provisioning focused guard 通过。
- `node --test scripts/check-legacy-removal.test.mjs scripts/deployment-guards.test.mjs scripts/promote-admin.test.mjs scripts/reset-local-db.test.mjs`：22/22。
- Workflow YAML 解析与单 job/单 trigger 拓扑校验通过。
- `git diff --check` 通过。
- 两轮独立审查：最终 APPROVE。
- 只读 Cloudflare 复核：`gomate-db-v2` 与 `gomate-cache-v2` 仍均不存在。

## Cloudflare / 数据库影响

当前无远程写入。合并本 PR 也不会自动运行 provisioning；workflow 仅支持后续经明确批准、production environment 审批后的手动执行。

## 回滚路径

合并后可 revert 本提交以移除 provisioning workflow 与对应规约/门禁；没有资源被本 PR 自动创建，无需数据或 route 回滚。

## 后续

1. 创建仅允许 `main` 的 GitHub `production` environment，配置 required reviewer。
2. 将六项生产凭据全部迁入 environment secrets。
3. 列出精确资源写入、影响与回滚并取得 Victor 明确批准。
4. 手动运行 provisioning，再以独立 binding PR 写入两个受审查 ID。