### PR TITLE
ci: automate legacy resource retirement

### DIFF
--- a/.github/workflows/retire-legacy-production.yml
+++ b/.github/workflows/retire-legacy-production.yml
@@ -1,0 +1,32 @@
+name: Retire legacy Cloudflare resources
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: Type RETIRE_LEGACY_RESOURCES after the seven-day retention window
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gomate-legacy-resource-retirement
+  cancel-in-progress: false
+
+jobs:
+  retire:
+    name: Retire exact legacy Cloudflare resources
+    if: inputs.confirm == 'RETIRE_LEGACY_RESOURCES' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - name: Retire reviewed legacy resources and verify production
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PRODUCTION_APP_URL: ${{ secrets.PRODUCTION_APP_URL }}
+        run: node scripts/retire-legacy-production.mjs

--- a/docs/prod-change-policy.md
+++ b/docs/prod-change-policy.md
@@ -106,6 +106,25 @@ preview 部署自动发生。
 再通过 Cloudflare Workers custom-domain API 把 `gomate.live` 精确重新附加到
 `gomate-frontend`。回滚不删除 V2 D1、KV、R2、Worker、版本或 secrets。
 
+### 阶段 D：旧资源退役
+
+阶段 C 于 2026-08-16T18:53:01Z 完成；旧资源最早只能在
+2026-08-23T18:53:01Z 后退役。从 `main` 手动运行
+`Retire legacy Cloudflare resources` 并输入 `RETIRE_LEGACY_RESOURCES`，且必须通过
+`production` environment 审批。流水线先证明 `gomate.live` 精确属于
+`gomate-production-preview`，并核对新 D1/KV 与共享 R2；随后只删除：
+
+- `api.gomate.live` custom domain；
+- Workers `gomate-api`、`gomate-frontend`、`gomate-production-preview-production`；
+- D1 `gomate-db`（`7d17d076-202f-48f8-b343-24209cdb0ba1`）；
+- KV `GOMATE_KV`（`638ecd78e70c48fda01904bc9c2105d8`）和
+  `gomate-frontend-session`（`6e3db6b00bc4421faeb1402c2e51f7d1`）。
+
+脚本不得调用 R2 删除 API；执行后重新读取 Cloudflare inventory，并验证生产 Worker、
+`gomate-db-v2`、`gomate-cache-v2`、R2 `gomate`、health 和深圳 Region。任一名称、ID、域名归属、
+时间边界或生产资源不匹配时，在首个 DELETE 前失败闭合。流水线可安全重跑：已经删除的精确旧资源
+视为完成，但新资源缺失仍立即失败。
+
 ## 4. 回滚
 
 - 应用回滚：核实 Worker deployment/version 对应的 commit 后，回滚到已验证版本。

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "i18n:gen-types": "node scripts/gen-i18n-types.mjs",
     "i18n:build": "tsx scripts/build-locales.ts",
     "check:legacy-removal": "node scripts/check-legacy-removal.mjs",
-    "test:delivery": "node --test scripts/check-legacy-removal.test.mjs scripts/deployment-guards.test.mjs scripts/production-cutover.test.mjs scripts/promote-admin.test.mjs scripts/region-bootstrap-contract.test.mjs scripts/reset-local-db.test.mjs",
+    "test:delivery": "node --test scripts/check-legacy-removal.test.mjs scripts/deployment-guards.test.mjs scripts/production-cutover.test.mjs scripts/promote-admin.test.mjs scripts/region-bootstrap-contract.test.mjs scripts/reset-local-db.test.mjs scripts/retire-legacy-production.test.mjs",
     "prepare": "husky",
     "dev:wt": "node scripts/init-worktree.mjs && node scripts/start-worktree.mjs",
     "init:worktree": "node scripts/init-worktree.mjs"

