### PR TITLE
fix(ci): deploy the reviewed production Worker name

### DIFF
--- a/.github/workflows/cutover-production.yml
+++ b/.github/workflows/cutover-production.yml
@@ -22,8 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: production
-    env:
-      CLOUDFLARE_ENV: production
     outputs:
       health_request_id: ${{ steps.smoke.outputs.health_request_id }}
       blocked_request_id: ${{ steps.smoke.outputs.blocked_request_id }}
@@ -38,6 +36,8 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Validate source and build protected production output
+        env:
+          CLOUDFLARE_ENV: production
         run: |
           pnpm audit --prod --audit-level high
           pnpm check:legacy-removal
@@ -52,7 +52,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          EXPECTED_DOMAIN_SERVICES: gomate-frontend,gomate-production-preview
+          EXPECTED_DOMAIN_SERVICES: gomate-frontend,gomate-production-preview,gomate-production-preview-production
         run: node scripts/production-domain.mjs assert
       - name: Prepare protected custom-domain deployment
         env:
@@ -129,7 +129,6 @@ jobs:
     timeout-minutes: 20
     environment: production
     env:
-      CLOUDFLARE_ENV: production
       CANARY_EMAIL: stage-c-canary-${{ github.run_id }}@example.invalid
     outputs:
       signup_request_id: ${{ steps.canary.outputs.signup_request_id }}
@@ -146,6 +145,8 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Build the reviewed production commit
+        env:
+          CLOUDFLARE_ENV: production
         run: |
           pnpm i18n:build
           pnpm --filter @gomate/frontend build

--- a/.github/workflows/rollback-production-cutover.yml
+++ b/.github/workflows/rollback-production-cutover.yml
@@ -22,8 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: production
-    env:
-      CLOUDFLARE_ENV: production
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -42,6 +40,7 @@ jobs:
         run: node scripts/production-domain.mjs assert
       - name: Build and prepare WRITE_MODE protected
         env:
+          CLOUDFLARE_ENV: production
           PRODUCTION_APP_URL: ${{ secrets.PRODUCTION_APP_URL }}
         run: |
           pnpm i18n:build

--- a/docs/prod-change-policy.md
+++ b/docs/prod-change-policy.md
@@ -91,8 +91,9 @@ route 变更必须是 preview 验证后的独立、受保护操作。切换前�
 preview 部署自动发生。
 
 从 `main` 手动运行 `Cut over unified Worker production` 并输入 `CUTOVER_PRODUCTION`。
-流水线先证明 `gomate.live` 只属于已审核的旧 `gomate-frontend` 或新
-`gomate-production-preview`（允许在受保护部署后的失败点安全重跑），再用 environment secret
+流水线先证明 `gomate.live` 只属于已审核的旧 `gomate-frontend`、新
+`gomate-production-preview`，或仅用于恢复一次错误双重环境选择的
+`gomate-production-preview-production`，再用 environment secret
 `PRODUCTION_APP_URL=https://gomate.live` 将同一 unified Worker 以 `WRITE_MODE=protected`
 挂为 custom domain。部署后的 custom-domain inventory 断言共用 120 秒有界传播窗口；窗口结束仍
 不属于新 Worker 时失败闭合。受保护读/SSR/写阻断与 Workers Logs 证据通过后，连续 30 分钟只读观察；

--- a/scripts/production-cutover.test.mjs
+++ b/scripts/production-cutover.test.mjs
@@ -190,6 +190,39 @@ test("domain audit supports an approved cutover state and bounded propagation re
   assert.equal(attempts, 3);
 });
 
