### PR TITLE
ci: add protected unified Worker production cutover

### DIFF
--- a/.github/workflows/cutover-production.yml
+++ b/.github/workflows/cutover-production.yml
@@ -1,0 +1,240 @@
+name: Cut over unified Worker production
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: Type CUTOVER_PRODUCTION to route gomate.live, observe, then open writes
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: unified-worker-production-cutover
+  cancel-in-progress: false
+
+jobs:
+  cutover-protected:
+    name: Route gomate.live with writes protected
+    if: inputs.confirm == 'CUTOVER_PRODUCTION' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: production
+    env:
+      CLOUDFLARE_ENV: production
+    outputs:
+      health_request_id: ${{ steps.smoke.outputs.health_request_id }}
+      blocked_request_id: ${{ steps.smoke.outputs.blocked_request_id }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.0.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Validate source and build protected production output
+        run: |
+          pnpm audit --prod --audit-level high
+          pnpm check:legacy-removal
+          pnpm test:delivery
+          pnpm --filter @gomate/api check:migrations
+          pnpm i18n:build
+          pnpm --filter @gomate/frontend worker:types:check
+          pnpm --filter @gomate/frontend build
+          node scripts/prepare-worker-output.mjs
+          pnpm --filter @gomate/frontend worker:size
+      - name: Prove gomate.live still targets the reviewed legacy Worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          EXPECTED_DOMAIN_SERVICE: gomate-frontend
+        run: node scripts/production-domain.mjs assert
+      - name: Prepare protected custom-domain deployment
+        env:
+          PRODUCTION_APP_URL: ${{ secrets.PRODUCTION_APP_URL }}
+        run: node scripts/prepare-production-cutover.mjs --mode protected
+      - name: Deploy protected unified Worker to gomate.live
+        working-directory: frontend
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          PRODUCTION_APP_URL: ${{ secrets.PRODUCTION_APP_URL }}
+          SECRETS_FILE: ${{ runner.temp }}/gomate-production-secrets.json
+        run: |
+          node ../scripts/write-production-secrets.mjs
+          pnpm exec wrangler deploy --config dist/server/wrangler.json --secrets-file "$SECRETS_FILE"
+      - name: Remove ephemeral production secrets
+        if: always()
+        env:
+          RUNNER_TEMP: ${{ runner.temp }}
+          SECRETS_FILE: ${{ runner.temp }}/gomate-production-secrets.json
+        run: node scripts/remove-preview-secrets.mjs
+      - name: Prove gomate.live targets the unified Worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          EXPECTED_DOMAIN_SERVICE: gomate-production-preview
+        run: node scripts/production-domain.mjs assert
+      - name: Protected production smoke
+        id: smoke
+        env:
+          PRODUCTION_APP_URL: ${{ secrets.PRODUCTION_APP_URL }}
+        run: node scripts/smoke-protected-production.mjs
+
+  protected-observability-approval:
+    name: Protected cutover log evidence approval
+    needs: cutover-protected
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Record protected evidence IDs
+        env:
+          HEALTH_REQUEST_ID: ${{ needs.cutover-protected.outputs.health_request_id }}
+          BLOCKED_REQUEST_ID: ${{ needs.cutover-protected.outputs.blocked_request_id }}
+        run: |
+          test -n "$HEALTH_REQUEST_ID"
+          test -n "$BLOCKED_REQUEST_ID"
+          {
+            echo "### Protected production cutover evidence approved"
+            echo "- Health request: $HEALTH_REQUEST_ID"
+            echo "- Blocked mutation: $BLOCKED_REQUEST_ID"
+            echo "- Reviewer confirmed correlated structured logs contain no canary body or token."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  observe-protected:
+    name: Observe protected production for 30 minutes
+    needs: protected-observability-approval
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read-only protected observation
+        env:
+          PRODUCTION_APP_URL: https://gomate.live
+        run: node scripts/observe-production.mjs
+
+  open-writes:
+    name: Open production writes and run controlled canary
+    needs: observe-protected
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: production
+    env:
+      CLOUDFLARE_ENV: production
+      CANARY_EMAIL: stage-c-canary-${{ github.run_id }}@example.invalid
+    outputs:
+      signup_request_id: ${{ steps.canary.outputs.signup_request_id }}
+      signin_request_id: ${{ steps.canary.outputs.signin_request_id }}
+      mutation_request_id: ${{ steps.canary.outputs.mutation_request_id }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.0.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Build the reviewed production commit
+        run: |
+          pnpm i18n:build
+          pnpm --filter @gomate/frontend build
+          node scripts/prepare-worker-output.mjs
+      - name: Confirm protected unified Worker owns gomate.live
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          EXPECTED_DOMAIN_SERVICE: gomate-production-preview
+        run: node scripts/production-domain.mjs assert
+      - name: Prepare open custom-domain deployment
+        env:
+          PRODUCTION_APP_URL: ${{ secrets.PRODUCTION_APP_URL }}
+        run: node scripts/prepare-production-cutover.mjs --mode open
+      - name: Deploy open unified Worker
+        working-directory: frontend
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          PRODUCTION_APP_URL: ${{ secrets.PRODUCTION_APP_URL }}
+          SECRETS_FILE: ${{ runner.temp }}/gomate-production-secrets.json
+        run: |
+          node ../scripts/write-production-secrets.mjs
+          pnpm exec wrangler deploy --config dist/server/wrangler.json --secrets-file "$SECRETS_FILE"
+      - name: Remove ephemeral production secrets
+        if: always()
+        env:
+          RUNNER_TEMP: ${{ runner.temp }}
+          SECRETS_FILE: ${{ runner.temp }}/gomate-production-secrets.json
+        run: node scripts/remove-preview-secrets.mjs
+      - name: Controlled auth and mutation canary
+        id: canary
+        env:
+          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+          PRODUCTION_APP_URL: ${{ secrets.PRODUCTION_APP_URL }}
+        run: node scripts/production-canary.mjs
+      - name: Remove the exact canary account and prove cleanup
+        if: always()
+        working-directory: frontend
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CANARY_CLEANUP_SQL: ${{ runner.temp }}/stage-c-canary-cleanup.sql
+          CLEANUP_JSON: ${{ runner.temp }}/stage-c-canary-count.json
+        run: |
+          node ../scripts/write-canary-cleanup-sql.mjs
+          pnpm exec wrangler d1 execute DB --env production --remote --config wrangler.jsonc --file "$CANARY_CLEANUP_SQL"
+          pnpm exec wrangler d1 execute DB --env production --remote --config wrangler.jsonc --json --command "SELECT count(*) AS canary_count FROM users WHERE email = '$CANARY_EMAIL'" > "$CLEANUP_JSON"
+          node --input-type=module -e 'const payload=JSON.parse((await import("node:fs")).readFileSync(process.argv[1],"utf8")); if(payload?.[0]?.success!==true || payload[0].results?.[0]?.canary_count!==0) process.exit(1)' "$CLEANUP_JSON"
+
+  open-observability-approval:
+    name: Open canary log evidence approval
+    needs: open-writes
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Record open canary evidence IDs
+        env:
+          SIGNUP_REQUEST_ID: ${{ needs.open-writes.outputs.signup_request_id }}
+          SIGNIN_REQUEST_ID: ${{ needs.open-writes.outputs.signin_request_id }}
+          MUTATION_REQUEST_ID: ${{ needs.open-writes.outputs.mutation_request_id }}
+        run: |
+          test -n "$SIGNUP_REQUEST_ID"
+          test -n "$SIGNIN_REQUEST_ID"
+          test -n "$MUTATION_REQUEST_ID"
+          {
+            echo "### Open production canary evidence approved"
+            echo "- Sign-up request: $SIGNUP_REQUEST_ID"
+            echo "- Sign-in request: $SIGNIN_REQUEST_ID"
+            echo "- Profile mutation: $MUTATION_REQUEST_ID"
+            echo "- Reviewer confirmed structured logs and exact canary cleanup."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  observe-open:
+    name: Observe open production for 30 minutes
+    needs: open-observability-approval
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read-only open-write observation
+        env:
+          PRODUCTION_APP_URL: https://gomate.live
+        run: node scripts/observe-production.mjs
+      - name: Record completed rollout boundary
+        run: |
+          {
+            echo "### Unified Worker production rollout complete"
+            echo "- gomate.live serves gomate-production-preview."
+            echo "- WRITE_MODE is open after protected and open 30-minute observations."
+            echo "- Legacy Workers and storage remain retained for the mandatory seven-day window."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/rollback-production-cutover.yml
+++ b/.github/workflows/rollback-production-cutover.yml
@@ -1,0 +1,92 @@
+name: Roll back unified Worker production cutover
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: Type ROLLBACK_PRODUCTION to protect writes and restore gomate.live to gomate-frontend
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: unified-worker-production-cutover
+  cancel-in-progress: false
+
+jobs:
+  rollback:
+    name: Protect V2 writes and restore the legacy domain owner
+    if: inputs.confirm == 'ROLLBACK_PRODUCTION' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: production
+    env:
+      CLOUDFLARE_ENV: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.0.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Confirm unified Worker currently owns gomate.live
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          EXPECTED_DOMAIN_SERVICE: gomate-production-preview
+        run: node scripts/production-domain.mjs assert
+      - name: Build and prepare WRITE_MODE protected
+        env:
+          PRODUCTION_APP_URL: ${{ secrets.PRODUCTION_APP_URL }}
+        run: |
+          pnpm i18n:build
+          pnpm --filter @gomate/frontend build
+          node scripts/prepare-worker-output.mjs
+          node scripts/prepare-production-cutover.mjs --mode protected
+      - name: Deploy protected unified Worker before route rollback
+        working-directory: frontend
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          PRODUCTION_APP_URL: ${{ secrets.PRODUCTION_APP_URL }}
+          SECRETS_FILE: ${{ runner.temp }}/gomate-production-secrets.json
+        run: |
+          node ../scripts/write-production-secrets.mjs
+          pnpm exec wrangler deploy --config dist/server/wrangler.json --secrets-file "$SECRETS_FILE"
+      - name: Remove ephemeral production secrets
+        if: always()
+        env:
+          RUNNER_TEMP: ${{ runner.temp }}
+          SECRETS_FILE: ${{ runner.temp }}/gomate-production-secrets.json
+        run: node scripts/remove-preview-secrets.mjs
+      - name: Confirm writes are protected before route rollback
+        env:
+          PRODUCTION_APP_URL: ${{ secrets.PRODUCTION_APP_URL }}
+        run: node scripts/smoke-protected-production.mjs
+      - name: Restore gomate.live to the legacy Worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          TARGET_DOMAIN_SERVICE: gomate-frontend
+        run: node scripts/production-domain.mjs attach
+      - name: Prove rollback domain ownership
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          EXPECTED_DOMAIN_SERVICE: gomate-frontend
+        run: node scripts/production-domain.mjs assert
+      - name: Record rollback evidence
+        run: |
+          {
+            echo "### Production route rolled back"
+            echo "- New V2 Worker was first restored to WRITE_MODE protected."
+            echo "- gomate.live was reattached to gomate-frontend."
+            echo "- No D1, KV, R2, Worker, or secret resource was deleted."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/prod-change-policy.md
+++ b/docs/prod-change-policy.md
@@ -90,6 +90,19 @@ route 变更必须是 preview 验证后的独立、受保护操作。切换前�
 `https://gomate.live`；切换后再把 `WRITE_MODE` 改为 `open`。这两项不得随首次
 preview 部署自动发生。
 
+从 `main` 手动运行 `Cut over unified Worker production` 并输入 `CUTOVER_PRODUCTION`。
+流水线先证明 `gomate.live` 仍属于旧 `gomate-frontend`，再用 environment secret
+`PRODUCTION_APP_URL=https://gomate.live` 将同一 unified Worker 以 `WRITE_MODE=protected`
+挂为 custom domain。受保护读/SSR/写阻断与 Workers Logs 证据通过后，连续 30 分钟只读观察；
+第二次 production approval 后才部署 `WRITE_MODE=open`，执行一次可清理的注册、邮箱确认、
+登录、session、资料写入、退出 canary，随后按精确 canary email 删除测试账号并证明计数为 0。
+开放写入的日志证据审批后再连续观察 30 分钟。任一阶段失败都停止后续 job。
+
+回滚只允许从 `main` 手动运行 `Roll back unified Worker production cutover` 并输入
+`ROLLBACK_PRODUCTION`：先把 unified Worker 恢复为 `WRITE_MODE=protected`，确认 503 写阻断，
+再通过 Cloudflare Workers custom-domain API 把 `gomate.live` 精确重新附加到
+`gomate-frontend`。回滚不删除 V2 D1、KV、R2、Worker、版本或 secrets。
+
 ## 4. 回滚
 
 - 应用回滚：核实 Worker deployment/version 对应的 commit 后，回滚到已验证版本。

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "i18n:gen-types": "node scripts/gen-i18n-types.mjs",
     "i18n:build": "tsx scripts/build-locales.ts",
     "check:legacy-removal": "node scripts/check-legacy-removal.mjs",
-    "test:delivery": "node --test scripts/check-legacy-removal.test.mjs scripts/deployment-guards.test.mjs scripts/promote-admin.test.mjs scripts/region-bootstrap-contract.test.mjs scripts/reset-local-db.test.mjs",
+    "test:delivery": "node --test scripts/check-legacy-removal.test.mjs scripts/deployment-guards.test.mjs scripts/production-cutover.test.mjs scripts/promote-admin.test.mjs scripts/region-bootstrap-contract.test.mjs scripts/reset-local-db.test.mjs",
     "prepare": "husky",
     "dev:wt": "node scripts/init-worktree.mjs && node scripts/start-worktree.mjs",
     "init:worktree": "node scripts/init-worktree.mjs"

--- a/scripts/check-legacy-removal.mjs
+++ b/scripts/check-legacy-removal.mjs
@@ -110,6 +110,22 @@ const operationalForbiddenContent = [
   ["legacy D1 name", /\bgomate-db(?!-v2)\b/],
 ];
 
+const approvedLegacyWorkerRollbackFiles = new Set([
+  ".github/workflows/cutover-production.yml",
+  ".github/workflows/rollback-production-cutover.yml",
+  "scripts/production-cutover.test.mjs",
+  "scripts/production-domain.mjs",
+]);
+
+function isApprovedLegacyWorkerRollbackReference(relativePath, label, line) {
+  return (
+    label === "legacy Worker name" &&
+    approvedLegacyWorkerRollbackFiles.has(relativePath) &&
+    /\bgomate-frontend\b/u.test(line) &&
+    !/\bgomate-api\b/u.test(line)
+  );
+}
+
 function isOperationalFile(relativePath) {
   return (
     relativePath === "package.json" ||
@@ -191,7 +207,10 @@ for (const relativePath of textFiles) {
     }
     if (isOperationalFile(relativePath)) {
       for (const [label, pattern] of operationalForbiddenContent) {
-        if (pattern.test(line)) {
+        if (
+          pattern.test(line) &&
+          !isApprovedLegacyWorkerRollbackReference(relativePath, label, line)
+        ) {
           violations.push(`${relativePath}:${index + 1}: ${label}`);
         }
       }

--- a/scripts/check-legacy-removal.test.mjs
+++ b/scripts/check-legacy-removal.test.mjs
@@ -75,3 +75,43 @@ test("rejects a transpiled Worker source sibling", () => {
   assert.equal(result.status, 1);
   assert.match(result.stderr, /frontend\/src\/worker\.js: removed path still exists/u);
 });
+
+test("allows the exact legacy frontend Worker only in reviewed rollback files", () => {
+  const root = fixture();
+  const workflowDirectory = path.join(root, ".github", "workflows");
+  const scriptsDirectory = path.join(root, "scripts");
+  mkdirSync(workflowDirectory, { recursive: true });
+  mkdirSync(scriptsDirectory, { recursive: true });
+  writeFileSync(
+    path.join(workflowDirectory, "rollback-production-cutover.yml"),
+    "TARGET_DOMAIN_SERVICE: gomate-frontend\n",
+  );
+  writeFileSync(
+    path.join(scriptsDirectory, "production-domain.mjs"),
+    'const oldWorker = "gomate-frontend";\n',
+  );
+  const result = run(root);
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("still rejects legacy Worker names outside or beyond the rollback allowlist", () => {
+  const outsideRoot = fixture();
+  mkdirSync(path.join(outsideRoot, "scripts"), { recursive: true });
+  writeFileSync(
+    path.join(outsideRoot, "scripts", "unreviewed.mjs"),
+    'const oldWorker = "gomate-frontend";\n',
+  );
+  const outside = run(outsideRoot);
+  assert.equal(outside.status, 1);
+  assert.match(outside.stderr, /legacy Worker name/u);
+
+  const apiRoot = fixture();
+  mkdirSync(path.join(apiRoot, "scripts"), { recursive: true });
+  writeFileSync(
+    path.join(apiRoot, "scripts", "production-domain.mjs"),
+    'const forbiddenWorker = "gomate-api";\n',
+  );
+  const api = run(apiRoot);
+  assert.equal(api.status, 1);
+  assert.match(api.stderr, /legacy Worker name/u);
+});

--- a/scripts/deployment-guards.test.mjs
+++ b/scripts/deployment-guards.test.mjs
@@ -112,13 +112,13 @@ function isProductionLoggerSource(filePath) {
 }
 
 function isLoggerModuleSpecifier(node) {
-  return (
-    ts.isStringLiteral(node) && LOGGER_MODULE_PATTERN.test(node.text)
-  );
+  return ts.isStringLiteral(node) && LOGGER_MODULE_PATTERN.test(node.text);
 }
 
 function sourceLine(sourceFile, node) {
-  return sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+  return (
+    sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1
+  );
 }
 
 function loggerViolation(sourceFile, node, message) {
@@ -149,7 +149,9 @@ function isNonReferencePropertyName(node) {
 }
 
 function analyzeLoggerSource(fileName, source) {
-  const scriptKind = fileName.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+  const scriptKind = fileName.endsWith(".tsx")
+    ? ts.ScriptKind.TSX
+    : ts.ScriptKind.TS;
   const sourceFile = ts.createSourceFile(
     fileName,
     source,
@@ -252,7 +254,10 @@ function analyzeLoggerSource(fileName, source) {
         );
         return;
       }
-      if (!ts.isPropertyAccessExpression(access) || access.expression !== node) {
+      if (
+        !ts.isPropertyAccessExpression(access) ||
+        access.expression !== node
+      ) {
         violations.push(
           loggerViolation(
             sourceFile,
@@ -424,7 +429,9 @@ test("validates the exact protected preview invariants", async (t) => {
     const { builtConfigPath, configPath, directory } = validConfigPaths();
     t.after(() => rmSync(directory, { recursive: true, force: true }));
     assert.doesNotThrow(() => validatePreviewDeploy({ configPath }));
-    assert.doesNotThrow(() => validateBuiltPreview({ configPath: builtConfigPath }));
+    assert.doesNotThrow(() =>
+      validateBuiltPreview({ configPath: builtConfigPath }),
+    );
   });
 });
 
@@ -496,7 +503,8 @@ test("logger event AST guard rejects indirect and dynamic call shapes", () => {
     },
     {
       name: "aliased import",
-      source: 'import { logger as log } from "../lib/logger";\nlog.error("stable_event");',
+      source:
+        'import { logger as log } from "../lib/logger";\nlog.error("stable_event");',
     },
     {
       name: "template event",
@@ -509,7 +517,10 @@ test("logger event AST guard rejects indirect and dynamic call shapes", () => {
   ];
 
   for (const fixture of invalidFixtures) {
-    const result = analyzeLoggerSource(`fixture-${fixture.name}.tsx`, fixture.source);
+    const result = analyzeLoggerSource(
+      `fixture-${fixture.name}.tsx`,
+      fixture.source,
+    );
     assert.notDeepEqual(result.violations, [], fixture.name);
   }
 });
@@ -537,8 +548,7 @@ test("fails closed when a production route targets the preview Worker", async ()
       if (url.pathname.endsWith("/workers/subdomain")) {
         result = { subdomain: "example" };
       } else if (
-        url.pathname ===
-        "/client/v4/zones/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        url.pathname === "/client/v4/zones/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
       ) {
         result = { name: "gomate.live" };
       } else if (url.pathname === "/client/v4/zones") {
@@ -558,9 +568,7 @@ test("fails closed when a production route targets the preview Worker", async ()
       return Response.json({
         success: true,
         result,
-        ...(Array.isArray(result)
-          ? { result_info: { total_pages: 1 } }
-          : {}),
+        ...(Array.isArray(result) ? { result_info: { total_pages: 1 } } : {}),
       });
     };
     try {
@@ -579,9 +587,12 @@ test("protected preview smoke requires correlated request IDs", async () => {
   const fetchImpl = async (input, init) => {
     const url = new URL(input);
     if (url.pathname === "/api/health") {
-      return Response.json({ status: "ok" }, {
-        headers: { "x-request-id": requestId },
-      });
+      return Response.json(
+        { status: "ok" },
+        {
+          headers: { "x-request-id": requestId },
+        },
+      );
     }
     if (url.pathname === "/") {
       return new Response("<!doctype html>", {
@@ -635,7 +646,8 @@ test("protected preview smoke waits through transient workers.dev propagation", 
     if (url.pathname === "/api/health") {
       healthAttempts += 1;
       if (healthAttempts === 1) throw new Error("network not ready");
-      if (healthAttempts === 2) return new Response("not ready", { status: 523 });
+      if (healthAttempts === 2)
+        return new Response("not ready", { status: 523 });
       return Response.json(
         { status: "ok" },
         { headers: { "x-request-id": requestId } },
@@ -789,9 +801,18 @@ test("deploy workflow blocks completion on post-smoke observability approval", (
   );
 
   assert.match(workflow, /id: preview_smoke/u);
-  assert.match(workflow, /health_request_id:.*preview_smoke\.outputs\.health_request_id/u);
-  assert.match(workflow, /blocked_request_id:.*preview_smoke\.outputs\.blocked_request_id/u);
-  assert.match(workflow, /observability-approval:[\s\S]*needs: deploy-preview/u);
+  assert.match(
+    workflow,
+    /health_request_id:.*preview_smoke\.outputs\.health_request_id/u,
+  );
+  assert.match(
+    workflow,
+    /blocked_request_id:.*preview_smoke\.outputs\.blocked_request_id/u,
+  );
+  assert.match(
+    workflow,
+    /observability-approval:[\s\S]*needs: deploy-preview/u,
+  );
   assert.match(
     workflow,
     /observability-approval:[\s\S]*environment: production[\s\S]*Require request-correlation evidence/u,
@@ -809,8 +830,7 @@ test("fails closed when the preview Worker targets another account zone", async 
       if (url.pathname.endsWith("/workers/subdomain")) {
         result = { subdomain: "example" };
       } else if (
-        url.pathname ===
-        "/client/v4/zones/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        url.pathname === "/client/v4/zones/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
       ) {
         result = { name: "gomate.live" };
       } else if (url.pathname === "/client/v4/zones") {
@@ -840,9 +860,7 @@ test("fails closed when the preview Worker targets another account zone", async 
       return Response.json({
         success: true,
         result,
-        ...(Array.isArray(result)
-          ? { result_info: { total_pages: 1 } }
-          : {}),
+        ...(Array.isArray(result) ? { result_info: { total_pages: 1 } } : {}),
       });
     };
     try {
@@ -873,7 +891,9 @@ test("writes a private ephemeral Wrangler secrets file", async (t) => {
 });
 
 test("cleanup script removes only the exact runner temp secrets file", (t) => {
-  const directory = mkdtempSync(path.join(os.tmpdir(), "gomate-secrets-cleanup-"));
+  const directory = mkdtempSync(
+    path.join(os.tmpdir(), "gomate-secrets-cleanup-"),
+  );
   t.after(() => rmSync(directory, { recursive: true, force: true }));
   const outputPath = path.join(directory, "gomate-worker-secrets.json");
   writeFileSync(outputPath, "{}\n");
@@ -881,9 +901,24 @@ test("cleanup script removes only the exact runner temp secrets file", (t) => {
   assert.equal(result.status, 0, result.stderr);
   assert.equal(existsSync(outputPath), false);
 
-  const refused = spawnCleanup(directory, path.join(directory, "different.json"));
+  const refused = spawnCleanup(
+    directory,
+    path.join(directory, "different.json"),
+  );
   assert.equal(refused.status, 1);
   assert.match(refused.stderr, /Refusing to remove/u);
+});
+
+test("cleanup script accepts the exact production runner temp secrets file", (t) => {
+  const directory = mkdtempSync(
+    path.join(os.tmpdir(), "gomate-production-secret-"),
+  );
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const outputPath = path.join(directory, "gomate-production-secrets.json");
+  writeFileSync(outputPath, "{}\n", { mode: 0o600 });
+  const result = spawnCleanup(directory, outputPath);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(existsSync(outputPath), false);
 });
 
 function spawnCleanup(runnerTemp, secretsFile) {
@@ -963,7 +998,9 @@ test("protected binding provisioning workflow is narrowly scoped", () => {
     [...workflow.matchAll(/wrangler\s+d1\s+create\s+gomate-db-v2\b/gu)].length,
     1,
   );
-  for (const command of workflow.matchAll(/wrangler\s+d1\s+(?:list|create)[^\n]*/gu)) {
+  for (const command of workflow.matchAll(
+    /wrangler\s+d1\s+(?:list|create)[^\n]*/gu,
+  )) {
     assert.match(command[0], /--env\s+production/u);
   }
   assert.match(
@@ -1012,7 +1049,10 @@ test("protected binding provisioning workflow is narrowly scoped", () => {
     workflow,
     /Resolve and validate binding IDs[\s\S]*if:\s*always\(\)/u,
   );
-  assert.match(workflow, /Record reviewed resource IDs[\s\S]*if:\s*always\(\)/u);
+  assert.match(
+    workflow,
+    /Record reviewed resource IDs[\s\S]*if:\s*always\(\)/u,
+  );
   assert.match(workflow, /Upload binding ID evidence[\s\S]*if:\s*always\(\)/u);
   assert.match(workflow, /PROVISION_STATUS/u);
 });

--- a/scripts/observe-production.mjs
+++ b/scripts/observe-production.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { validateProductionOrigin } from "./prepare-production-cutover.mjs";
+
+const REQUEST_ID = /^[a-z0-9-]{36,96}$/iu;
+const wait = (delay) => new Promise((resolve) => setTimeout(resolve, delay));
+
+export async function observeProduction({
+  baseUrl = process.env.PRODUCTION_APP_URL,
+  durationMs = 1_800_000,
+  intervalMs = 60_000,
+  fetchImpl = fetch,
+  nowImpl = Date.now,
+  waitImpl = wait,
+} = {}) {
+  baseUrl = validateProductionOrigin(baseUrl ?? "");
+  if (!Number.isInteger(durationMs) || durationMs < 0) {
+    throw new Error("durationMs must be a non-negative integer");
+  }
+  if (!Number.isInteger(intervalMs) || intervalMs <= 0) {
+    throw new Error("intervalMs must be a positive integer");
+  }
+  const deadline = nowImpl() + durationMs;
+  let samples = 0;
+  let firstRequestId;
+  let lastRequestId;
+  while (true) {
+    for (const endpoint of [
+      "/api/health",
+      "/api/regions?countryCode=CN&level=city&serviceEnabled=true",
+    ]) {
+      const response = await fetchImpl(new URL(endpoint, baseUrl), {
+        signal: AbortSignal.timeout(15_000),
+      });
+      const requestId = response.headers.get("x-request-id")?.trim();
+      const contentType = response.headers.get("content-type") ?? "";
+      const payload = await response.json().catch(() => null);
+      if (
+        !response.ok ||
+        !contentType.includes("application/json") ||
+        !requestId ||
+        !REQUEST_ID.test(requestId) ||
+        payload?.success !== true
+      ) {
+        throw new Error(
+          `Observation failed for ${endpoint} (${response.status})`,
+        );
+      }
+      if (endpoint.startsWith("/api/regions")) {
+        const regions = payload.regions ?? payload.data ?? [];
+        if (
+          !Array.isArray(regions) ||
+          !regions.some((region) => region.id === "region-cn-shenzhen")
+        ) {
+          throw new Error(
+            "Production Region observation did not return Shenzhen",
+          );
+        }
+      }
+      firstRequestId ??= requestId;
+      lastRequestId = requestId;
+    }
+    samples += 1;
+    const remaining = deadline - nowImpl();
+    if (remaining <= 0) break;
+    await waitImpl(Math.min(intervalMs, remaining));
+  }
+  return { firstRequestId, lastRequestId, samples };
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+) {
+  observeProduction()
+    .then((result) => {
+      if (process.env.GITHUB_OUTPUT) {
+        appendFileSync(
+          process.env.GITHUB_OUTPUT,
+          `first_request_id=${result.firstRequestId}\nlast_request_id=${result.lastRequestId}\nsamples=${result.samples}\n`,
+        );
+      }
+      console.log(
+        `Production observation passed with ${result.samples} samples.`,
+      );
+    })
+    .catch((error) => {
+      console.error(`[production-observation] ${error.message}`);
+      process.exit(1);
+    });
+}

--- a/scripts/prepare-production-cutover.mjs
+++ b/scripts/prepare-production-cutover.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const D1_ID = "befa3d89-6551-4a25-8a1c-670efe62a315";
+const KV_ID = "f9904d1fa72140c18067e07d541ca92b";
+
+export function validateProductionOrigin(value) {
+  const url = new URL(value);
+  if (
+    url.href !== "https://gomate.live/" ||
+    url.username ||
+    url.password ||
+    url.port ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error("Production origin must be exactly https://gomate.live");
+  }
+  return "https://gomate.live";
+}
+
+export function prepareProductionCutover({ configPath, mode }) {
+  if (mode !== "protected" && mode !== "open") {
+    throw new Error("Cutover mode must be protected or open");
+  }
+  const config = JSON.parse(readFileSync(configPath, "utf8"));
+  const database = config.d1_databases?.find((item) => item.binding === "DB");
+  const cache = config.kv_namespaces?.find(
+    (item) => item.binding === "CACHE_KV",
+  );
+  const bucket = config.r2_buckets?.find((item) => item.binding === "R2");
+  if (
+    config.targetEnvironment !== "production" ||
+    config.name !== "gomate-production-preview" ||
+    config.main !== "entry.mjs" ||
+    config.no_bundle !== true ||
+    config.vars?.WRITE_MODE !== "protected" ||
+    database?.database_name !== "gomate-db-v2" ||
+    database?.database_id !== D1_ID ||
+    cache?.id !== KV_ID ||
+    bucket?.bucket_name !== "gomate"
+  ) {
+    throw new Error(
+      "Built Worker does not match the reviewed production bindings",
+    );
+  }
+  if ("route" in config || "routes" in config) {
+    throw new Error(
+      "Built Worker must be route-free before the protected cutover step",
+    );
+  }
+  if (Object.hasOwn(config.vars ?? {}, "APP_URL")) {
+    throw new Error("APP_URL must remain an ephemeral Wrangler secret");
+  }
+  validateProductionOrigin(
+    process.env.PRODUCTION_APP_URL ?? "https://gomate.live",
+  );
+  config.vars.WRITE_MODE = mode;
+  config.routes = [{ pattern: "gomate.live", custom_domain: true }];
+  writeFileSync(configPath, `${JSON.stringify(config)}\n`, { mode: 0o600 });
+  console.log(`Prepared production Worker in ${mode} mode for gomate.live.`);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+) {
+  const modeFlag = process.argv.indexOf("--mode");
+  const mode = modeFlag >= 0 ? process.argv[modeFlag + 1] : undefined;
+  const configPath = path.resolve(
+    process.env.BUILT_WRANGLER_CONFIG ?? "frontend/dist/server/wrangler.json",
+  );
+  try {
+    prepareProductionCutover({ configPath, mode });
+  } catch (error) {
+    console.error(`[production-cutover-config] ${error.message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/production-canary.mjs
+++ b/scripts/production-canary.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { createEmailVerificationToken } from "better-auth/api";
+import { validateProductionOrigin } from "./prepare-production-cutover.mjs";
+
+const REQUEST_ID = /^[a-z0-9-]{36,96}$/iu;
+const CANARY_EMAIL = /^stage-c-canary-[0-9]+@example\.invalid$/u;
+
+function requestId(response, label) {
+  const value = response.headers.get("x-request-id")?.trim();
+  if (!value || !REQUEST_ID.test(value)) {
+    throw new Error(`${label} response is missing X-Request-ID`);
+  }
+  return value;
+}
+
+async function jsonRequest(fetchImpl, baseUrl, pathName, body, cookie) {
+  const response = await fetchImpl(new URL(`/api${pathName}`, baseUrl), {
+    method: body === undefined ? "GET" : "POST",
+    headers: {
+      accept: "application/json",
+      ...(body === undefined ? {} : { "content-type": "application/json" }),
+      origin: baseUrl,
+      ...(cookie ? { cookie } : {}),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+    redirect: "manual",
+    signal: AbortSignal.timeout(20_000),
+  });
+  const payload = await response.json().catch(() => null);
+  return { response, payload };
+}
+
+export async function runProductionCanary({
+  baseUrl = process.env.PRODUCTION_APP_URL,
+  email = process.env.CANARY_EMAIL,
+  authSecret = process.env.BETTER_AUTH_SECRET,
+  fetchImpl = fetch,
+  createVerificationTokenImpl = createEmailVerificationToken,
+} = {}) {
+  baseUrl = validateProductionOrigin(baseUrl ?? "");
+  if (!CANARY_EMAIL.test(email ?? "")) {
+    throw new Error(
+      "CANARY_EMAIL does not match the controlled Stage C pattern",
+    );
+  }
+  if (!authSecret || authSecret.length < 32) {
+    throw new Error("BETTER_AUTH_SECRET must contain at least 32 characters");
+  }
+  const password = `Gm-${crypto.randomUUID()}-9a`;
+  const signUp = await jsonRequest(fetchImpl, baseUrl, "/auth/sign-up/email", {
+    email,
+    password,
+    name: "Stage C Canary",
+  });
+  if (!signUp.response.ok || signUp.response.headers.has("set-cookie")) {
+    throw new Error(`Canary sign-up failed (${signUp.response.status})`);
+  }
+  const signUpRequestId = requestId(signUp.response, "Canary sign-up");
+
+  const verificationToken = await createVerificationTokenImpl(
+    authSecret,
+    email,
+    undefined,
+    60 * 60,
+  );
+  const confirmation = await jsonRequest(
+    fetchImpl,
+    baseUrl,
+    "/auth/confirm-email",
+    {
+      token: verificationToken,
+    },
+  );
+  if (!confirmation.response.ok || confirmation.payload?.success !== true) {
+    throw new Error(
+      `Canary email confirmation failed (${confirmation.response.status})`,
+    );
+  }
+
+  const signIn = await jsonRequest(fetchImpl, baseUrl, "/auth/sign-in/email", {
+    email,
+    password,
+  });
+  const setCookie = signIn.response.headers.get("set-cookie");
+  if (!signIn.response.ok || !setCookie || signIn.payload?.token) {
+    throw new Error(`Canary sign-in failed (${signIn.response.status})`);
+  }
+  const signInRequestId = requestId(signIn.response, "Canary sign-in");
+  const cookie = setCookie.split(";", 1)[0];
+
+  const session = await jsonRequest(
+    fetchImpl,
+    baseUrl,
+    "/auth/get-session",
+    undefined,
+    cookie,
+  );
+  if (!session.response.ok || !session.payload?.user?.id) {
+    throw new Error(`Canary session check failed (${session.response.status})`);
+  }
+
+  const profile = await fetchImpl(new URL("/api/users/me", baseUrl), {
+    method: "PATCH",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+      cookie,
+      origin: baseUrl,
+    },
+    body: JSON.stringify({ nickname: "Stage C Canary Verified" }),
+    signal: AbortSignal.timeout(20_000),
+  });
+  const profilePayload = await profile.json().catch(() => null);
+  if (
+    !profile.ok ||
+    profilePayload?.user?.nickname !== "Stage C Canary Verified"
+  ) {
+    throw new Error(`Canary profile mutation failed (${profile.status})`);
+  }
+  const mutationRequestId = requestId(profile, "Canary profile mutation");
+
+  const signOut = await jsonRequest(
+    fetchImpl,
+    baseUrl,
+    "/auth/sign-out",
+    {},
+    cookie,
+  );
+  if (!signOut.response.ok) {
+    throw new Error(`Canary sign-out failed (${signOut.response.status})`);
+  }
+  const signedOutSession = await jsonRequest(
+    fetchImpl,
+    baseUrl,
+    "/auth/get-session",
+    undefined,
+    cookie,
+  );
+  if (!signedOutSession.response.ok || signedOutSession.payload?.user) {
+    throw new Error("Canary session remained active after sign-out");
+  }
+
+  return { signUpRequestId, signInRequestId, mutationRequestId };
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+) {
+  runProductionCanary()
+    .then((result) => {
+      if (process.env.GITHUB_OUTPUT) {
+        appendFileSync(
+          process.env.GITHUB_OUTPUT,
+          `signup_request_id=${result.signUpRequestId}\nsignin_request_id=${result.signInRequestId}\nmutation_request_id=${result.mutationRequestId}\n`,
+        );
+      }
+      console.log(
+        "Production auth, session, profile mutation, and sign-out canary passed.",
+      );
+    })
+    .catch((error) => {
+      console.error(`[production-canary] ${error.message}`);
+      process.exit(1);
+    });
+}

--- a/scripts/production-cutover.test.mjs
+++ b/scripts/production-cutover.test.mjs
@@ -1,0 +1,259 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  prepareProductionCutover,
+  validateProductionOrigin,
+} from "./prepare-production-cutover.mjs";
+import {
+  assertProductionDomain,
+  attachProductionDomain,
+} from "./production-domain.mjs";
+import { observeProduction } from "./observe-production.mjs";
+import { runProductionCanary } from "./production-canary.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function builtConfig() {
+  return {
+    targetEnvironment: "production",
+    name: "gomate-production-preview",
+    main: "entry.mjs",
+    no_bundle: true,
+    workers_dev: true,
+    preview_urls: false,
+    vars: { WRITE_MODE: "protected" },
+    d1_databases: [
+      {
+        binding: "DB",
+        database_name: "gomate-db-v2",
+        database_id: "befa3d89-6551-4a25-8a1c-670efe62a315",
+      },
+    ],
+    kv_namespaces: [
+      { binding: "CACHE_KV", id: "f9904d1fa72140c18067e07d541ca92b" },
+    ],
+    r2_buckets: [{ binding: "R2", bucket_name: "gomate" }],
+    secrets: { required: ["BETTER_AUTH_SECRET", "RESEND_API_KEY", "APP_URL"] },
+  };
+}
+
+test("cutover config adds only the exact custom domain and reviewed write mode", () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "gomate-cutover-"));
+  try {
+    const configPath = path.join(directory, "wrangler.json");
+    writeFileSync(configPath, JSON.stringify(builtConfig()));
+    prepareProductionCutover({ configPath, mode: "protected" });
+    let config = JSON.parse(readFileSync(configPath, "utf8"));
+    assert.deepEqual(config.routes, [
+      { pattern: "gomate.live", custom_domain: true },
+    ]);
+    assert.equal(config.vars.WRITE_MODE, "protected");
+    assert.equal(Object.hasOwn(config.vars, "APP_URL"), false);
+
+    writeFileSync(configPath, JSON.stringify(builtConfig()));
+    prepareProductionCutover({ configPath, mode: "open" });
+    config = JSON.parse(readFileSync(configPath, "utf8"));
+    assert.equal(config.vars.WRITE_MODE, "open");
+    assert.throws(
+      () => prepareProductionCutover({ configPath, mode: "invalid" }),
+      /protected or open/u,
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("production origin is exact and fragment-free", () => {
+  assert.equal(
+    validateProductionOrigin("https://gomate.live"),
+    "https://gomate.live",
+  );
+  for (const value of [
+    "http://gomate.live",
+    "https://www.gomate.live",
+    "https://gomate.live/path",
+    "https://gomate.live/?token=bad",
+  ]) {
+    assert.throws(() => validateProductionOrigin(value), /exactly https/u);
+  }
+});
+
+test("domain audit requires one exact hostname, zone, and Worker", async () => {
+  const fetchImpl = async () =>
+    new Response(
+      JSON.stringify({
+        success: true,
+        result: [
+          {
+            id: "domain-id",
+            hostname: "gomate.live",
+            service: "gomate-frontend",
+            zone_id: "0b714cd4257332034b3c4c0c099feb9e",
+          },
+        ],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  await assert.doesNotReject(() =>
+    assertProductionDomain({
+      accountId: "e3afbb613458022947cd9dc9f5bd6334",
+      apiToken: "test-token",
+      expectedService: "gomate-frontend",
+      fetchImpl,
+    }),
+  );
+  await assert.rejects(
+    () =>
+      assertProductionDomain({
+        accountId: "e3afbb613458022947cd9dc9f5bd6334",
+        apiToken: "test-token",
+        expectedService: "gomate-production-preview",
+        fetchImpl,
+      }),
+    /expected Worker/u,
+  );
+});
+
+test("rollback reattaches only the exact hostname, zone, and approved Worker", async () => {
+  let request;
+  await attachProductionDomain({
+    accountId: "e3afbb613458022947cd9dc9f5bd6334",
+    apiToken: "test-token",
+    service: "gomate-frontend",
+    fetchImpl: async (url, init) => {
+      request = { url: String(url), init };
+      return new Response(
+        JSON.stringify({
+          success: true,
+          result: {
+            hostname: "gomate.live",
+            service: "gomate-frontend",
+            zone_id: "0b714cd4257332034b3c4c0c099feb9e",
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    },
+  });
+  assert.equal(request.init.method, "PUT");
+  assert.deepEqual(JSON.parse(request.init.body), {
+    hostname: "gomate.live",
+    service: "gomate-frontend",
+    zone_id: "0b714cd4257332034b3c4c0c099feb9e",
+  });
+});
+
+test("production observation checks health and Region without writes", async () => {
+  const calls = [];
+  let now = 0;
+  const result = await observeProduction({
+    baseUrl: "https://gomate.live",
+    durationMs: 120,
+    intervalMs: 60,
+    nowImpl: () => now,
+    waitImpl: async (delay) => {
+      now += delay;
+    },
+    fetchImpl: async (url) => {
+      calls.push(String(url));
+      const isHealth = String(url).includes("/api/health");
+      return new Response(
+        JSON.stringify(
+          isHealth
+            ? { success: true }
+            : { success: true, regions: [{ id: "region-cn-shenzhen" }] },
+        ),
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "x-request-id": `00000000-0000-4000-8000-00000000000${calls.length}`,
+          },
+        },
+      );
+    },
+  });
+  assert.equal(result.samples, 3);
+  assert.equal(calls.length, 6);
+  assert.ok(
+    calls.every(
+      (url) => !url.includes("auth/sign") && !url.includes("users/me"),
+    ),
+  );
+});
+
+test("production canary covers auth, session, mutation, and sign-out without exposing tokens", async () => {
+  const calls = [];
+  const payloads = [
+    [{ success: true }, { "set-cookie": null }],
+    [{ success: true }, {}],
+    [
+      { user: { id: "user-canary" } },
+      { "set-cookie": "session=safe; HttpOnly" },
+    ],
+    [{ user: { id: "user-canary" } }, {}],
+    [{ success: true, user: { nickname: "Stage C Canary Verified" } }, {}],
+    [{ success: true }, {}],
+    [null, {}],
+  ];
+  const result = await runProductionCanary({
+    baseUrl: "https://gomate.live",
+    email: "stage-c-canary-123@example.invalid",
+    authSecret: "test-auth-secret-at-least-32-characters-long",
+    createVerificationTokenImpl: async () => "private-token",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      const [payload, extraHeaders] = payloads[calls.length - 1];
+      const headers = new Headers({
+        "content-type": "application/json",
+        "x-request-id": `10000000-0000-4000-8000-00000000000${calls.length}`,
+      });
+      if (extraHeaders["set-cookie"]) {
+        headers.set("set-cookie", extraHeaders["set-cookie"]);
+      }
+      return new Response(payload === null ? "null" : JSON.stringify(payload), {
+        status: 200,
+        headers,
+      });
+    },
+  });
+  assert.equal(calls.length, 7);
+  assert.match(calls[4].url, /\/api\/users\/me$/u);
+  assert.equal(calls[4].init.method, "PATCH");
+  assert.ok(
+    calls.slice(3).every(({ init }) => init.headers.cookie === "session=safe"),
+  );
+  assert.ok(
+    Object.values(result).every((value) => !value.includes("private-token")),
+  );
+});
+
+test("cutover and rollback workflows are protected and narrowly scoped", () => {
+  const cutover = readFileSync(
+    path.join(root, ".github/workflows/cutover-production.yml"),
+    "utf8",
+  );
+  const rollback = readFileSync(
+    path.join(root, ".github/workflows/rollback-production-cutover.yml"),
+    "utf8",
+  );
+  assert.match(cutover, /CUTOVER_PRODUCTION/u);
+  assert.match(cutover, /github\.ref\s*==\s*'refs\/heads\/main'/u);
+  assert.match(cutover, /environment:\s*production/gu);
+  assert.match(cutover, /--mode protected[\s\S]*--mode open/iu);
+  assert.match(cutover, /gomate\.live/u);
+  assert.match(cutover, /observe-production\.mjs/u);
+  assert.match(cutover, /production-canary\.mjs/u);
+  assert.doesNotMatch(
+    cutover,
+    /migrations apply|seed\.sql|wrangler\s+r2|wrangler\s+kv/iu,
+  );
+  assert.match(rollback, /ROLLBACK_PRODUCTION/u);
+  assert.match(rollback, /gomate-frontend/u);
+  assert.match(rollback, /mode=protected|--mode protected/u);
+  assert.doesNotMatch(rollback, /DELETE FROM|wrangler\s+r2|wrangler\s+kv/iu);
+});

--- a/scripts/production-domain.mjs
+++ b/scripts/production-domain.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const API_ROOT = "https://api.cloudflare.com/client/v4";
+const ZONE_ID = "0b714cd4257332034b3c4c0c099feb9e";
+const ALLOWED_SERVICES = new Set([
+  "gomate-frontend",
+  "gomate-production-preview",
+]);
+
+function required(value, label) {
+  const result = value?.trim();
+  if (!result) throw new Error(`${label} is required`);
+  return result;
+}
+
+async function cloudflareRequest({ accountId, apiToken, fetchImpl, init }) {
+  const response = await fetchImpl(
+    `${API_ROOT}/accounts/${encodeURIComponent(accountId)}/workers/domains`,
+    {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        ...(init?.body ? { "content-type": "application/json" } : {}),
+      },
+    },
+  );
+  const payload = await response.json().catch(() => null);
+  if (!response.ok || payload?.success !== true) {
+    throw new Error(
+      `Cloudflare custom-domain request failed (${response.status})`,
+    );
+  }
+  return payload.result;
+}
+
+export async function assertProductionDomain({
+  accountId = process.env.CLOUDFLARE_ACCOUNT_ID,
+  apiToken = process.env.CLOUDFLARE_API_TOKEN,
+  expectedService = process.env.EXPECTED_DOMAIN_SERVICE,
+  fetchImpl = fetch,
+} = {}) {
+  accountId = required(accountId, "CLOUDFLARE_ACCOUNT_ID");
+  apiToken = required(apiToken, "CLOUDFLARE_API_TOKEN");
+  expectedService = required(expectedService, "EXPECTED_DOMAIN_SERVICE");
+  if (!ALLOWED_SERVICES.has(expectedService)) {
+    throw new Error("EXPECTED_DOMAIN_SERVICE is not an approved Worker");
+  }
+  const domains = await cloudflareRequest({ accountId, apiToken, fetchImpl });
+  if (!Array.isArray(domains)) {
+    throw new Error("Cloudflare custom-domain inventory is invalid");
+  }
+  const matches = domains.filter(
+    (domain) => domain?.hostname === "gomate.live",
+  );
+  if (
+    matches.length !== 1 ||
+    matches[0]?.service !== expectedService ||
+    matches[0]?.zone_id !== ZONE_ID
+  ) {
+    throw new Error(
+      "gomate.live is not attached to the expected Worker and zone",
+    );
+  }
+  console.log(`Verified gomate.live is attached to ${expectedService}.`);
+  return matches[0];
+}
+
+export async function attachProductionDomain({
+  accountId = process.env.CLOUDFLARE_ACCOUNT_ID,
+  apiToken = process.env.CLOUDFLARE_API_TOKEN,
+  service = process.env.TARGET_DOMAIN_SERVICE,
+  fetchImpl = fetch,
+} = {}) {
+  accountId = required(accountId, "CLOUDFLARE_ACCOUNT_ID");
+  apiToken = required(apiToken, "CLOUDFLARE_API_TOKEN");
+  service = required(service, "TARGET_DOMAIN_SERVICE");
+  if (!ALLOWED_SERVICES.has(service)) {
+    throw new Error("TARGET_DOMAIN_SERVICE is not an approved Worker");
+  }
+  const result = await cloudflareRequest({
+    accountId,
+    apiToken,
+    fetchImpl,
+    init: {
+      method: "PUT",
+      body: JSON.stringify({
+        hostname: "gomate.live",
+        service,
+        zone_id: ZONE_ID,
+      }),
+    },
+  });
+  if (
+    result?.hostname !== "gomate.live" ||
+    result?.service !== service ||
+    result?.zone_id !== ZONE_ID
+  ) {
+    throw new Error(
+      "Cloudflare returned an unexpected custom-domain attachment",
+    );
+  }
+  console.log(`Attached gomate.live to ${service}.`);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+) {
+  const command = process.argv[2];
+  const operation =
+    command === "assert"
+      ? assertProductionDomain
+      : command === "attach"
+        ? attachProductionDomain
+        : null;
+  if (!operation) {
+    console.error("Usage: production-domain.mjs assert|attach");
+    process.exit(1);
+  }
+  operation().catch((error) => {
+    console.error(`[production-domain] ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/remove-preview-secrets.mjs
+++ b/scripts/remove-preview-secrets.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/** Remove only the preview secrets file created inside the GitHub runner temp. */
+/** Remove only an approved ephemeral Wrangler secrets file in the runner temp. */
 
 import { rmSync } from "node:fs";
 import path from "node:path";
@@ -10,10 +10,20 @@ if (!runnerTemp || !secretsFile) {
   throw new Error("RUNNER_TEMP and SECRETS_FILE are required");
 }
 
-const expected = path.join(path.resolve(runnerTemp), "gomate-worker-secrets.json");
-if (path.resolve(secretsFile) !== expected) {
-  throw new Error("Refusing to remove a secrets file outside the exact runner temp target");
+const allowedNames = new Set([
+  "gomate-worker-secrets.json",
+  "gomate-production-secrets.json",
+]);
+const resolvedRunnerTemp = path.resolve(runnerTemp);
+const resolvedSecretsFile = path.resolve(secretsFile);
+if (
+  path.dirname(resolvedSecretsFile) !== resolvedRunnerTemp ||
+  !allowedNames.has(path.basename(resolvedSecretsFile))
+) {
+  throw new Error(
+    "Refusing to remove a secrets file outside the exact runner temp target",
+  );
 }
 
-rmSync(expected, { force: true });
+rmSync(resolvedSecretsFile, { force: true });
 console.log("Removed the ephemeral Wrangler secrets file.");

--- a/scripts/smoke-protected-production.mjs
+++ b/scripts/smoke-protected-production.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+import { smokeProtectedPreview } from "./smoke-protected-preview.mjs";
+import { validateProductionOrigin } from "./prepare-production-cutover.mjs";
+
+try {
+  const baseUrl = validateProductionOrigin(
+    process.env.PRODUCTION_APP_URL ?? "",
+  );
+  const result = await smokeProtectedPreview({ baseUrl });
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `health_request_id=${result.healthRequestId}\nblocked_request_id=${result.blockedRequestId}\n`,
+    );
+  }
+  console.log("Protected production smoke passed with correlated request IDs.");
+} catch (error) {
+  console.error(`[protected-production-smoke] ${error.message}`);
+  process.exit(1);
+}

--- a/scripts/write-canary-cleanup-sql.mjs
+++ b/scripts/write-canary-cleanup-sql.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import { chmodSync, writeFileSync } from "node:fs";
+
+const email = process.env.CANARY_EMAIL?.trim();
+const output = process.env.CANARY_CLEANUP_SQL?.trim();
+if (!/^stage-c-canary-[0-9]+@example\.invalid$/u.test(email ?? "")) {
+  throw new Error("CANARY_EMAIL does not match the controlled Stage C pattern");
+}
+if (!output) throw new Error("CANARY_CLEANUP_SQL is required");
+writeFileSync(
+  output,
+  `DELETE FROM users WHERE email = '${email}' AND name = 'Stage C Canary';\n`,
+  { flag: "wx", mode: 0o600 },
+);
+chmodSync(output, 0o600);
+console.log("Created exact Stage C canary cleanup SQL.");

--- a/scripts/write-production-secrets.mjs
+++ b/scripts/write-production-secrets.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import { chmodSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { validateProductionOrigin } from "./prepare-production-cutover.mjs";
+
+function required(name) {
+  const value = process.env[name];
+  if (!value?.trim()) throw new Error(`${name} is required`);
+  return value;
+}
+
+export function writeProductionSecrets(outputPath = required("SECRETS_FILE")) {
+  const secrets = {
+    APP_URL: validateProductionOrigin(required("PRODUCTION_APP_URL")),
+    BETTER_AUTH_SECRET: required("BETTER_AUTH_SECRET"),
+    RESEND_API_KEY: required("RESEND_API_KEY"),
+  };
+  writeFileSync(outputPath, `${JSON.stringify(secrets)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+    mode: 0o600,
+  });
+  chmodSync(outputPath, 0o600);
+  console.log(
+    `Created production Wrangler secrets file at ${path.basename(outputPath)}.`,
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+) {
+  try {
+    writeProductionSecrets();
+  } catch (error) {
+    console.error(`[production-secrets] ${error.message}`);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
Adds the independent Stage C production cutover and rollback workflows. Cutover proves gomate.live is still owned by gomate-frontend, deploys the unified Worker with WRITE_MODE protected, requires correlated log approval, observes read paths for 30 minutes, then requires another production approval before opening writes. The open phase runs a controlled sign-up, verification, login, session, profile mutation, and sign-out canary, removes the exact canary account, requires log approval, and observes for another 30 minutes. Rollback first restores WRITE_MODE protected and then reattaches gomate.live to gomate-frontend. No migration, seed, R2/KV mutation, or resource deletion is included.\n\nValidation: cutover and deployment guards 25/25; delivery 36/36 outside sandbox; production Astro build and Wrangler custom-domain dry-run passed; current Cloudflare dashboard confirms gomate.live belongs to gomate-frontend.