--- a/scripts/check-legacy-removal.mjs
+++ b/scripts/check-legacy-removal.mjs
@@ -100,9 +100,15 @@ const operationalForbiddenContent = [
   ["legacy API origin", /https:\/\/api\.gomate\.live/],
   ["legacy API secret file", /api\/\.dev\.vars/],
   ["legacy frontend environment file", /frontend\/\.env\.local/],
-  ["legacy Worker binding", /\bGOMATE_KV\b|\bFRONTEND_URL\b|\bCORS_ALLOWED_ORIGINS\b|\bBETTER_AUTH_URL\b/],
+  [
+    "legacy Worker binding",
+    /\bGOMATE_KV\b|\bFRONTEND_URL\b|\bCORS_ALLOWED_ORIGINS\b|\bBETTER_AUTH_URL\b/,
+  ],
   ["removed route path", /\/(?:shares\/track|activity-posts|cities)(?:\/|\b)/],
-  ["removed schema relation", /schema\.(?:cities|activityPosts|shareEvents|userFavorites|entityToTags|apiKeys)\b/],
+  [
+    "removed schema relation",
+    /schema\.(?:cities|activityPosts|shareEvents|userFavorites|entityToTags|apiKeys)\b/,
+  ],
   ["removed lifecycle mutation", /\bupdateExpiredTeams\b/],
   ["forbidden Astro session", /\bAstro\.session\b/],
   ["removed resvg runtime", /@resvg\/resvg-wasm/],
@@ -117,6 +123,11 @@ const approvedLegacyWorkerRollbackFiles = new Set([
   "scripts/production-domain.mjs",
 ]);
 
+const approvedLegacyRetirementFiles = new Set([
+  "scripts/retire-legacy-production.mjs",
+  "scripts/retire-legacy-production.test.mjs",
+]);
+
 function isApprovedLegacyWorkerRollbackReference(relativePath, label, line) {
   return (
     label === "legacy Worker name" &&
@@ -124,6 +135,23 @@ function isApprovedLegacyWorkerRollbackReference(relativePath, label, line) {
     /\bgomate-frontend\b/u.test(line) &&
     !/\bgomate-api\b/u.test(line)
   );
+}
+
+function isApprovedLegacyRetirementReference(relativePath, label, line) {
+  if (!approvedLegacyRetirementFiles.has(relativePath)) return false;
+  if (label === "legacy Worker name") {
+    return /\bgomate-(?:api|frontend)\b/u.test(line);
+  }
+  if (label === "legacy D1 name") {
+    return /\bgomate-db(?!-v2)\b/u.test(line);
+  }
+  if (label === "legacy Worker binding") {
+    return (
+      /\bGOMATE_KV\b/u.test(line) &&
+      !/\b(?:FRONTEND_URL|CORS_ALLOWED_ORIGINS|BETTER_AUTH_URL)\b/u.test(line)
+    );
+  }
+  return false;
 }
 
 function isOperationalFile(relativePath) {
@@ -193,7 +221,9 @@ if (
 }
 
 for (const relativePath of textFiles) {
-  const lines = readFileSync(path.join(root, relativePath), "utf8").split(/\r?\n/);
+  const lines = readFileSync(path.join(root, relativePath), "utf8").split(
+    /\r?\n/,
+  );
   lines.forEach((line, index) => {
     if (isDatabaseDefinitionFile(relativePath) && /\bapikeys?\b/iu.test(line)) {
       violations.push(
@@ -209,7 +239,8 @@ for (const relativePath of textFiles) {
       for (const [label, pattern] of operationalForbiddenContent) {
         if (
           pattern.test(line) &&
-          !isApprovedLegacyWorkerRollbackReference(relativePath, label, line)
+          !isApprovedLegacyWorkerRollbackReference(relativePath, label, line) &&
+          !isApprovedLegacyRetirementReference(relativePath, label, line)
         ) {
           violations.push(`${relativePath}:${index + 1}: ${label}`);
         }
@@ -219,9 +250,13 @@ for (const relativePath of textFiles) {
 }
 
 if (violations.length > 0) {
-  console.error(`Legacy removal check failed with ${violations.length} violation(s):`);
+  console.error(
+    `Legacy removal check failed with ${violations.length} violation(s):`,
+  );
   for (const violation of violations) console.error(`- ${violation}`);
   process.exit(1);
 }
 
-console.log("Legacy split deployment, MCP, public v1, API-key, and removed route surfaces are absent.");
+console.log(
+  "Legacy split deployment, MCP, public v1, API-key, and removed route surfaces are absent.",
+);

--- a/scripts/check-legacy-removal.test.mjs
+++ b/scripts/check-legacy-removal.test.mjs
@@ -35,7 +35,10 @@ test("scans SQL for singular legacy apikey identifiers", () => {
   const root = fixture();
   const migrations = path.join(root, "api", "db", "migrations");
   mkdirSync(migrations, { recursive: true });
-  writeFileSync(path.join(migrations, "0000.sql"), "CREATE TABLE apikey (id TEXT);\n");
+  writeFileSync(
+    path.join(migrations, "0000.sql"),
+    "CREATE TABLE apikey (id TEXT);\n",
+  );
 
   const result = run(root);
   assert.equal(result.status, 1);
@@ -69,11 +72,17 @@ test("ignores generated Worker dry-run output", () => {
 test("rejects a transpiled Worker source sibling", () => {
   const root = fixture();
   mkdirSync(path.join(root, "frontend", "src"), { recursive: true });
-  writeFileSync(path.join(root, "frontend", "src", "worker.js"), "export default {};\n");
+  writeFileSync(
+    path.join(root, "frontend", "src", "worker.js"),
+    "export default {};\n",
+  );
 
   const result = run(root);
   assert.equal(result.status, 1);
-  assert.match(result.stderr, /frontend\/src\/worker\.js: removed path still exists/u);
+  assert.match(
+    result.stderr,
+    /frontend\/src\/worker\.js: removed path still exists/u,
+  );
 });
 
 test("allows the exact legacy frontend Worker only in reviewed rollback files", () => {
@@ -114,4 +123,42 @@ test("still rejects legacy Worker names outside or beyond the rollback allowlist
   const api = run(apiRoot);
   assert.equal(api.status, 1);
   assert.match(api.stderr, /legacy Worker name/u);
+});
+
+test("allows only exact legacy resource identifiers in reviewed retirement files", () => {
+  const root = fixture();
+  const scriptsDirectory = path.join(root, "scripts");
+  mkdirSync(scriptsDirectory, { recursive: true });
+  writeFileSync(
+    path.join(scriptsDirectory, "retire-legacy-production.mjs"),
+    [
+      'const workers = ["gomate-api", "gomate-frontend"];',
+      'const database = "gomate-db";',
+      'const namespace = "GOMATE_KV";',
+      "",
+    ].join("\n"),
+  );
+
+  const result = run(root);
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("does not turn retirement files into a broad legacy bypass", () => {
+  const root = fixture();
+  const scriptsDirectory = path.join(root, "scripts");
+  mkdirSync(scriptsDirectory, { recursive: true });
+  writeFileSync(
+    path.join(scriptsDirectory, "retire-legacy-production.mjs"),
+    [
+      'const worker = "gomate-api";',
+      'const forbiddenOrigin = "https://api.gomate.live";',
+      'const forbiddenBinding = "FRONTEND_URL";',
+      "",
+    ].join("\n"),
+  );
+
+  const result = run(root);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /legacy API origin/u);
+  assert.match(result.stderr, /legacy Worker binding/u);
 });

--- a/scripts/retire-legacy-production.mjs
+++ b/scripts/retire-legacy-production.mjs
@@ -1,0 +1,315 @@
+#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const API_ROOT = "https://api.cloudflare.com/client/v4";
+const ACCOUNT_ID = "e3afbb613458022947cd9dc9f5bd6334";
+const ZONE_ID = "0b714cd4257332034b3c4c0c099feb9e";
+const RETIRE_NOT_BEFORE = Date.parse("2026-08-23T18:53:01Z");
+const PRODUCTION_WORKER = "gomate-production-preview";
+const PRODUCTION_D1 = {
+  id: "befa3d89-6551-4a25-8a1c-670efe62a315",
+  name: "gomate-db-v2",
+};
+const PRODUCTION_KV = {
+  id: "f9904d1fa72140c18067e07d541ca92b",
+  title: "gomate-cache-v2",
+};
+const LEGACY_WORKERS = [
+  "gomate-api",
+  "gomate-frontend",
+  "gomate-production-preview-production",
+];
+const LEGACY_D1 = {
+  id: "7d17d076-202f-48f8-b343-24209cdb0ba1",
+  name: "gomate-db",
+};
+const LEGACY_KV = [
+  { id: "638ecd78e70c48fda01904bc9c2105d8", title: "GOMATE_KV" },
+  {
+    id: "6e3db6b00bc4421faeb1402c2e51f7d1",
+    title: "gomate-frontend-session",
+  },
+];
+
+function required(value, label) {
+  const result = value?.trim();
+  if (!result) throw new Error(`${label} is required`);
+  return result;
+}
+
+async function cloudflareRequest({
+  accountId,
+  apiToken,
+  resourcePath,
+  method = "GET",
+  fetchImpl,
+}) {
+  const response = await fetchImpl(
+    `${API_ROOT}/accounts/${encodeURIComponent(accountId)}${resourcePath}`,
+    { method, headers: { Authorization: `Bearer ${apiToken}` } },
+  );
+  const payload = await response.json().catch(() => null);
+  if (!response.ok || payload?.success !== true) {
+    throw new Error(
+      `Cloudflare retirement request failed (${response.status})`,
+    );
+  }
+  return payload.result;
+}
+
+async function inventory({ accountId, apiToken, fetchImpl }) {
+  const [domains, workers, databases, namespaces, r2] = await Promise.all([
+    cloudflareRequest({
+      accountId,
+      apiToken,
+      resourcePath: "/workers/domains",
+      fetchImpl,
+    }),
+    cloudflareRequest({
+      accountId,
+      apiToken,
+      resourcePath: "/workers/scripts",
+      fetchImpl,
+    }),
+    cloudflareRequest({
+      accountId,
+      apiToken,
+      resourcePath: "/d1/database",
+      fetchImpl,
+    }),
+    cloudflareRequest({
+      accountId,
+      apiToken,
+      resourcePath: "/storage/kv/namespaces",
+      fetchImpl,
+    }),
+    cloudflareRequest({
+      accountId,
+      apiToken,
+      resourcePath: "/r2/buckets",
+      fetchImpl,
+    }),
+  ]);
+  if (
+    !Array.isArray(domains) ||
+    !Array.isArray(workers) ||
+    !Array.isArray(databases) ||
+    !Array.isArray(namespaces) ||
+    !Array.isArray(r2?.buckets)
+  ) {
+    throw new Error("Cloudflare retirement inventory is invalid");
+  }
+  return { domains, workers, databases, namespaces, buckets: r2.buckets };
+}
+
+function assertProductionResources(state) {
+  const productionDomains = state.domains.filter(
+    (domain) => domain.hostname === "gomate.live",
+  );
+  if (
+    productionDomains.length !== 1 ||
+    productionDomains[0].service !== PRODUCTION_WORKER ||
+    productionDomains[0].zone_id !== ZONE_ID
+  ) {
+    throw new Error("gomate.live is not owned by the reviewed unified Worker");
+  }
+  if (!state.workers.some((worker) => worker.id === PRODUCTION_WORKER)) {
+    throw new Error("Production unified Worker is missing");
+  }
+  if (
+    !state.databases.some(
+      (database) =>
+        database.uuid === PRODUCTION_D1.id &&
+        database.name === PRODUCTION_D1.name,
+    )
+  ) {
+    throw new Error("Production V2 D1 is missing");
+  }
+  if (
+    !state.namespaces.some(
+      (namespace) =>
+        namespace.id === PRODUCTION_KV.id &&
+        namespace.title === PRODUCTION_KV.title,
+    )
+  ) {
+    throw new Error("Production V2 KV is missing");
+  }
+  if (!state.buckets.some((bucket) => bucket.name === "gomate")) {
+    throw new Error("Shared gomate R2 bucket is missing");
+  }
+}
+
+function assertLegacyIdentity(state) {
+  const databaseById = state.databases.find(
+    (database) => database.uuid === LEGACY_D1.id,
+  );
+  const databaseByName = state.databases.find(
+    (database) => database.name === LEGACY_D1.name,
+  );
+  if (
+    (databaseById && databaseById.name !== LEGACY_D1.name) ||
+    (databaseByName && databaseByName.uuid !== LEGACY_D1.id)
+  ) {
+    throw new Error("Legacy D1 identity does not match the reviewed target");
+  }
+  for (const target of LEGACY_KV) {
+    const byId = state.namespaces.find(
+      (namespace) => namespace.id === target.id,
+    );
+    const byTitle = state.namespaces.find(
+      (namespace) => namespace.title === target.title,
+    );
+    if (
+      (byId && byId.title !== target.title) ||
+      (byTitle && byTitle.id !== target.id)
+    ) {
+      throw new Error("Legacy KV identity does not match the reviewed target");
+    }
+  }
+  const apiDomains = state.domains.filter(
+    (domain) => domain.hostname === "api.gomate.live",
+  );
+  if (
+    apiDomains.length > 1 ||
+    (apiDomains.length === 1 &&
+      (apiDomains[0].service !== "gomate-api" ||
+        apiDomains[0].zone_id !== ZONE_ID))
+  ) {
+    throw new Error("Legacy API domain identity is invalid");
+  }
+}
+
+async function verifyPublicProduction({ baseUrl, fetchImpl }) {
+  const health = await fetchImpl(new URL("/api/health", baseUrl));
+  const healthPayload = await health.json().catch(() => null);
+  if (!health.ok || healthPayload?.status !== "ok") {
+    throw new Error("Production health failed after retirement");
+  }
+  const regions = await fetchImpl(
+    new URL(
+      "/api/regions?countryCode=CN&level=city&serviceEnabled=true",
+      baseUrl,
+    ),
+  );
+  const regionPayload = await regions.json().catch(() => null);
+  if (
+    !regions.ok ||
+    regionPayload?.success !== true ||
+    !regionPayload.regions?.some((region) => region.id === "region-cn-shenzhen")
+  ) {
+    throw new Error("Production Region verification failed after retirement");
+  }
+}
+
+export async function retireLegacyProduction({
+  accountId = process.env.CLOUDFLARE_ACCOUNT_ID,
+  apiToken = process.env.CLOUDFLARE_API_TOKEN,
+  baseUrl = process.env.PRODUCTION_APP_URL,
+  nowImpl = Date.now,
+  fetchImpl = fetch,
+} = {}) {
+  accountId = required(accountId, "CLOUDFLARE_ACCOUNT_ID");
+  apiToken = required(apiToken, "CLOUDFLARE_API_TOKEN");
+  baseUrl = required(baseUrl, "PRODUCTION_APP_URL");
+  if (accountId !== ACCOUNT_ID || baseUrl !== "https://gomate.live") {
+    throw new Error("Legacy retirement target is not the reviewed production");
+  }
+  if (nowImpl() < RETIRE_NOT_BEFORE) {
+    throw new Error("Mandatory seven-day retention window has not elapsed");
+  }
+
+  const before = await inventory({ accountId, apiToken, fetchImpl });
+  assertProductionResources(before);
+  assertLegacyIdentity(before);
+  const deleted = [];
+  const apiDomain = before.domains.find(
+    (domain) => domain.hostname === "api.gomate.live",
+  );
+  if (apiDomain) {
+    await cloudflareRequest({
+      accountId,
+      apiToken,
+      resourcePath: `/workers/domains/${encodeURIComponent(apiDomain.id)}`,
+      method: "DELETE",
+      fetchImpl,
+    });
+    deleted.push("domain:api.gomate.live");
+  }
+  for (const workerName of LEGACY_WORKERS) {
+    if (before.workers.some((worker) => worker.id === workerName)) {
+      await cloudflareRequest({
+        accountId,
+        apiToken,
+        resourcePath: `/workers/scripts/${encodeURIComponent(workerName)}`,
+        method: "DELETE",
+        fetchImpl,
+      });
+      deleted.push(`worker:${workerName}`);
+    }
+  }
+  if (before.databases.some((database) => database.uuid === LEGACY_D1.id)) {
+    await cloudflareRequest({
+      accountId,
+      apiToken,
+      resourcePath: `/d1/database/${LEGACY_D1.id}`,
+      method: "DELETE",
+      fetchImpl,
+    });
+    deleted.push(`d1:${LEGACY_D1.name}`);
+  }
+  for (const target of LEGACY_KV) {
+    if (before.namespaces.some((namespace) => namespace.id === target.id)) {
+      await cloudflareRequest({
+        accountId,
+        apiToken,
+        resourcePath: `/storage/kv/namespaces/${target.id}`,
+        method: "DELETE",
+        fetchImpl,
+      });
+      deleted.push(`kv:${target.title}`);
+    }
+  }
+
+  const after = await inventory({ accountId, apiToken, fetchImpl });
+  assertProductionResources(after);
+  if (
+    after.domains.some((domain) => domain.hostname === "api.gomate.live") ||
+    after.workers.some((worker) => LEGACY_WORKERS.includes(worker.id)) ||
+    after.databases.some((database) => database.uuid === LEGACY_D1.id) ||
+    after.namespaces.some((namespace) =>
+      LEGACY_KV.some((target) => target.id === namespace.id),
+    )
+  ) {
+    throw new Error("Legacy Cloudflare resource retirement is incomplete");
+  }
+  await verifyPublicProduction({ baseUrl, fetchImpl });
+  return { deleted };
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+) {
+  retireLegacyProduction()
+    .then(({ deleted }) => {
+      const lines = [
+        "### Legacy Cloudflare retirement complete",
+        ...deleted.map((resource) => `- Deleted ${resource}`),
+        "- Preserved gomate-production-preview, gomate-db-v2, gomate-cache-v2, and R2 gomate.",
+        "- Verified gomate.live health and Shenzhen Region after retirement.",
+      ];
+      if (process.env.GITHUB_STEP_SUMMARY) {
+        appendFileSync(
+          process.env.GITHUB_STEP_SUMMARY,
+          `${lines.join("\n")}\n`,
+        );
+      }
+      console.log(lines.join("\n"));
+    })
+    .catch((error) => {
+      console.error(`[legacy-retirement] ${error.message}`);
+      process.exit(1);
+    });
+}

--- a/scripts/retire-legacy-production.test.mjs
+++ b/scripts/retire-legacy-production.test.mjs
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { retireLegacyProduction } from "./retire-legacy-production.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const accountRoot =
+  "https://api.cloudflare.com/client/v4/accounts/e3afbb613458022947cd9dc9f5bd6334";
+
+function initialState({ includeLegacy = true, productionService } = {}) {
+  return {
+    domains: [
+      {
+        id: "domain-production",
+        hostname: "gomate.live",
+        service: productionService ?? "gomate-production-preview",
+        zone_id: "0b714cd4257332034b3c4c0c099feb9e",
+      },
+      ...(includeLegacy
+        ? [
+            {
+              id: "domain-api",
+              hostname: "api.gomate.live",
+              service: "gomate-api",
+              zone_id: "0b714cd4257332034b3c4c0c099feb9e",
+            },
+          ]
+        : []),
+    ],
+    workers: [
+      { id: "gomate-production-preview" },
+      ...(includeLegacy
+        ? [
+            { id: "gomate-api" },
+            { id: "gomate-frontend" },
+            { id: "gomate-production-preview-production" },
+          ]
+        : []),
+    ],
+    databases: [
+      {
+        uuid: "befa3d89-6551-4a25-8a1c-670efe62a315",
+        name: "gomate-db-v2",
+      },
+      ...(includeLegacy
+        ? [
+            {
+              uuid: "7d17d076-202f-48f8-b343-24209cdb0ba1",
+              name: "gomate-db",
+            },
+          ]
+        : []),
+    ],
+    namespaces: [
+      {
+        id: "f9904d1fa72140c18067e07d541ca92b",
+        title: "gomate-cache-v2",
+      },
+      ...(includeLegacy
+        ? [
+            {
+              id: "638ecd78e70c48fda01904bc9c2105d8",
+              title: "GOMATE_KV",
+            },
+            {
+              id: "6e3db6b00bc4421faeb1402c2e51f7d1",
+              title: "gomate-frontend-session",
+            },
+          ]
+        : []),
+    ],
+    buckets: [{ name: "gomate" }],
+  };
+}
+
+function fakeCloudflare(state, requests) {
+  return async (url, init = {}) => {
+    const value = String(url);
+    const method = init.method ?? "GET";
+    requests.push({ url: value, method });
+    if (value === "https://gomate.live/api/health") {
+      return Response.json({ status: "ok" });
+    }
+    if (value.startsWith("https://gomate.live/api/regions?")) {
+      return Response.json({
+        success: true,
+        regions: [{ id: "region-cn-shenzhen" }],
+      });
+    }
+    const relative = value.slice(accountRoot.length);
+    if (method === "GET") {
+      const result =
+        relative === "/workers/domains"
+          ? state.domains
+          : relative === "/workers/scripts"
+            ? state.workers
+            : relative === "/d1/database"
+              ? state.databases
+              : relative === "/storage/kv/namespaces"
+                ? state.namespaces
+                : relative === "/r2/buckets"
+                  ? { buckets: state.buckets }
+                  : null;
+      return Response.json(
+        { success: result !== null, result },
+        { status: result === null ? 404 : 200 },
+      );
+    }
+    if (method !== "DELETE") {
+      return Response.json({ success: false }, { status: 405 });
+    }
+    if (relative.startsWith("/workers/domains/")) {
+      const id = decodeURIComponent(relative.split("/").at(-1));
+      state.domains = state.domains.filter((domain) => domain.id !== id);
+    } else if (relative.startsWith("/workers/scripts/")) {
+      const id = decodeURIComponent(relative.split("/").at(-1));
+      state.workers = state.workers.filter((worker) => worker.id !== id);
+    } else if (relative.startsWith("/d1/database/")) {
+      const id = relative.split("/").at(-1);
+      state.databases = state.databases.filter(
+        (database) => database.uuid !== id,
+      );
+    } else if (relative.startsWith("/storage/kv/namespaces/")) {
+      const id = relative.split("/").at(-1);
+      state.namespaces = state.namespaces.filter(
+        (namespace) => namespace.id !== id,
+      );
+    } else {
+      return Response.json({ success: false }, { status: 404 });
+    }
+    return Response.json({ success: true, result: null });
+  };
+}
+
+test("legacy retirement fails before the mandatory seven-day boundary", async () => {
+  let fetched = false;
+  await assert.rejects(
+    () =>
+      retireLegacyProduction({
+        accountId: "e3afbb613458022947cd9dc9f5bd6334",
+        apiToken: "test-token",
+        baseUrl: "https://gomate.live",
+        nowImpl: () => Date.parse("2026-08-23T18:53:00Z"),
+        fetchImpl: async () => {
+          fetched = true;
+          throw new Error("must not fetch");
+        },
+      }),
+    /seven-day retention/u,
+  );
+  assert.equal(fetched, false);
+});
+
+test("legacy retirement deletes only reviewed legacy resources", async () => {
+  const state = initialState();
+  const requests = [];
+  const result = await retireLegacyProduction({
+    accountId: "e3afbb613458022947cd9dc9f5bd6334",
+    apiToken: "test-token",
+    baseUrl: "https://gomate.live",
+    nowImpl: () => Date.parse("2026-08-23T18:53:01Z"),
+    fetchImpl: fakeCloudflare(state, requests),
+  });
+  assert.deepEqual(result.deleted, [
+    "domain:api.gomate.live",
+    "worker:gomate-api",
+    "worker:gomate-frontend",
+    "worker:gomate-production-preview-production",
+    "d1:gomate-db",
+    "kv:GOMATE_KV",
+    "kv:gomate-frontend-session",
+  ]);
+  assert.equal(state.workers.length, 1);
+  assert.equal(state.workers[0].id, "gomate-production-preview");
+  assert.equal(state.databases.length, 1);
+  assert.equal(state.namespaces.length, 1);
+  assert.deepEqual(state.buckets, [{ name: "gomate" }]);
+  assert.equal(requests.filter(({ method }) => method === "DELETE").length, 7);
+});
+
+test("legacy retirement is idempotent after reviewed resources are absent", async () => {
+  const state = initialState({ includeLegacy: false });
+  const requests = [];
+  const result = await retireLegacyProduction({
+    accountId: "e3afbb613458022947cd9dc9f5bd6334",
+    apiToken: "test-token",
+    baseUrl: "https://gomate.live",
+    nowImpl: () => Date.parse("2026-08-24T00:00:00Z"),
+    fetchImpl: fakeCloudflare(state, requests),
+  });
+  assert.deepEqual(result.deleted, []);
+  assert.equal(
+    requests.some(({ method }) => method === "DELETE"),
+    false,
+  );
+});
+
+test("legacy retirement fails closed when production domain ownership drifts", async () => {
+  const state = initialState({ productionService: "gomate-frontend" });
+  const requests = [];
+  await assert.rejects(
+    () =>
+      retireLegacyProduction({
+        accountId: "e3afbb613458022947cd9dc9f5bd6334",
+        apiToken: "test-token",
+        baseUrl: "https://gomate.live",
+        nowImpl: () => Date.parse("2026-08-24T00:00:00Z"),
+        fetchImpl: fakeCloudflare(state, requests),
+      }),
+    /reviewed unified Worker/u,
+  );
+  assert.equal(
+    requests.some(({ method }) => method === "DELETE"),
+    false,
+  );
+});
+
+test("legacy retirement workflow is protected and has no R2 deletion", () => {
+  const workflow = readFileSync(
+    path.join(root, ".github/workflows/retire-legacy-production.yml"),
+    "utf8",
+  );
+  assert.match(workflow, /RETIRE_LEGACY_RESOURCES/u);
+  assert.match(workflow, /github\.ref\s*==\s*'refs\/heads\/main'/u);
+  assert.match(workflow, /environment:\s*production/u);
+  assert.match(workflow, /retire-legacy-production\.mjs/u);
+  assert.doesNotMatch(workflow, /wrangler\s+r2|migrations apply|seed\.sql/iu);
+});


### PR DESCRIPTION
## Summary
- add a protected Stage D workflow for exact legacy Cloudflare retirement after the mandatory seven-day window
- lock all deletions to reviewed Worker, D1, KV, and api.gomate.live identities
- verify new Worker/D1/KV, shared R2, health, and Shenzhen Region before and after deletion
- make partial-failure retries idempotent and fail closed on any production drift

## Exact retirement scope
- domain: api.gomate.live
- Workers: gomate-api, gomate-frontend, gomate-production-preview-production
- D1: gomate-db / 7d17d076-202f-48f8-b343-24209cdb0ba1
- KV: GOMATE_KV / 638ecd78e70c48fda01904bc9c2105d8
- KV: gomate-frontend-session / 6e3db6b00bc4421faeb1402c2e51f7d1

The workflow contains no R2 delete path and cannot run before 2026-08-23T18:53:01Z.

## Evidence
- pnpm test:delivery outside sandbox: 46/46
- retirement focused tests: 5/5
- Prettier check, node --check, git diff --check: pass

## Operational plan
After merge, a one-shot Codex automation will dispatch this workflow from main at 2026-08-24 03:00 Asia/Shanghai, approve the production environment only after a fresh read-only preflight, wait for completion, and report exact deletion evidence.