### PR TITLE
fix: wait for preview worker readiness

### DIFF
--- a/docs/prod-change-policy.md
+++ b/docs/prod-change-policy.md
@@ -61,6 +61,10 @@ route 切换，都必须：
 5. 部署 `gomate-production-preview`，保持 `WRITE_MODE=protected` 且不挂生产域名。
 6. 执行 `/api/health`、SSR 页面读取烟测，并用一个认证 mutation 断言
    `503 + WRITE_PROTECTED`；请求必须在进入 Better Auth 前被拦截，不能写 D1。
+   Worker 部署完成后，health/SSR 共用约 2 分钟的 readiness deadline；只对尚未出现应用
+   `X-Request-ID` 的 workers.dev 传播期 `404/523` 与网络失败重试，每次请求不得超过剩余预算。
+   一旦收到其他状态、成功状态但内容类型错误，或认证 mutation 不是精确的
+   `503 + WRITE_PROTECTED`，必须立即失败，禁止用重试掩盖实现错误。
 7. smoke 输出 health 与 protected-mutation 两个 `X-Request-ID`；随后第二个 `production`
    protected-environment job 必须由审批人在 Workers Logs 完成人工证据检查后放行。未审批时
    整个部署工作流保持未完成。

--- a/scripts/deployment-guards.test.mjs
+++ b/scripts/deployment-guards.test.mjs
@@ -622,6 +622,163 @@ test("protected preview smoke requires correlated request IDs", async () => {
   );
 });
 
