### PR TITLE
chore: close cutover recovery state

### DIFF
--- a/.github/workflows/cutover-production.yml
+++ b/.github/workflows/cutover-production.yml
@@ -52,7 +52,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          EXPECTED_DOMAIN_SERVICES: gomate-frontend,gomate-production-preview,gomate-production-preview-production
+          EXPECTED_DOMAIN_SERVICES: gomate-frontend,gomate-production-preview
         run: node scripts/production-domain.mjs assert
       - name: Prepare protected custom-domain deployment
         env:

--- a/docs/prod-change-policy.md
+++ b/docs/prod-change-policy.md
@@ -91,9 +91,9 @@ route 变更必须是 preview 验证后的独立、受保护操作。切换前�
 preview 部署自动发生。
 
 从 `main` 手动运行 `Cut over unified Worker production` 并输入 `CUTOVER_PRODUCTION`。
-流水线先证明 `gomate.live` 只属于已审核的旧 `gomate-frontend`、新
-`gomate-production-preview`，或仅用于恢复一次错误双重环境选择的
-`gomate-production-preview-production`，再用 environment secret
+流水线先证明 `gomate.live` 只属于已审核的旧 `gomate-frontend` 或新
+`gomate-production-preview`；阶段 C 成功后不再接受曾用于恢复错误双重环境选择的
+临时 Worker。然后使用 environment secret
 `PRODUCTION_APP_URL=https://gomate.live` 将同一 unified Worker 以 `WRITE_MODE=protected`
 挂为 custom domain。部署后的 custom-domain inventory 断言共用 120 秒有界传播窗口；窗口结束仍
 不属于新 Worker 时失败闭合。受保护读/SSR/写阻断与 Workers Logs 证据通过后，连续 30 分钟只读观察；

--- a/scripts/production-cutover.test.mjs
+++ b/scripts/production-cutover.test.mjs
@@ -190,28 +190,16 @@ test("domain audit supports an approved cutover state and bounded propagation re
   assert.equal(attempts, 3);
 });
 
-test("domain audit may recover from the accidental suffixed Worker but cannot target it", async () => {
-  const observed = await assertProductionDomain({
-    accountId: "e3afbb613458022947cd9dc9f5bd6334",
-    apiToken: "test-token",
-    expectedService: "gomate-production-preview-production",
-    fetchImpl: async () =>
-      new Response(
-        JSON.stringify({
-          success: true,
-          result: [
-            {
-              id: "domain-id",
-              hostname: "gomate.live",
-              service: "gomate-production-preview-production",
-              zone_id: "0b714cd4257332034b3c4c0c099feb9e",
-            },
-          ],
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      ),
-  });
-  assert.equal(observed.service, "gomate-production-preview-production");
+test("domain audit rejects the accidental suffixed Worker after cutover", async () => {
+  await assert.rejects(
+    () =>
+      assertProductionDomain({
+        accountId: "e3afbb613458022947cd9dc9f5bd6334",
+        apiToken: "test-token",
+        expectedService: "gomate-production-preview-production",
+      }),
+    /unapproved Worker/u,
+  );
   await assert.rejects(
     () =>
       attachProductionDomain({
@@ -384,8 +372,9 @@ test("cutover and rollback workflows are protected and narrowly scoped", () => {
   assert.match(cutover, /production-canary\.mjs/u);
   assert.match(
     cutover,
-    /EXPECTED_DOMAIN_SERVICES:\s*gomate-frontend,gomate-production-preview,gomate-production-preview-production/u,
+    /EXPECTED_DOMAIN_SERVICES:\s*gomate-frontend,gomate-production-preview/u,
   );
+  assert.doesNotMatch(cutover, /gomate-production-preview-production/u);
   assert.match(cutover, /DOMAIN_ASSERT_TIMEOUT_MS:\s*"120000"/u);
   assert.doesNotMatch(
     cutover,

--- a/scripts/production-domain.mjs
+++ b/scripts/production-domain.mjs
@@ -8,11 +8,6 @@ const ALLOWED_TARGET_SERVICES = new Set([
   "gomate-frontend",
   "gomate-production-preview",
 ]);
-const ALLOWED_OBSERVED_SERVICES = new Set([
-  ...ALLOWED_TARGET_SERVICES,
-  // Recovery-only state created by a double-applied production environment.
-  "gomate-production-preview-production",
-]);
 const DEFAULT_RETRY_DELAY_MS = 5_000;
 
 function required(value, label) {
@@ -36,7 +31,7 @@ function expectedServiceSet(value) {
     .filter(Boolean);
   if (
     services.length === 0 ||
-    services.some((service) => !ALLOWED_OBSERVED_SERVICES.has(service))
+    services.some((service) => !ALLOWED_TARGET_SERVICES.has(service))
   ) {
     throw new Error("Expected domain services contain an unapproved Worker");
   }


### PR DESCRIPTION
## Summary
- remove the one-time accidental suffixed Worker from future domain preflight allowlists
- keep only gomate-frontend and gomate-production-preview as approved observed services
- update the production change policy and regression tests

## Evidence
- Stage C run 31962491818 completed successfully, including both 30-minute observations
- node --test scripts/production-cutover.test.mjs scripts/deployment-guards.test.mjs (28/28)
- node --check scripts/production-domain.mjs
- git diff --check

## Impact
Pipeline hardening only. This does not deploy, change routes, mutate D1/KV/R2, or delete the accidental/legacy Workers. Those resources remain retained for the mandatory seven-day window.