### PR TITLE
fix(ci): make production domain verification resumable

### DIFF
--- a/.github/workflows/cutover-production.yml
+++ b/.github/workflows/cutover-production.yml
@@ -48,11 +48,11 @@ jobs:
           pnpm --filter @gomate/frontend build
           pnpm --filter @gomate/frontend worker:dry-run
           pnpm --filter @gomate/frontend worker:size
-      - name: Prove gomate.live still targets the reviewed legacy Worker
+      - name: Prove gomate.live targets an approved cutover Worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          EXPECTED_DOMAIN_SERVICE: gomate-frontend
+          EXPECTED_DOMAIN_SERVICES: gomate-frontend,gomate-production-preview
         run: node scripts/production-domain.mjs assert
       - name: Prepare protected custom-domain deployment
         env:
@@ -81,6 +81,8 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           EXPECTED_DOMAIN_SERVICE: gomate-production-preview
+          DOMAIN_ASSERT_TIMEOUT_MS: "120000"
+          DOMAIN_ASSERT_RETRY_DELAY_MS: "5000"
         run: node scripts/production-domain.mjs assert
       - name: Protected production smoke
         id: smoke

--- a/.github/workflows/rollback-production-cutover.yml
+++ b/.github/workflows/rollback-production-cutover.yml
@@ -81,6 +81,8 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           EXPECTED_DOMAIN_SERVICE: gomate-frontend
+          DOMAIN_ASSERT_TIMEOUT_MS: "120000"
+          DOMAIN_ASSERT_RETRY_DELAY_MS: "5000"
         run: node scripts/production-domain.mjs assert
       - name: Record rollback evidence
         run: |

--- a/docs/prod-change-policy.md
+++ b/docs/prod-change-policy.md
@@ -91,9 +91,11 @@ route 变更必须是 preview 验证后的独立、受保护操作。切换前�
 preview 部署自动发生。
 
 从 `main` 手动运行 `Cut over unified Worker production` 并输入 `CUTOVER_PRODUCTION`。
-流水线先证明 `gomate.live` 仍属于旧 `gomate-frontend`，再用 environment secret
+流水线先证明 `gomate.live` 只属于已审核的旧 `gomate-frontend` 或新
+`gomate-production-preview`（允许在受保护部署后的失败点安全重跑），再用 environment secret
 `PRODUCTION_APP_URL=https://gomate.live` 将同一 unified Worker 以 `WRITE_MODE=protected`
-挂为 custom domain。受保护读/SSR/写阻断与 Workers Logs 证据通过后，连续 30 分钟只读观察；
+挂为 custom domain。部署后的 custom-domain inventory 断言共用 120 秒有界传播窗口；窗口结束仍
+不属于新 Worker 时失败闭合。受保护读/SSR/写阻断与 Workers Logs 证据通过后，连续 30 分钟只读观察；
 第二次 production approval 后才部署 `WRITE_MODE=open`，执行一次可清理的注册、邮箱确认、
 登录、session、资料写入、退出 canary，随后按精确 canary email 删除测试账号并证明计数为 0。
 开放写入的日志证据审批后再连续观察 30 分钟。任一阶段失败都停止后续 job。

--- a/scripts/production-cutover.test.mjs
+++ b/scripts/production-cutover.test.mjs
@@ -118,6 +118,78 @@ test("domain audit requires one exact hostname, zone, and Worker", async () => {
   );
 });
 