+test("domain audit may recover from the accidental suffixed Worker but cannot target it", async () => {
+  const observed = await assertProductionDomain({
+    accountId: "e3afbb613458022947cd9dc9f5bd6334",
+    apiToken: "test-token",
+    expectedService: "gomate-production-preview-production",
+    fetchImpl: async () =>
+      new Response(
+        JSON.stringify({
+          success: true,
+          result: [
+            {
+              id: "domain-id",
+              hostname: "gomate.live",
+              service: "gomate-production-preview-production",
+              zone_id: "0b714cd4257332034b3c4c0c099feb9e",
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+  });
+  assert.equal(observed.service, "gomate-production-preview-production");
+  await assert.rejects(
+    () =>
+      attachProductionDomain({
+        accountId: "e3afbb613458022947cd9dc9f5bd6334",
+        apiToken: "test-token",
+        service: "gomate-production-preview-production",
+      }),
+    /not an approved Worker/u,
+  );
+});
+
 test("rollback reattaches only the exact hostname, zone, and approved Worker", async () => {
   let request;
   await attachProductionDomain({
@@ -322,9 +355,13 @@ test("cutover and rollback workflows are protected and narrowly scoped", () => {
   assert.match(cutover, /production-canary\.mjs/u);
   assert.match(
     cutover,
-    /EXPECTED_DOMAIN_SERVICES:\s*gomate-frontend,gomate-production-preview/u,
+    /EXPECTED_DOMAIN_SERVICES:\s*gomate-frontend,gomate-production-preview,gomate-production-preview-production/u,
   );
   assert.match(cutover, /DOMAIN_ASSERT_TIMEOUT_MS:\s*"120000"/u);
+  assert.doesNotMatch(
+    cutover,
+    /environment:\s*production\s+env:\s+CLOUDFLARE_ENV:\s*production/u,
+  );
   assert.match(
     cutover,
     /pnpm --filter @gomate\/frontend worker:dry-run\s+pnpm --filter @gomate\/frontend worker:size/u,

--- a/scripts/production-domain.mjs
+++ b/scripts/production-domain.mjs
@@ -4,9 +4,14 @@ import { pathToFileURL } from "node:url";
 
 const API_ROOT = "https://api.cloudflare.com/client/v4";
 const ZONE_ID = "0b714cd4257332034b3c4c0c099feb9e";
-const ALLOWED_SERVICES = new Set([
+const ALLOWED_TARGET_SERVICES = new Set([
   "gomate-frontend",
   "gomate-production-preview",
+]);
+const ALLOWED_OBSERVED_SERVICES = new Set([
+  ...ALLOWED_TARGET_SERVICES,
+  // Recovery-only state created by a double-applied production environment.
+  "gomate-production-preview-production",
 ]);
 const DEFAULT_RETRY_DELAY_MS = 5_000;
 
@@ -31,7 +36,7 @@ function expectedServiceSet(value) {
     .filter(Boolean);
   if (
     services.length === 0 ||
-    services.some((service) => !ALLOWED_SERVICES.has(service))
+    services.some((service) => !ALLOWED_OBSERVED_SERVICES.has(service))
   ) {
     throw new Error("Expected domain services contain an unapproved Worker");
   }
@@ -130,7 +135,7 @@ export async function attachProductionDomain({
   accountId = required(accountId, "CLOUDFLARE_ACCOUNT_ID");
   apiToken = required(apiToken, "CLOUDFLARE_API_TOKEN");
   service = required(service, "TARGET_DOMAIN_SERVICE");
-  if (!ALLOWED_SERVICES.has(service)) {
+  if (!ALLOWED_TARGET_SERVICES.has(service)) {
     throw new Error("TARGET_DOMAIN_SERVICE is not an approved Worker");
   }
   const result = await cloudflareRequest({


### PR DESCRIPTION
## Summary
- scope CLOUDFLARE_ENV=production to build steps only
- deploy the flattened Astro config without re-applying the production environment suffix
- allow the accidental gomate-production-preview-production service only as an observed recovery state
- keep attach targets restricted to gomate-frontend and gomate-production-preview

## Root cause
Stage C run 31960647320 uploaded gomate-production-preview-production because job-level CLOUDFLARE_ENV was applied again after Astro had already generated the production config. Stage B's reviewed Worker is gomate-production-preview.

## Current safe state
- gomate.live currently serves the unified Worker
- WRITE_MODE remains protected (503 WRITE_PROTECTED verified)
- no open-write job has run

## Validation
- complete delivery gate: 40/40
- focused production/deployment tests: 27/27
- node --check scripts/production-domain.mjs
- git diff --check

## Rollout behavior
The next Stage C run may observe the accidental suffixed service, but it can only deploy/attach the reviewed gomate-production-preview target. No resource is deleted.