+test("protected preview smoke waits through transient workers.dev propagation", async () => {
+  const requestId = "22222222-2222-4222-8222-222222222222";
+  const waits = [];
+  const requestTimeouts = [];
+  let nowMs = 0;
+  let healthAttempts = 0;
+  let ssrAttempts = 0;
+  let mutationAttempts = 0;
+  const fetchImpl = async (input, init) => {
+    const url = new URL(input);
+    if (url.pathname === "/api/health") {
+      healthAttempts += 1;
+      if (healthAttempts === 1) throw new Error("network not ready");
+      if (healthAttempts === 2) return new Response("not ready", { status: 523 });
+      return Response.json(
+        { status: "ok" },
+        { headers: { "x-request-id": requestId } },
+      );
+    }
+    if (url.pathname === "/") {
+      ssrAttempts += 1;
+      if (ssrAttempts === 1) {
+        return new Response("not found", { status: 404 });
+      }
+      return new Response("<!doctype html>", {
+        headers: { "content-type": "text/html" },
+      });
+    }
+    mutationAttempts += 1;
+    assert.equal(init?.method, "POST");
+    return Response.json(
+      { success: false, error: { code: "WRITE_PROTECTED" } },
+      {
+        status: 503,
+        headers: {
+          "retry-after": "60",
+          "x-request-id": requestId,
+        },
+      },
+    );
+  };
+
+  const result = await smokeProtectedPreview({
+    baseUrl: "https://gomate-production-preview.example.workers.dev",
+    fetchImpl,
+    readinessTimeoutMs: 10,
+    readinessRetryDelayMs: 1,
+    nowImpl: () => nowMs,
+    waitImpl: async (delayMs) => {
+      waits.push(delayMs);
+      nowMs += delayMs;
+    },
+    timeoutSignalImpl: (timeoutMs) => {
+      requestTimeouts.push(timeoutMs);
+      return { timeoutMs };
+    },
+  });
+
+  assert.equal(healthAttempts, 3);
+  assert.equal(ssrAttempts, 2);
+  assert.equal(mutationAttempts, 1);
+  assert.deepEqual(waits, [1, 1, 1]);
+  assert.deepEqual(requestTimeouts, [10, 9, 8, 8, 7]);
+  assert.deepEqual(result, {
+    healthRequestId: requestId,
+    blockedRequestId: requestId,
+  });
+});
+
+test("protected preview smoke shares one bounded readiness deadline", async () => {
+  const requestId = "33333333-3333-4333-8333-333333333333";
+  let nowMs = 0;
+  let healthAttempts = 0;
+  let ssrAttempts = 0;
+  const waits = [];
+  await assert.rejects(
+    smokeProtectedPreview({
+      baseUrl: "https://gomate-production-preview.example.workers.dev",
+      fetchImpl: async (input) => {
+        const url = new URL(input);
+        if (url.pathname === "/api/health") {
+          healthAttempts += 1;
+          if (healthAttempts === 1) {
+            return new Response("not found", { status: 404 });
+          }
+          return Response.json(
+            { status: "ok" },
+            { headers: { "x-request-id": requestId } },
+          );
+        }
+        ssrAttempts += 1;
+        return new Response("not found", { status: 404 });
+      },
+      readinessTimeoutMs: 2,
+      readinessRetryDelayMs: 1,
+      nowImpl: () => nowMs,
+      waitImpl: async (delayMs) => {
+        waits.push(delayMs);
+        nowMs += delayMs;
+      },
+      timeoutSignalImpl: (timeoutMs) => ({ timeoutMs }),
+    }),
+    /SSR smoke readiness timed out/u,
+  );
+  assert.equal(healthAttempts, 2);
+  assert.equal(ssrAttempts, 1);
+  assert.deepEqual(waits, [1, 1]);
+});
+
+test("protected preview smoke does not retry application failures", async () => {
+  const requestId = "44444444-4444-4444-8444-444444444444";
+  let attempts = 0;
+  const waits = [];
+  await assert.rejects(
+    smokeProtectedPreview({
+      baseUrl: "https://gomate-production-preview.example.workers.dev",
+      fetchImpl: async () => {
+        attempts += 1;
+        return Response.json(
+          { success: false, error: { code: "SERVICE_UNAVAILABLE" } },
+          {
+            status: 503,
+            headers: { "x-request-id": requestId },
+          },
+        );
+      },
+      readinessTimeoutMs: 10,
+      readinessRetryDelayMs: 1,
+      waitImpl: async (delayMs) => waits.push(delayMs),
+      timeoutSignalImpl: (timeoutMs) => ({ timeoutMs }),
+    }),
+    /Health smoke failed \(503\)/u,
+  );
+  assert.equal(attempts, 1);
+  assert.deepEqual(waits, []);
+
+  attempts = 0;
+  await assert.rejects(
+    smokeProtectedPreview({
+      baseUrl: "https://gomate-production-preview.example.workers.dev",
+      fetchImpl: async () => {
+        attempts += 1;
+        return new Response("wrong content type", {
+          headers: { "content-type": "text/plain" },
+        });
+      },
+      readinessTimeoutMs: 10,
+      readinessRetryDelayMs: 1,
+      waitImpl: async (delayMs) => waits.push(delayMs),
+      timeoutSignalImpl: (timeoutMs) => ({ timeoutMs }),
+    }),
+    /Health smoke failed \(200\)/u,
+  );
+  assert.equal(attempts, 1);
+  assert.deepEqual(waits, []);
+});
+
 test("deploy workflow blocks completion on post-smoke observability approval", () => {
   const workflow = readFileSync(
     path.resolve(

--- a/scripts/smoke-protected-preview.mjs
+++ b/scripts/smoke-protected-preview.mjs
@@ -6,6 +6,12 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 const REQUEST_ID_PATTERN = /^[a-z0-9-]{36,96}$/iu;
+const DEFAULT_READINESS_TIMEOUT_MS = 120_000;
+const DEFAULT_READINESS_RETRY_DELAY_MS = 5_000;
+const TRANSIENT_READINESS_STATUSES = new Set([404, 523]);
+
+const wait = (delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs));
+const timeoutSignal = (timeoutMs) => AbortSignal.timeout(timeoutMs);
 
 function requiredRequestId(response, label) {
   const requestId = response.headers.get("x-request-id")?.trim();
@@ -15,22 +21,97 @@ function requiredRequestId(response, label) {
   return requestId;
 }
 
+async function waitForReadyResponse({
+  label,
+  request,
+  isReady,
+  deadlineMs,
+  retryDelayMs,
+  waitImpl,
+  nowImpl,
+  timeoutSignalImpl,
+}) {
+  while (true) {
+    const remainingMs = deadlineMs - nowImpl();
+    if (remainingMs <= 0) {
+      throw new Error(`${label} smoke readiness timed out`);
+    }
+
+    let response;
+    try {
+      response = await request(timeoutSignalImpl(remainingMs));
+    } catch {
+      const retryWaitMs = Math.min(retryDelayMs, deadlineMs - nowImpl());
+      if (retryWaitMs <= 0) {
+        throw new Error(`${label} smoke readiness timed out`);
+      }
+      await waitImpl(retryWaitMs);
+      continue;
+    }
+
+    if (isReady(response)) return response;
+    if (
+      !TRANSIENT_READINESS_STATUSES.has(response.status) ||
+      response.headers.has("x-request-id")
+    ) {
+      throw new Error(`${label} smoke failed (${response.status})`);
+    }
+
+    const retryWaitMs = Math.min(retryDelayMs, deadlineMs - nowImpl());
+    if (retryWaitMs <= 0) {
+      throw new Error(`${label} smoke readiness timed out`);
+    }
+    await waitImpl(retryWaitMs);
+  }
+}
+
 export async function smokeProtectedPreview({
   baseUrl = process.env.PREVIEW_APP_URL?.trim(),
   fetchImpl = fetch,
+  readinessTimeoutMs = DEFAULT_READINESS_TIMEOUT_MS,
+  readinessRetryDelayMs = DEFAULT_READINESS_RETRY_DELAY_MS,
+  waitImpl = wait,
+  nowImpl = Date.now,
+  timeoutSignalImpl = timeoutSignal,
 } = {}) {
   if (!baseUrl) throw new Error("PREVIEW_APP_URL is required");
-
-  const health = await fetchImpl(new URL("/api/health", baseUrl));
-  if (!health.ok || !health.headers.get("content-type")?.includes("application/json")) {
-    throw new Error(`Health smoke failed (${health.status})`);
+  if (!Number.isInteger(readinessTimeoutMs) || readinessTimeoutMs <= 0) {
+    throw new Error("readinessTimeoutMs must be a positive integer");
   }
+  if (
+    !Number.isInteger(readinessRetryDelayMs) ||
+    readinessRetryDelayMs <= 0
+  ) {
+    throw new Error("readinessRetryDelayMs must be a positive integer");
+  }
+  const readinessDeadlineMs = nowImpl() + readinessTimeoutMs;
+
+  const health = await waitForReadyResponse({
+    label: "Health",
+    request: (signal) =>
+      fetchImpl(new URL("/api/health", baseUrl), { signal }),
+    isReady: (response) =>
+      response.ok &&
+      response.headers.get("content-type")?.includes("application/json"),
+    deadlineMs: readinessDeadlineMs,
+    retryDelayMs: readinessRetryDelayMs,
+    waitImpl,
+    nowImpl,
+    timeoutSignalImpl,
+  });
   const healthRequestId = requiredRequestId(health, "Health");
 
-  const home = await fetchImpl(new URL("/", baseUrl));
-  if (!home.ok || !home.headers.get("content-type")?.includes("text/html")) {
-    throw new Error(`SSR smoke failed (${home.status})`);
-  }
+  await waitForReadyResponse({
+    label: "SSR",
+    request: (signal) => fetchImpl(new URL("/", baseUrl), { signal }),
+    isReady: (response) =>
+      response.ok && response.headers.get("content-type")?.includes("text/html"),
+    deadlineMs: readinessDeadlineMs,
+    retryDelayMs: readinessRetryDelayMs,
+    waitImpl,
+    nowImpl,
+    timeoutSignalImpl,
+  });
 
   const blocked = await fetchImpl(new URL("/api/auth/sign-in/email", baseUrl), {
     method: "POST",


### PR DESCRIPTION
## 变更

- 为 protected preview 的 health 与 SSR 烟测增加共享 120 秒 readiness deadline
- 每次 GET 使用剩余预算作为请求超时
- 仅重试尚未到达 GoMate 应用的网络失败、404 和 523
- 保持认证 mutation 单次执行，并严格验证 503、Retry-After: 60 和 WRITE_PROTECTED
- 同步生产变更策略与覆盖传播、超时、应用故障边界的回归测试

## 根因

阶段 B 首次部署在 Worker 发布完成后约 0.12 秒立即请求 workers.dev，短暂收到 404；约 52 秒后同一 health URL 已返回 200。Worker、绑定和 WRITE_MODE 均正确，失败来自首次 workers.dev 传播窗口。

## 影响范围

仅修改部署烟测脚本、部署门禁测试和生产变更文档。不会应用迁移、部署 Worker、修改 Cloudflare 资源、切换路由或写入 R2。

## 验证

- deployment guards：17/17
- delivery tests：25/25
- legacy removal gate：通过
- Node syntax check：通过
- git diff check：通过
- 独立审查：APPROVE，无 Critical、Important 或 Suggestion
