### PR TITLE
Bind unified Worker to reviewed V2 resources

### DIFF
--- a/frontend/wrangler.jsonc
+++ b/frontend/wrangler.jsonc
@@ -85,7 +85,7 @@
         {
           "binding": "DB",
           "database_name": "gomate-db-v2",
-          "database_id": "REPLACE_IN_BINDINGS_PR",
+          "database_id": "befa3d89-6551-4a25-8a1c-670efe62a315",
           "migrations_dir": "../api/db/migrations"
         }
       ],
@@ -98,7 +98,7 @@
       "kv_namespaces": [
         {
           "binding": "CACHE_KV",
-          "id": "REPLACE_IN_BINDINGS_PR"
+          "id": "f9904d1fa72140c18067e07d541ca92b"
         }
       ],
       "ratelimits": [


### PR DESCRIPTION
## Summary

- replace the fail-closed production D1 placeholder with the reviewed `gomate-db-v2` ID
- replace the fail-closed production KV placeholder with the reviewed `gomate-cache-v2` ID
- keep the preview Worker protected and unrouted

## Why

Protected provisioning run [#31955191318](https://github.com/redisread/gomate/actions/runs/31955191318) created the new empty V2 resources after production-environment approval. This PR records only those reviewed binding IDs so later rollout stages can be separately approved.

## Production impact

This PR does **not** apply migrations, deploy a Worker, write secrets, mutate R2, change routes/domains, or delete old resources. Merging it only resolves the fail-closed source configuration.

## Evidence

- provisioning artifact status: `complete`
- D1 `gomate-db-v2`: `befa3d89-6551-4a25-8a1c-670efe62a315` (APAC, empty)
- KV `gomate-cache-v2`: `f9904d1fa72140c18067e07d541ca92b`
- old `gomate-db` and `GOMATE_KV` remain present
- GoMate reviewer: APPROVE, no findings

## Validation

- delivery guards: pass
- binding-level local reset: pass
- Worker types check: pass
- production Astro build: pass
- generated config validation: pass
- Wrangler production dry-run: pass, no deploy
- bundle size: 1.50 MiB gzip
- startup profile: pass
- `git diff --check`: pass

## Rollback

Revert commit `e97d00d` to restore the fail-closed placeholders. No remote data rollback is required because this PR does not perform a deployment or migration.