### PR TITLE
fix(ci): generate cutover dry-run bundle before size gate

### DIFF
--- a/.github/workflows/cutover-production.yml
+++ b/.github/workflows/cutover-production.yml
@@ -46,7 +46,7 @@ jobs:
           pnpm i18n:build
           pnpm --filter @gomate/frontend worker:types:check
           pnpm --filter @gomate/frontend build
-          node scripts/prepare-worker-output.mjs
+          pnpm --filter @gomate/frontend worker:dry-run
           pnpm --filter @gomate/frontend worker:size
       - name: Prove gomate.live still targets the reviewed legacy Worker
         env:

--- a/scripts/production-cutover.test.mjs
+++ b/scripts/production-cutover.test.mjs
@@ -248,6 +248,10 @@ test("cutover and rollback workflows are protected and narrowly scoped", () => {
   assert.match(cutover, /gomate\.live/u);
   assert.match(cutover, /observe-production\.mjs/u);
   assert.match(cutover, /production-canary\.mjs/u);
+  assert.match(
+    cutover,
+    /pnpm --filter @gomate\/frontend worker:dry-run\s+pnpm --filter @gomate\/frontend worker:size/u,
+  );
   assert.doesNotMatch(
     cutover,
     /migrations apply|seed\.sql|wrangler\s+r2|wrangler\s+kv/iu,


### PR DESCRIPTION
## Summary
- run the production Worker dry-run before the cutover bundle-size gate
- add a regression assertion that preserves dry-run-before-size ordering

## Why
Stage C run 31960110157 stopped before any Cloudflare write because the size gate could not find dist-worker output.

## Validation
- node --test scripts/production-cutover.test.mjs (7/7)
- node --test scripts/deployment-guards.test.mjs (18/18)
- pinned pnpm 9 production build
- Wrangler dry-run: protected bindings, 1.50 MiB gzip
- worker:size passed
- git diff --check

## Rollout impact
Pipeline-only fix. No migration, deploy, route/domain, R2, KV, D1, or legacy-resource mutation is performed by this PR.