### PR TITLE
ci: add protected production Region bootstrap

### DIFF
--- a/.github/workflows/bootstrap-production-regions.yml
+++ b/.github/workflows/bootstrap-production-regions.yml
@@ -1,0 +1,94 @@
+name: Bootstrap production V2 Regions
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: Type BOOTSTRAP_REGIONS to insert the reviewed three-row hierarchy
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bootstrap-production-v2-regions
+  cancel-in-progress: false
+
+jobs:
+  bootstrap:
+    name: Bootstrap reviewed production Regions
+    if: inputs.confirm == 'BOOTSTRAP_REGIONS' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    env:
+      CLOUDFLARE_ENV: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.0.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Validate reviewed bootstrap contract
+        run: |
+          cd api/db/bootstrap
+          sha256sum --check regions-v1.sha256
+          cd ../../..
+          node --test scripts/region-bootstrap-contract.test.mjs
+
+      - name: Prove the V2 database is empty
+        working-directory: frontend
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PREFLIGHT_JSON: ${{ runner.temp }}/region-bootstrap-preflight.json
+        run: |
+          pnpm exec wrangler d1 execute DB --env production --remote --config wrangler.jsonc --json --command "SELECT (SELECT count(*) FROM users) + (SELECT count(*) FROM sessions) + (SELECT count(*) FROM accounts) + (SELECT count(*) FROM verifications) + (SELECT count(*) FROM tags) + (SELECT count(*) FROM locations) + (SELECT count(*) FROM teams) + (SELECT count(*) FROM team_join_requests) + (SELECT count(*) FROM team_members) + (SELECT count(*) FROM stories) + (SELECT count(*) FROM location_tags) + (SELECT count(*) FROM team_tags) + (SELECT count(*) FROM story_tags) + (SELECT count(*) FROM story_likes) + (SELECT count(*) FROM user_location_favorites) + (SELECT count(*) FROM user_story_favorites) + (SELECT count(*) FROM conversations) + (SELECT count(*) FROM messages) AS business_row_count, (SELECT count(*) FROM region) AS region_row_count" > "$PREFLIGHT_JSON"
+          node ../scripts/region-bootstrap-contract.mjs preflight "$PREFLIGHT_JSON"
+
+      - name: Apply exact reviewed Region bootstrap
+        working-directory: frontend
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm exec wrangler d1 execute DB --env production --remote --config wrangler.jsonc --file ../api/db/bootstrap/regions-v1.sql
+
+      - name: Validate and record exact production rows
+        working-directory: frontend
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          REGION_JSON: ${{ runner.temp }}/region-bootstrap-regions.json
+          COUNT_JSON: ${{ runner.temp }}/region-bootstrap-counts.json
+          EVIDENCE_JSON: ${{ runner.temp }}/region-bootstrap-evidence.json
+        run: |
+          pnpm exec wrangler d1 execute DB --env production --remote --config wrangler.jsonc --json --command "SELECT id, parent_id, country_code, level, timezone, center_latitude, center_longitude, service_enabled FROM region ORDER BY id" > "$REGION_JSON"
+          pnpm exec wrangler d1 execute DB --env production --remote --config wrangler.jsonc --json --command "SELECT (SELECT count(*) FROM users) + (SELECT count(*) FROM sessions) + (SELECT count(*) FROM accounts) + (SELECT count(*) FROM verifications) + (SELECT count(*) FROM tags) + (SELECT count(*) FROM locations) + (SELECT count(*) FROM teams) + (SELECT count(*) FROM team_join_requests) + (SELECT count(*) FROM team_members) + (SELECT count(*) FROM stories) + (SELECT count(*) FROM location_tags) + (SELECT count(*) FROM team_tags) + (SELECT count(*) FROM story_tags) + (SELECT count(*) FROM story_likes) + (SELECT count(*) FROM user_location_favorites) + (SELECT count(*) FROM user_story_favorites) + (SELECT count(*) FROM conversations) + (SELECT count(*) FROM messages) AS business_row_count" > "$COUNT_JSON"
+          node ../scripts/region-bootstrap-contract.mjs postflight "$REGION_JSON" "$COUNT_JSON" "$EVIDENCE_JSON"
+          cp ../api/db/bootstrap/regions-v1.sha256 "$RUNNER_TEMP/regions-v1.sha256"
+
+      - name: Record production bootstrap evidence
+        run: |
+          {
+            echo "### Production V2 Region bootstrap complete"
+            echo "- Database: \`gomate-db-v2\`"
+            echo "- IDs: \`region-cn\`, \`region-cn-guangdong\`, \`region-cn-shenzhen\`"
+            echo "- Source checksum: \`$(cut -d ' ' -f 1 api/db/bootstrap/regions-v1.sha256)\`"
+            echo "- No user, location, tag, Worker, route, R2, KV, or secret mutation was performed."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Region bootstrap evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: gomate-production-region-bootstrap
+          path: |
+            ${{ runner.temp }}/region-bootstrap-evidence.json
+            ${{ runner.temp }}/regions-v1.sha256
+          if-no-files-found: error
+          retention-days: 90

--- a/api/db/bootstrap/regions-v1.rollback.sql
+++ b/api/db/bootstrap/regions-v1.rollback.sql
@@ -1,0 +1,4 @@
+-- Emergency rollback only. Run after proving no business rows reference these IDs.
+DELETE FROM `region` WHERE `id` = 'region-cn-shenzhen';
+DELETE FROM `region` WHERE `id` = 'region-cn-guangdong';
+DELETE FROM `region` WHERE `id` = 'region-cn';

--- a/api/db/bootstrap/regions-v1.sha256
+++ b/api/db/bootstrap/regions-v1.sha256
@@ -1,0 +1,1 @@
+a29c265ab6f2948798e50f9c33c8342d5fa2bc47bbfac2dfeaf6e7aec60cf084  regions-v1.sql

--- a/api/db/bootstrap/regions-v1.sql
+++ b/api/db/bootstrap/regions-v1.sql
@@ -1,0 +1,18 @@
+-- Production bootstrap v1: the exact CN/Guangdong/Shenzhen Region hierarchy.
+-- This is intentionally separate from the development seed.
+INSERT INTO `region` (
+  `id`, `country_code`, `parent_id`, `name`, `name_en`, `slug`, `code`, `level`,
+  `timezone`, `center_latitude`, `center_longitude`, `service_enabled`, `is_hot`, `sort_order`
+) VALUES
+  (
+    'region-cn', 'CN', NULL, '中国', 'China', 'china', 'CN', 'other',
+    NULL, NULL, NULL, 0, 0, 0
+  ),
+  (
+    'region-cn-guangdong', 'CN', 'region-cn', '广东省', 'Guangdong', 'guangdong',
+    '440000', 'province', NULL, NULL, NULL, 0, 0, 10
+  ),
+  (
+    'region-cn-shenzhen', 'CN', 'region-cn-guangdong', '深圳市', 'Shenzhen',
+    'shenzhen', '440300', 'city', 'Asia/Shanghai', 22.5431, 114.0579, 1, 1, 10
+  );

--- a/docs/prod-change-policy.md
+++ b/docs/prod-change-policy.md
@@ -78,6 +78,11 @@ bootstrap。该变更只能写入已复核的国家/省/city Region 行，不得
 执行前记录 SQL 文件 checksum 与这些精确 Region ID，执行后验证 `level=city`、
 `service_enabled=1`、IANA timezone 和地图中心坐标，并保存 D1 查询证据。若验证失败，在尚无
 业务引用时只按该清单中的精确 Region ID 回滚；不得运行 development seed 作为快捷方案。
+生产 bootstrap 只能从 `main` 手动运行 `Bootstrap production V2 Regions`，输入
+`BOOTSTRAP_REGIONS` 并通过 `production` environment 审批。工作流在写入前要求全部 18 个
+非 Region 业务表与 Region 表均为空，只执行 `api/db/bootstrap/regions-v1.sql`，并把 checksum、
+精确三行查询和业务行计数保存为 90 天 artifact。`regions-v1.rollback.sql` 只作为经再次审批的
+紧急回滚输入，禁止由 bootstrap 失败自动执行。
 
 ### 阶段 C：route 切换
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "i18n:gen-types": "node scripts/gen-i18n-types.mjs",
     "i18n:build": "tsx scripts/build-locales.ts",
     "check:legacy-removal": "node scripts/check-legacy-removal.mjs",
-    "test:delivery": "node --test scripts/check-legacy-removal.test.mjs scripts/deployment-guards.test.mjs scripts/promote-admin.test.mjs scripts/reset-local-db.test.mjs",
+    "test:delivery": "node --test scripts/check-legacy-removal.test.mjs scripts/deployment-guards.test.mjs scripts/promote-admin.test.mjs scripts/region-bootstrap-contract.test.mjs scripts/reset-local-db.test.mjs",
     "prepare": "husky",
     "dev:wt": "node scripts/init-worktree.mjs && node scripts/start-worktree.mjs",
     "init:worktree": "node scripts/init-worktree.mjs"

--- a/scripts/region-bootstrap-contract.mjs
+++ b/scripts/region-bootstrap-contract.mjs
@@ -1,0 +1,160 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+export const EXPECTED_REGION_IDS = [
+  "region-cn",
+  "region-cn-guangdong",
+  "region-cn-shenzhen",
+];
+
+const EXPECTED_REGIONS = [
+  {
+    id: "region-cn",
+    parent_id: null,
+    country_code: "CN",
+    level: "other",
+    timezone: null,
+    center_latitude: null,
+    center_longitude: null,
+    service_enabled: 0,
+  },
+  {
+    id: "region-cn-guangdong",
+    parent_id: "region-cn",
+    country_code: "CN",
+    level: "province",
+    timezone: null,
+    center_latitude: null,
+    center_longitude: null,
+    service_enabled: 0,
+  },
+  {
+    id: "region-cn-shenzhen",
+    parent_id: "region-cn-guangdong",
+    country_code: "CN",
+    level: "city",
+    timezone: "Asia/Shanghai",
+    center_latitude: 22.5431,
+    center_longitude: 114.0579,
+    service_enabled: 1,
+  },
+];
+
+function integer(value, label) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`${label} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+export function assertBootstrapPreflight(input) {
+  const businessRowCount = integer(
+    input.businessRowCount,
+    "businessRowCount",
+  );
+  const regionRowCount = integer(input.regionRowCount, "regionRowCount");
+  if (businessRowCount !== 0) {
+    throw new Error(`Refusing bootstrap: found ${businessRowCount} business rows`);
+  }
+  if (regionRowCount !== 0) {
+    throw new Error(`Refusing bootstrap: found ${regionRowCount} existing Region rows`);
+  }
+}
+
+export function assertBootstrapResult(input) {
+  const businessRowCount = integer(
+    input.businessRowCount,
+    "businessRowCount",
+  );
+  if (businessRowCount !== 0) {
+    throw new Error(`Postflight found ${businessRowCount} unexpected business rows`);
+  }
+  if (!Array.isArray(input.rows) || input.rows.length !== 3) {
+    throw new Error("Postflight must return exactly three Region rows");
+  }
+  const actual = [...input.rows]
+    .map((row) => ({
+      id: row.id,
+      parent_id: row.parent_id ?? null,
+      country_code: row.country_code,
+      level: row.level,
+      timezone: row.timezone ?? null,
+      center_latitude:
+        row.center_latitude == null ? null : Number(row.center_latitude),
+      center_longitude:
+        row.center_longitude == null ? null : Number(row.center_longitude),
+      service_enabled: Number(row.service_enabled),
+    }))
+    .sort((left, right) => left.id.localeCompare(right.id));
+  const expected = [...EXPECTED_REGIONS].sort((left, right) =>
+    left.id.localeCompare(right.id),
+  );
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error("Postflight does not match the reviewed Region hierarchy");
+  }
+}
+
+function rowsFromWrangler(filePath) {
+  const payload = JSON.parse(readFileSync(filePath, "utf8"));
+  const executions = Array.isArray(payload) ? payload : [payload];
+  if (executions.length !== 1 || executions[0]?.success !== true) {
+    throw new Error("Wrangler D1 evidence is missing one successful execution");
+  }
+  const rows = executions[0]?.results;
+  if (!Array.isArray(rows)) {
+    throw new Error("Wrangler D1 evidence does not contain result rows");
+  }
+  return rows;
+}
+
+export function validatePreflightFile(filePath) {
+  const rows = rowsFromWrangler(filePath);
+  if (rows.length !== 1) {
+    throw new Error("Preflight query must return exactly one row");
+  }
+  assertBootstrapPreflight({
+    businessRowCount: rows[0].business_row_count,
+    regionRowCount: rows[0].region_row_count,
+  });
+}
+
+export function validatePostflightFiles(regionPath, countPath, evidencePath) {
+  const rows = rowsFromWrangler(regionPath);
+  const counts = rowsFromWrangler(countPath);
+  if (counts.length !== 1) {
+    throw new Error("Postflight count query must return exactly one row");
+  }
+  assertBootstrapResult({
+    businessRowCount: counts[0].business_row_count,
+    rows,
+  });
+  writeFileSync(
+    evidencePath,
+    `${JSON.stringify(
+      {
+        status: "complete",
+        database: "gomate-db-v2",
+        regionIds: EXPECTED_REGION_IDS,
+        regions: rows,
+        businessRowCount: Number(counts[0].business_row_count),
+      },
+      null,
+      2,
+    )}\n`,
+    { mode: 0o600 },
+  );
+}
+
+if (process.argv[1]?.endsWith("region-bootstrap-contract.mjs")) {
+  const [, , command, ...args] = process.argv;
+  if (command === "preflight" && args.length === 1) {
+    validatePreflightFile(args[0]);
+  } else if (command === "postflight" && args.length === 3) {
+    validatePostflightFiles(args[0], args[1], args[2]);
+  } else {
+    console.error(
+      "Usage: region-bootstrap-contract.mjs preflight <json> | postflight <regions-json> <counts-json> <evidence-json>",
+    );
+    process.exit(1);
+  }
+}

--- a/scripts/region-bootstrap-contract.test.mjs
+++ b/scripts/region-bootstrap-contract.test.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  EXPECTED_REGION_IDS,
+  assertBootstrapPreflight,
+  assertBootstrapResult,
+} from "./region-bootstrap-contract.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+test("production Region bootstrap is exact, protected, and reversible", () => {
+  const workflow = readFileSync(
+    path.join(root, ".github/workflows/bootstrap-production-regions.yml"),
+    "utf8",
+  );
+  const applyPath = path.join(root, "api/db/bootstrap/regions-v1.sql");
+  const applySql = readFileSync(applyPath, "utf8");
+  const rollbackSql = readFileSync(
+    path.join(root, "api/db/bootstrap/regions-v1.rollback.sql"),
+    "utf8",
+  );
+  const checksum = readFileSync(
+    path.join(root, "api/db/bootstrap/regions-v1.sha256"),
+    "utf8",
+  );
+
+  assert.deepEqual(EXPECTED_REGION_IDS, [
+    "region-cn",
+    "region-cn-guangdong",
+    "region-cn-shenzhen",
+  ]);
+  for (const id of EXPECTED_REGION_IDS) {
+    assert.match(applySql, new RegExp(`'${id}'`, "u"));
+    assert.match(rollbackSql, new RegExp(`'${id}'`, "u"));
+  }
+  assert.equal((applySql.match(/INSERT INTO `region`/gu) ?? []).length, 1);
+  assert.doesNotMatch(applySql, /INSERT OR|UPDATE|DELETE|users|locations|tags/iu);
+  assert.doesNotMatch(rollbackSql, /DROP|UPDATE|INSERT/iu);
+  assert.match(checksum, /^[0-9a-f]{64}\s+regions-v1\.sql\s*$/u);
+  assert.equal(
+    checksum.split(/\s+/u)[0],
+    createHash("sha256").update(readFileSync(applyPath)).digest("hex"),
+  );
+
+  assert.match(workflow, /workflow_dispatch:[\s\S]*BOOTSTRAP_REGIONS/u);
+  assert.match(
+    workflow,
+    /inputs\.confirm\s*==\s*'BOOTSTRAP_REGIONS'.*github\.ref\s*==\s*'refs\/heads\/main'/u,
+  );
+  assert.match(workflow, /environment:\s*production/u);
+  assert.match(workflow, /CLOUDFLARE_ENV:\s*production/u);
+  assert.match(workflow, /--env production --remote --config wrangler\.jsonc/u);
+  assert.match(workflow, /sha256sum --check regions-v1\.sha256/u);
+  assert.match(workflow, /actions\/upload-artifact@v4/u);
+  assert.doesNotMatch(workflow, /seed\.sql|wrangler\s+deploy|wrangler\s+secret|wrangler\s+r2/iu);
+});
+
+test("preflight accepts only an empty V2 business database", () => {
+  assert.doesNotThrow(() =>
+    assertBootstrapPreflight({ businessRowCount: 0, regionRowCount: 0 }),
+  );
+  assert.throws(
+    () => assertBootstrapPreflight({ businessRowCount: 1, regionRowCount: 0 }),
+    /business rows/u,
+  );
+  assert.throws(
+    () => assertBootstrapPreflight({ businessRowCount: 0, regionRowCount: 1 }),
+    /Region rows/u,
+  );
+});
+
+test("postflight accepts only the reviewed three-row hierarchy", () => {
+  const rows = [
+    {
+      id: "region-cn",
+      parent_id: null,
+      country_code: "CN",
+      level: "other",
+      timezone: null,
+      center_latitude: null,
+      center_longitude: null,
+      service_enabled: 0,
+    },
+    {
+      id: "region-cn-guangdong",
+      parent_id: "region-cn",
+      country_code: "CN",
+      level: "province",
+      timezone: null,
+      center_latitude: null,
+      center_longitude: null,
+      service_enabled: 0,
+    },
+    {
+      id: "region-cn-shenzhen",
+      parent_id: "region-cn-guangdong",
+      country_code: "CN",
+      level: "city",
+      timezone: "Asia/Shanghai",
+      center_latitude: 22.5431,
+      center_longitude: 114.0579,
+      service_enabled: 1,
+    },
+  ];
+  assert.doesNotThrow(() =>
+    assertBootstrapResult({ businessRowCount: 0, rows }),
+  );
+  assert.throws(
+    () => assertBootstrapResult({ businessRowCount: 0, rows: rows.slice(0, 2) }),
+    /exactly three/u,
+  );
+  assert.throws(
+    () =>
+      assertBootstrapResult({
+        businessRowCount: 0,
+        rows: rows.map((row) =>
+          row.id === "region-cn-shenzhen"
+            ? { ...row, timezone: "UTC" }
+            : row,
+        ),
+      }),
+    /reviewed Region hierarchy/u,
+  );
+});


### PR DESCRIPTION
Adds a manual production-environment workflow that inserts only the reviewed CN, Guangdong, and Shenzhen Region rows into gomate-db-v2. The workflow fails closed unless all business tables and Region are empty, validates the exact hierarchy after the write, and retains checksum/query evidence for 90 days. It does not deploy a Worker, change routes or secrets, apply seed data, or mutate R2/KV. Rollback SQL is documented but never runs automatically.\n\nValidation: region contract 3/3; delivery 28/28 outside sandbox; legacy gate passed; prod audit has no high or critical findings; SQLite baseline plus bootstrap replay passed.