### PR TITLE
fix: validate production health contract

### DIFF
--- a/scripts/observe-production.mjs
+++ b/scripts/observe-production.mjs
@@ -37,12 +37,15 @@ export async function observeProduction({
       const requestId = response.headers.get("x-request-id")?.trim();
       const contentType = response.headers.get("content-type") ?? "";
       const payload = await response.json().catch(() => null);
+      const payloadIsValid = endpoint === "/api/health"
+        ? payload?.status === "ok"
+        : payload?.success === true;
       if (
         !response.ok ||
         !contentType.includes("application/json") ||
         !requestId ||
         !REQUEST_ID.test(requestId) ||
-        payload?.success !== true
+        !payloadIsValid
       ) {
         throw new Error(
           `Observation failed for ${endpoint} (${response.status})`,

--- a/scripts/production-cutover.test.mjs
+++ b/scripts/production-cutover.test.mjs
@@ -269,7 +269,7 @@ test("production observation checks health and Region without writes", async () 
       return new Response(
         JSON.stringify(
           isHealth
-            ? { success: true }
+            ? { status: "ok", timestamp: "2026-08-16T17:37:36.642Z" }
             : { success: true, regions: [{ id: "region-cn-shenzhen" }] },
         ),
         {
@@ -288,6 +288,35 @@ test("production observation checks health and Region without writes", async () 
     calls.every(
       (url) => !url.includes("auth/sign") && !url.includes("users/me"),
     ),
+  );
+});
+
+test("production observation rejects an invalid health payload", async () => {
+  await assert.rejects(
+    () =>
+      observeProduction({
+        baseUrl: "https://gomate.live",
+        durationMs: 0,
+        fetchImpl: async (url) =>
+          new Response(
+            JSON.stringify(
+              String(url).includes("/api/health")
+                ? { success: true }
+                : {
+                    success: true,
+                    regions: [{ id: "region-cn-shenzhen" }],
+                  },
+            ),
+            {
+              status: 200,
+              headers: {
+                "content-type": "application/json",
+                "x-request-id": "00000000-0000-4000-8000-000000000001",
+              },
+            },
+          ),
+      }),
+    /Observation failed for \/api\/health/u,
   );
 });
 


### PR DESCRIPTION
## Summary
- validate the real /api/health payload contract during production observation
- keep Region success-envelope validation unchanged
- add a regression that rejects invalid health payloads

## Evidence
- Stage C run 31961736839 failed read-only observation on a healthy 200 response
- live /api/health returned status=ok with a valid X-Request-ID
- node --test scripts/production-cutover.test.mjs scripts/deployment-guards.test.mjs (28/28)
- node --check scripts/observe-production.mjs
- git diff --check

## Rollout impact
Pipeline-only correction. No Worker code, D1 data, routes, R2 objects, or Cloudflare resources are changed by this PR. Production remains WRITE_MODE=protected until the corrected Stage C run passes its gates.