+test("domain audit supports an approved cutover state and bounded propagation retries", async () => {
+  let attempts = 0;
+  let now = 0;
+  const result = await assertProductionDomain({
+    accountId: "e3afbb613458022947cd9dc9f5bd6334",
+    apiToken: "test-token",
+    expectedServices: "gomate-frontend,gomate-production-preview",
+    timeoutMs: 20,
+    retryDelayMs: 5,
+    nowImpl: () => now,
+    waitImpl: async (delay) => {
+      now += delay;
+    },
+    fetchImpl: async () => {
+      attempts += 1;
+      return new Response(
+        JSON.stringify({
+          success: true,
+          result: [
+            {
+              id: "domain-id",
+              hostname: "gomate.live",
+              service:
+                attempts === 1
+                  ? "gomate-frontend"
+                  : "gomate-production-preview",
+              zone_id: "0b714cd4257332034b3c4c0c099feb9e",
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    },
+  });
+  assert.equal(result.service, "gomate-frontend");
+  assert.equal(attempts, 1);
+
+  attempts = 0;
+  now = 0;
+  const propagated = await assertProductionDomain({
+    accountId: "e3afbb613458022947cd9dc9f5bd6334",
+    apiToken: "test-token",
+    expectedService: "gomate-production-preview",
+    timeoutMs: 20,
+    retryDelayMs: 5,
+    nowImpl: () => now,
+    waitImpl: async (delay) => {
+      now += delay;
+    },
+    fetchImpl: async () => {
+      attempts += 1;
+      return new Response(
+        JSON.stringify({
+          success: true,
+          result: [
+            {
+              id: "domain-id",
+              hostname: "gomate.live",
+              service:
+                attempts < 3 ? "gomate-frontend" : "gomate-production-preview",
+              zone_id: "0b714cd4257332034b3c4c0c099feb9e",
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    },
+  });
+  assert.equal(propagated.service, "gomate-production-preview");
+  assert.equal(attempts, 3);
+});
+
 test("rollback reattaches only the exact hostname, zone, and approved Worker", async () => {
   let request;
   await attachProductionDomain({
@@ -248,6 +320,11 @@ test("cutover and rollback workflows are protected and narrowly scoped", () => {
   assert.match(cutover, /gomate\.live/u);
   assert.match(cutover, /observe-production\.mjs/u);
   assert.match(cutover, /production-canary\.mjs/u);
+  assert.match(
+    cutover,
+    /EXPECTED_DOMAIN_SERVICES:\s*gomate-frontend,gomate-production-preview/u,
+  );
+  assert.match(cutover, /DOMAIN_ASSERT_TIMEOUT_MS:\s*"120000"/u);
   assert.match(
     cutover,
     /pnpm --filter @gomate\/frontend worker:dry-run\s+pnpm --filter @gomate\/frontend worker:size/u,

--- a/scripts/production-domain.mjs
+++ b/scripts/production-domain.mjs
@@ -8,11 +8,34 @@ const ALLOWED_SERVICES = new Set([
   "gomate-frontend",
   "gomate-production-preview",
 ]);
+const DEFAULT_RETRY_DELAY_MS = 5_000;
 
 function required(value, label) {
   const result = value?.trim();
   if (!result) throw new Error(`${label} is required`);
   return result;
+}
+
+function nonNegativeInteger(value, label, fallback) {
+  const candidate = value === undefined || value === "" ? fallback : Number(value);
+  if (!Number.isInteger(candidate) || candidate < 0) {
+    throw new Error(`${label} must be a non-negative integer`);
+  }
+  return candidate;
+}
+
+function expectedServiceSet(value) {
+  const services = required(value, "EXPECTED_DOMAIN_SERVICE(S)")
+    .split(",")
+    .map((service) => service.trim())
+    .filter(Boolean);
+  if (
+    services.length === 0 ||
+    services.some((service) => !ALLOWED_SERVICES.has(service))
+  ) {
+    throw new Error("Expected domain services contain an unapproved Worker");
+  }
+  return new Set(services);
 }
 
 async function cloudflareRequest({ accountId, apiToken, fetchImpl, init }) {
@@ -38,33 +61,64 @@ async function cloudflareRequest({ accountId, apiToken, fetchImpl, init }) {
 export async function assertProductionDomain({
   accountId = process.env.CLOUDFLARE_ACCOUNT_ID,
   apiToken = process.env.CLOUDFLARE_API_TOKEN,
-  expectedService = process.env.EXPECTED_DOMAIN_SERVICE,
+  expectedService,
+  expectedServices,
+  timeoutMs = process.env.DOMAIN_ASSERT_TIMEOUT_MS,
+  retryDelayMs = process.env.DOMAIN_ASSERT_RETRY_DELAY_MS,
+  waitImpl = (delay) => new Promise((resolve) => setTimeout(resolve, delay)),
+  nowImpl = Date.now,
   fetchImpl = fetch,
 } = {}) {
   accountId = required(accountId, "CLOUDFLARE_ACCOUNT_ID");
   apiToken = required(apiToken, "CLOUDFLARE_API_TOKEN");
-  expectedService = required(expectedService, "EXPECTED_DOMAIN_SERVICE");
-  if (!ALLOWED_SERVICES.has(expectedService)) {
-    throw new Error("EXPECTED_DOMAIN_SERVICE is not an approved Worker");
-  }
-  const domains = await cloudflareRequest({ accountId, apiToken, fetchImpl });
-  if (!Array.isArray(domains)) {
-    throw new Error("Cloudflare custom-domain inventory is invalid");
-  }
-  const matches = domains.filter(
-    (domain) => domain?.hostname === "gomate.live",
+  const approvedServices = expectedServiceSet(
+    expectedServices ??
+      expectedService ??
+      process.env.EXPECTED_DOMAIN_SERVICES ??
+      process.env.EXPECTED_DOMAIN_SERVICE,
   );
-  if (
-    matches.length !== 1 ||
-    matches[0]?.service !== expectedService ||
-    matches[0]?.zone_id !== ZONE_ID
-  ) {
-    throw new Error(
-      "gomate.live is not attached to the expected Worker and zone",
-    );
+  timeoutMs = nonNegativeInteger(timeoutMs, "DOMAIN_ASSERT_TIMEOUT_MS", 0);
+  retryDelayMs = nonNegativeInteger(
+    retryDelayMs,
+    "DOMAIN_ASSERT_RETRY_DELAY_MS",
+    DEFAULT_RETRY_DELAY_MS,
+  );
+  if (retryDelayMs === 0 && timeoutMs > 0) {
+    throw new Error("DOMAIN_ASSERT_RETRY_DELAY_MS must be positive when retrying");
   }
-  console.log(`Verified gomate.live is attached to ${expectedService}.`);
-  return matches[0];
+  const deadline = nowImpl() + timeoutMs;
+
+  while (true) {
+    try {
+      const domains = await cloudflareRequest({ accountId, apiToken, fetchImpl });
+      if (!Array.isArray(domains)) {
+        throw new Error("Cloudflare custom-domain inventory is invalid");
+      }
+      const matches = domains.filter(
+        (domain) => domain?.hostname === "gomate.live",
+      );
+      if (
+        matches.length === 1 &&
+        approvedServices.has(matches[0]?.service) &&
+        matches[0]?.zone_id === ZONE_ID
+      ) {
+        console.log(
+          `Verified gomate.live is attached to ${matches[0].service}.`,
+        );
+        return matches[0];
+      }
+    } catch (error) {
+      if (nowImpl() >= deadline) throw error;
+    }
+
+    const remainingMs = deadline - nowImpl();
+    if (remainingMs <= 0) {
+      throw new Error(
+        "gomate.live is not attached to an expected Worker and zone",
+      );
+    }
+    await waitImpl(Math.min(retryDelayMs, remainingMs));
+  }
 }
 
 export async function attachProductionDomain({


### PR DESCRIPTION
## Summary
- allow Stage C to resume when gomate.live is already attached to either reviewed cutover Worker
- add a bounded 120-second Cloudflare domain-inventory propagation retry after deploy and rollback
- keep every unexpected Worker/zone fail-closed
- document the resumable cutover contract

## Incident evidence
Run 31960647320 successfully deployed the unified Worker in WRITE_MODE=protected, then the immediate custom-domain inventory assertion observed stale state. Public verification after the job:
- GET /api/health: 200 with X-Request-ID 906e0a3f-ccb0-4731-a9a6-63e3934285e8
- protected sign-in canary: 503 WRITE_PROTECTED with X-Request-ID 5dc79813-a85b-4d43-9b6c-0abb6fec1a45
- no open-write job ran

## Validation
- full delivery gate: 39/39
- focused production/deployment tests after formatting: 26/26
- node --check scripts/production-domain.mjs
- git diff --check

## Safety
No migration, seed, R2/KV/D1 mutation, secret write, deploy, or route change occurs in this PR. The rerun still redeploys protected mode before any later approval can open writes.