### PR TITLE
data: migrate legacy locations to V2 D1

### DIFF
--- a/.github/workflows/migrate-production-locations.yml
+++ b/.github/workflows/migrate-production-locations.yml
@@ -1,0 +1,119 @@
+name: Migrate production V2 Locations
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: Type MIGRATE_LEGACY_LOCATIONS to import the reviewed 36-row snapshot
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: migrate-production-v2-locations
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    name: Migrate reviewed production Locations
+    if: inputs.confirm == 'MIGRATE_LEGACY_LOCATIONS' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: production
+    env:
+      CLOUDFLARE_ENV: production
+      SOURCE_JSON: ${{ runner.temp }}/legacy-locations.json
+      TARGET_PREFLIGHT_JSON: ${{ runner.temp }}/location-target-preflight.json
+      APPLY_SQL: ${{ runner.temp }}/locations-v1.sql
+      ROLLBACK_SQL: ${{ runner.temp }}/locations-v1.rollback.sql
+      MANIFEST_JSON: ${{ runner.temp }}/location-migration-manifest.json
+      LOCATIONS_JSON: ${{ runner.temp }}/location-postflight.json
+      REGIONS_JSON: ${{ runner.temp }}/location-region-postflight.json
+      EVIDENCE_JSON: ${{ runner.temp }}/location-migration-evidence.json
+      PUBLIC_JSON: ${{ runner.temp }}/location-public-api.json
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.0.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Verify migration contract tests
+        run: node --test scripts/location-migration-contract.test.mjs
+
+      - name: Read and validate the immutable legacy Location snapshot
+        working-directory: frontend
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          for attempt in 1 2 3; do
+            if pnpm exec wrangler d1 execute 7d17d076-202f-48f8-b343-24209cdb0ba1 --remote --json --command "SELECT l.*, c.adcode AS city_adcode, c.name AS canonical_city_name, c.province AS city_province FROM locations l JOIN cities c ON c.id = l.city_id ORDER BY l.id" > "$SOURCE_JSON"; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then exit 1; fi
+            sleep 5
+          done
+          node ../scripts/location-migration-contract.mjs source "$SOURCE_JSON" "$APPLY_SQL" "$ROLLBACK_SQL" "$MANIFEST_JSON"
+
+      - name: Prove the V2 target is ready for the exact import
+        working-directory: frontend
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          pnpm exec wrangler d1 execute DB --env production --remote --config wrangler.jsonc --json --command "SELECT (SELECT count(*) FROM locations) AS location_count, (SELECT json_group_array(id) FROM (SELECT id FROM region ORDER BY id)) AS region_ids" > "$TARGET_PREFLIGHT_JSON"
+          node ../scripts/location-migration-contract.mjs target-preflight "$TARGET_PREFLIGHT_JSON"
+
+      - name: Apply the reviewed Region and Location import
+        working-directory: frontend
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm exec wrangler d1 execute DB --env production --remote --config wrangler.jsonc --file "$APPLY_SQL"
+
+      - name: Validate exact D1 rows and public API projection
+        working-directory: frontend
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          pnpm exec wrangler d1 execute DB --env production --remote --config wrangler.jsonc --json --command "SELECT id, region_id, name, slug, supported_activity_types, status, subtitle, description, address, latitude, longitude, cover_image_url, images, extra, created_by_user_id, created_at, updated_at FROM locations ORDER BY id" > "$LOCATIONS_JSON"
+          pnpm exec wrangler d1 execute DB --env production --remote --config wrangler.jsonc --json --command "SELECT id, country_code, parent_id, name, name_en, slug, code, level, timezone, center_latitude, center_longitude, service_enabled, is_hot, sort_order, created_at, updated_at FROM region WHERE id NOT IN ('region-cn', 'region-cn-guangdong', 'region-cn-shenzhen') ORDER BY id" > "$REGIONS_JSON"
+          node ../scripts/location-migration-contract.mjs postflight "$SOURCE_JSON" "$LOCATIONS_JSON" "$REGIONS_JSON" "$EVIDENCE_JSON"
+          for attempt in 1 2 3 4 5 6; do
+            if curl --fail --silent --show-error 'https://gomate.live/api/locations?limit=100' > "$PUBLIC_JSON" && node ../scripts/location-migration-contract.mjs public "$SOURCE_JSON" "$PUBLIC_JSON"; then
+              break
+            fi
+            if [ "$attempt" -eq 6 ]; then exit 1; fi
+            sleep 5
+          done
+
+      - name: Record production Location migration evidence
+        run: |
+          {
+            echo "### Production V2 Location migration complete"
+            echo "- Source snapshot: 36 legacy Locations"
+            echo "- Target: \`gomate-db-v2\`"
+            echo "- Added: 5 provinces, 11 non-Shenzhen cities, 36 published Locations"
+            echo "- No user, Team, Story, tag, Worker, route, R2, KV, secret, or domain mutation was performed."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload migration and rollback evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gomate-production-location-migration
+          path: |
+            ${{ runner.temp }}/location-migration-manifest.json
+            ${{ runner.temp }}/location-migration-evidence.json
+            ${{ runner.temp }}/locations-v1.sql
+            ${{ runner.temp }}/locations-v1.rollback.sql
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/prod-change-policy.md
+++ b/docs/prod-change-policy.md
@@ -1,6 +1,7 @@
 # GoMate 单 Worker / D1 V2 生产变更规约
 
-> 2026-08-16 起适用。当前没有真实用户，本次发布创建全新资源，不迁移旧 D1。
+> 2026-08-16 起适用。当前没有真实用户；认证和活动数据不迁移，但切流后按单独批准将旧库
+> 36 条公开地点转换为 V2 Region/Location 数据。
 
 ## 1. 当前发布边界
 
@@ -106,6 +107,24 @@ preview 部署自动发生。
 再通过 Cloudflare Workers custom-domain API 把 `gomate.live` 精确重新附加到
 `gomate-frontend`。回滚不删除 V2 D1、KV、R2、Worker、版本或 secrets。
 
+### 阶段 C.1：旧地点数据一次性导入
+
+阶段 C 切流后、阶段 D 删除旧 D1 前，从 `main` 手动运行
+`Migrate production V2 Locations` 并输入 `MIGRATE_LEGACY_LOCATIONS`，通过
+`production` environment 审批。该工作流只读旧 D1 固定 UUID
+`7d17d076-202f-48f8-b343-24209cdb0ba1`，要求旧地点查询恰好返回 36 行且规范化快照
+SHA-256 为 `7685b4d2424271c2d5fc7bd871c8e25e20dbecd9a336477a4b16552b45662677`；任一字段
+变化都必须在写入前失败闭合。
+
+转换只新增 5 个省级 Region、11 个非深圳 city Region 和 36 个 published Location，保留旧地点
+ID、名称、slug、描述、坐标、HTTPS 媒体 URL 与时间戳；活动类型转为
+`supported_activity_types`，徒步字段转为 V2 `extra.hiking` snake_case。旧库没有任何地点标签关联，
+因此不得从未关联的旧标签词典伪造 `location_tags`。目标写入前必须证明新库仍只有首发三条
+Region 且 `locations=0`；写入后必须逐字段比对 36 条 V2 projection、16 条新增 Region，并通过
+`/api/locations?limit=100` 证明全部公开可读。工作流不得修改用户、队伍、故事、标签、Worker、
+route、domain、KV、R2、secret 或 migration ledger；精确 rollback SQL 只作为 90 天 artifact
+保存，不自动执行。
+
 ### 阶段 D：旧资源退役
 
 阶段 C 于 2026-08-16T18:53:01Z 完成；旧资源最早只能在
@@ -122,14 +141,15 @@ preview 部署自动发生。
 
 脚本不得调用 R2 删除 API；执行后重新读取 Cloudflare inventory，并验证生产 Worker、
 `gomate-db-v2`、`gomate-cache-v2`、R2 `gomate`、health 和深圳 Region。任一名称、ID、域名归属、
-时间边界或生产资源不匹配时，在首个 DELETE 前失败闭合。流水线可安全重跑：已经删除的精确旧资源
-视为完成，但新资源缺失仍立即失败。
+时间边界、36 条地点迁移结果或生产资源不匹配时，在首个 DELETE 前失败闭合。流水线可安全重跑：
+已经删除的精确旧资源视为完成，但新资源缺失仍立即失败。
 
 ## 4. 回滚
 
 - 应用回滚：核实 Worker deployment/version 对应的 commit 后，回滚到已验证版本。
 - route 回滚：将 `gomate.live` 恢复到旧 Worker；不要删除新资源。
-- 数据回滚：V2 首发没有旧数据迁移。出现 schema 或写入问题时先把
+- 数据回滚：地点导入前由 workflow 生成精确 rollback SQL 并保存 90 天；该 SQL 仍需单独批准，
+  且只能在没有新 Team/Story 引用迁入地点时执行。出现 schema 或写入问题时先把
   `WRITE_MODE` 恢复为 `protected`，再从 D1 Time Travel/备份恢复或创建新的 V2
   数据库；不得修改已应用的 migration 文件。
 - secrets 与资源只有在稳定观察期结束后才能清理，清理需再次显式批准。

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "i18n:gen-types": "node scripts/gen-i18n-types.mjs",
     "i18n:build": "tsx scripts/build-locales.ts",
     "check:legacy-removal": "node scripts/check-legacy-removal.mjs",
-    "test:delivery": "node --test scripts/check-legacy-removal.test.mjs scripts/deployment-guards.test.mjs scripts/production-cutover.test.mjs scripts/promote-admin.test.mjs scripts/region-bootstrap-contract.test.mjs scripts/reset-local-db.test.mjs scripts/retire-legacy-production.test.mjs",
+    "test:delivery": "node --test scripts/check-legacy-removal.test.mjs scripts/deployment-guards.test.mjs scripts/location-migration-contract.test.mjs scripts/production-cutover.test.mjs scripts/promote-admin.test.mjs scripts/region-bootstrap-contract.test.mjs scripts/reset-local-db.test.mjs scripts/retire-legacy-production.test.mjs",
     "prepare": "husky",
     "dev:wt": "node scripts/init-worktree.mjs && node scripts/start-worktree.mjs",
     "init:worktree": "node scripts/init-worktree.mjs"

--- a/scripts/location-migration-contract.mjs
+++ b/scripts/location-migration-contract.mjs
@@ -1,0 +1,708 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+
+export const EXPECTED_LEGACY_LOCATION_COUNT = 36;
+export const EXPECTED_LEGACY_LOCATION_SHA256 =
+  "7685b4d2424271c2d5fc7bd871c8e25e20dbecd9a336477a4b16552b45662677";
+
+const EXISTING_REGION_IDS = [
+  "region-cn",
+  "region-cn-guangdong",
+  "region-cn-shenzhen",
+];
+const MIGRATION_TIMESTAMP = Date.parse("2026-08-17T05:30:00Z");
+const ACTIVITY_TYPES = new Set(["hiking", "explore", "leisure", "travel"]);
+const DIFFICULTIES = new Set(["easy", "moderate", "hard", "expert"]);
+
+const PROVINCES = [
+  [
+    "region-cn-guangxi",
+    "region-cn",
+    "广西壮族自治区",
+    "Guangxi",
+    "guangxi",
+    "450000",
+    30,
+  ],
+  ["region-cn-hunan", "region-cn", "湖南省", "Hunan", "hunan", "430000", 40],
+  [
+    "region-cn-jiangxi",
+    "region-cn",
+    "江西省",
+    "Jiangxi",
+    "jiangxi",
+    "360000",
+    50,
+  ],
+  [
+    "region-cn-sichuan",
+    "region-cn",
+    "四川省",
+    "Sichuan",
+    "sichuan",
+    "510000",
+    60,
+  ],
+  ["region-cn-yunnan", "region-cn", "云南省", "Yunnan", "yunnan", "530000", 70],
+].map(([id, parentId, name, nameEn, slug, code, sortOrder]) => ({
+  id,
+  country_code: "CN",
+  parent_id: parentId,
+  name,
+  name_en: nameEn,
+  slug,
+  code,
+  level: "province",
+  timezone: null,
+  center_latitude: null,
+  center_longitude: null,
+  service_enabled: 0,
+  is_hot: 0,
+  sort_order: sortOrder,
+  created_at: MIGRATION_TIMESTAMP,
+  updated_at: MIGRATION_TIMESTAMP,
+}));
+
+const CITY_BY_CODE = new Map(
+  [
+    [
+      "440300",
+      "region-cn-shenzhen",
+      "region-cn-guangdong",
+      "深圳市",
+      "Shenzhen",
+      "shenzhen",
+      "Asia/Shanghai",
+      22.5431,
+      114.0579,
+      10,
+      true,
+    ],
+    [
+      "441300",
+      "region-cn-huizhou",
+      "region-cn-guangdong",
+      "惠州市",
+      "Huizhou",
+      "huizhou",
+      "Asia/Shanghai",
+      23.1115,
+      114.4168,
+      20,
+    ],
+    [
+      "450200",
+      "region-cn-liuzhou",
+      "region-cn-guangxi",
+      "柳州市",
+      "Liuzhou",
+      "liuzhou",
+      "Asia/Shanghai",
+      24.3265,
+      109.4285,
+      30,
+    ],
+    [
+      "430100",
+      "region-cn-changsha",
+      "region-cn-hunan",
+      "长沙市",
+      "Changsha",
+      "changsha",
+      "Asia/Shanghai",
+      28.2282,
+      112.9388,
+      40,
+    ],
+    [
+      "360300",
+      "region-cn-pingxiang",
+      "region-cn-jiangxi",
+      "萍乡市",
+      "Pingxiang",
+      "pingxiang",
+      "Asia/Shanghai",
+      27.6229,
+      113.8547,
+      50,
+    ],
+    [
+      "510100",
+      "region-cn-chengdu",
+      "region-cn-sichuan",
+      "成都市",
+      "Chengdu",
+      "chengdu",
+      "Asia/Shanghai",
+      30.5728,
+      104.0668,
+      60,
+    ],
+    [
+      "530100",
+      "region-cn-kunming",
+      "region-cn-yunnan",
+      "昆明市",
+      "Kunming",
+      "kunming",
+      "Asia/Shanghai",
+      25.0389,
+      102.7183,
+      70,
+    ],
+    [
+      "530700",
+      "region-cn-lijiang",
+      "region-cn-yunnan",
+      "丽江市",
+      "Lijiang",
+      "lijiang",
+      "Asia/Shanghai",
+      26.8721,
+      100.2299,
+      80,
+    ],
+    [
+      "532800",
+      "region-cn-xishuangbanna",
+      "region-cn-yunnan",
+      "西双版纳傣族自治州",
+      "Xishuangbanna",
+      "xishuangbanna",
+      "Asia/Shanghai",
+      22.0017,
+      100.797,
+      90,
+    ],
+    [
+      "532900",
+      "region-cn-dali",
+      "region-cn-yunnan",
+      "大理白族自治州",
+      "Dali",
+      "dali",
+      "Asia/Shanghai",
+      25.6065,
+      100.2676,
+      100,
+    ],
+    [
+      "810000",
+      "region-cn-hong-kong",
+      "region-cn",
+      "香港特别行政区",
+      "Hong Kong",
+      "hong-kong",
+      "Asia/Hong_Kong",
+      22.3193,
+      114.1694,
+      110,
+    ],
+    [
+      "820000",
+      "region-cn-macau",
+      "region-cn",
+      "澳门特别行政区",
+      "Macau",
+      "macau",
+      "Asia/Macau",
+      22.1987,
+      113.5439,
+      120,
+    ],
+  ].map(
+    ([
+      code,
+      id,
+      parentId,
+      name,
+      nameEn,
+      slug,
+      timezone,
+      latitude,
+      longitude,
+      sortOrder,
+      existing = false,
+    ]) => [
+      code,
+      {
+        id,
+        country_code: "CN",
+        parent_id: parentId,
+        name,
+        name_en: nameEn,
+        slug,
+        code,
+        level: "city",
+        timezone,
+        center_latitude: latitude,
+        center_longitude: longitude,
+        service_enabled: 1,
+        is_hot: existing ? 1 : 0,
+        sort_order: sortOrder,
+        created_at: MIGRATION_TIMESTAMP,
+        updated_at: MIGRATION_TIMESTAMP,
+        existing,
+      },
+    ],
+  ),
+);
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function parseJson(value, fallback, label) {
+  if (value == null || value === "") return fallback;
+  try {
+    return typeof value === "string" ? JSON.parse(value) : value;
+  } catch {
+    throw new Error(`${label} must be valid JSON`);
+  }
+}
+
+function stringArray(value, label) {
+  const parsed = parseJson(value, [], label);
+  if (
+    !Array.isArray(parsed) ||
+    parsed.some((item) => typeof item !== "string")
+  ) {
+    throw new Error(`${label} must be a string array`);
+  }
+  return [...new Set(parsed.map((item) => item.trim()).filter(Boolean))];
+}
+
+function optionalNumber(value, label) {
+  if (value == null) return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`${label} must be a non-negative number`);
+  }
+  return parsed;
+}
+
+function sqlValue(value) {
+  if (value == null) return "NULL";
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new Error("SQL number must be finite");
+    return String(value);
+  }
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function insertSql(table, columns, rows) {
+  const values = rows
+    .map(
+      (row) =>
+        `  (${columns.map((column) => sqlValue(row[column])).join(", ")})`,
+    )
+    .join(",\n");
+  return `INSERT INTO \`${table}\` (${columns.map((column) => `\`${column}\``).join(", ")}) VALUES\n${values};`;
+}
+
+function normalizeExtra(row) {
+  const legacy = parseJson(row.extra, {}, `${row.id}.extra`);
+  if (legacy == null || Array.isArray(legacy) || typeof legacy !== "object") {
+    throw new Error(`${row.id}.extra must be an object`);
+  }
+  const result = {};
+  const facilities = Array.isArray(legacy.facilities)
+    ? [
+        ...new Set(
+          legacy.facilities
+            .filter((item) => typeof item === "string")
+            .map((item) => item.trim())
+            .filter(Boolean),
+        ),
+      ]
+    : [];
+  if (row.type === "hiking") {
+    const legacyHiking =
+      legacy.hiking &&
+      !Array.isArray(legacy.hiking) &&
+      typeof legacy.hiking === "object"
+        ? legacy.hiking
+        : {};
+    const hiking = {};
+    if (row.difficulty != null) {
+      if (!DIFFICULTIES.has(row.difficulty)) {
+        throw new Error(`${row.id}.difficulty is invalid`);
+      }
+      hiking.difficulty = row.difficulty;
+    }
+    const numbers = [
+      ["duration_min", row.duration_min],
+      ["duration_max", row.duration_max],
+      ["distance_km", row.distance],
+      ["elevation_gain_m", row.elevation],
+    ];
+    for (const [key, value] of numbers) {
+      const parsed = optionalNumber(value, `${row.id}.${key}`);
+      if (parsed !== undefined) hiking[key] = parsed;
+    }
+    const bestSeasons = stringArray(row.best_season, `${row.id}.best_season`);
+    const gearEssential = stringArray(
+      row.gear_essential,
+      `${row.id}.gear_essential`,
+    );
+    const gearOptional = stringArray(
+      row.gear_optional,
+      `${row.id}.gear_optional`,
+    );
+    const tips = Array.isArray(legacyHiking.tips)
+      ? legacyHiking.tips
+      : Array.isArray(legacy.tips)
+        ? legacy.tips
+        : [];
+    const warnings = Array.isArray(legacyHiking.warnings)
+      ? legacyHiking.warnings
+      : Array.isArray(legacy.warnings)
+        ? legacy.warnings
+        : [];
+    if (bestSeasons.length) hiking.best_seasons = bestSeasons;
+    if (gearEssential.length) hiking.gear_essential = gearEssential;
+    if (gearOptional.length) hiking.gear_optional = gearOptional;
+    if (typeof legacyHiking.overview === "string") {
+      hiking.overview = legacyHiking.overview;
+    }
+    const cleanTips = tips
+      .filter((item) => typeof item === "string" && item.trim())
+      .map((item) => item.trim());
+    const cleanWarnings = warnings
+      .filter((item) => typeof item === "string" && item.trim())
+      .map((item) => item.trim());
+    if (cleanTips.length) hiking.tips = [...new Set(cleanTips)];
+    if (cleanWarnings.length) hiking.warnings = [...new Set(cleanWarnings)];
+    result.hiking = hiking;
+  }
+  if (facilities.length) result.facilities = facilities;
+  return result;
+}
+
+function transformLocation(row) {
+  if (!ACTIVITY_TYPES.has(row.type)) {
+    throw new Error(`${row.id}.type is invalid`);
+  }
+  const city = CITY_BY_CODE.get(String(row.city_adcode));
+  if (!city) throw new Error(`${row.id}.city_adcode is not reviewed`);
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(row.slug)) {
+    throw new Error(`${row.id}.slug is invalid`);
+  }
+  const coordinates = parseJson(row.coordinates, null, `${row.id}.coordinates`);
+  const latitude = Number(coordinates?.lat);
+  const longitude = Number(coordinates?.lng);
+  if (
+    !Number.isFinite(latitude) ||
+    latitude < -90 ||
+    latitude > 90 ||
+    !Number.isFinite(longitude) ||
+    longitude < -180 ||
+    longitude > 180
+  ) {
+    throw new Error(`${row.id}.coordinates are invalid`);
+  }
+  const images = stringArray(row.images, `${row.id}.images`);
+  if (images.length > 20) throw new Error(`${row.id}.images exceeds V2 limit`);
+  for (const value of [row.cover_image, ...images]) {
+    if (new URL(value).protocol !== "https:") {
+      throw new Error(`${row.id} contains a non-HTTPS image`);
+    }
+  }
+  return {
+    id: row.id,
+    region_id: city.id,
+    name: row.name,
+    slug: row.slug,
+    supported_activity_types: [row.type],
+    status: "published",
+    subtitle: row.subtitle ?? null,
+    description: row.description,
+    address: row.address ?? null,
+    latitude,
+    longitude,
+    cover_image_url: row.cover_image,
+    images,
+    extra: normalizeExtra(row),
+    created_by_user_id: null,
+    created_at: Number(row.created_at),
+    updated_at: Number(row.updated_at),
+  };
+}
+
+export function buildLocationMigration(
+  rows,
+  {
+    expectedCount = EXPECTED_LEGACY_LOCATION_COUNT,
+    expectedSha256 = EXPECTED_LEGACY_LOCATION_SHA256,
+  } = {},
+) {
+  if (!Array.isArray(rows) || rows.length !== expectedCount) {
+    throw new Error(
+      "Legacy Location snapshot count does not match the reviewed source",
+    );
+  }
+  const sourceSha256 = sha256(JSON.stringify(rows));
+  if (sourceSha256 !== expectedSha256) {
+    throw new Error(
+      "Legacy Location snapshot hash does not match the reviewed source",
+    );
+  }
+  const locations = rows
+    .map(transformLocation)
+    .sort((left, right) => left.id.localeCompare(right.id));
+  if (new Set(locations.map((row) => row.id)).size !== locations.length) {
+    throw new Error("Legacy Location snapshot contains duplicate IDs");
+  }
+  const regionSlugs = new Set();
+  const newRegions = [
+    ...PROVINCES,
+    ...[...CITY_BY_CODE.values()].filter((region) => !region.existing),
+  ]
+    .map(({ existing: _existing, ...region }) => region)
+    .sort((left, right) => left.id.localeCompare(right.id));
+  for (const region of newRegions) {
+    if (regionSlugs.has(region.slug))
+      throw new Error("Region slugs must be unique");
+    regionSlugs.add(region.slug);
+  }
+
+  const regionColumns = [
+    "id",
+    "country_code",
+    "parent_id",
+    "name",
+    "name_en",
+    "slug",
+    "code",
+    "level",
+    "timezone",
+    "center_latitude",
+    "center_longitude",
+    "service_enabled",
+    "is_hot",
+    "sort_order",
+    "created_at",
+    "updated_at",
+  ];
+  const locationColumns = [
+    "id",
+    "region_id",
+    "name",
+    "slug",
+    "supported_activity_types",
+    "status",
+    "subtitle",
+    "description",
+    "address",
+    "latitude",
+    "longitude",
+    "cover_image_url",
+    "images",
+    "extra",
+    "created_by_user_id",
+    "created_at",
+    "updated_at",
+  ];
+  const sqlLocations = locations.map((row) => ({
+    ...row,
+    supported_activity_types: JSON.stringify(row.supported_activity_types),
+    images: JSON.stringify(row.images),
+    extra: JSON.stringify(row.extra),
+  }));
+  const applySql = [
+    `-- Legacy Location snapshot SHA-256: ${sourceSha256}`,
+    "-- Generated only by scripts/location-migration-contract.mjs.",
+    insertSql("region", regionColumns, newRegions),
+    insertSql("locations", locationColumns, sqlLocations),
+    "",
+  ].join("\n\n");
+  const locationIds = locations.map((row) => row.id);
+  const cityRegionIds = newRegions
+    .filter((region) => region.level === "city")
+    .map((region) => region.id);
+  const provinceRegionIds = newRegions
+    .filter((region) => region.level === "province")
+    .map((region) => region.id);
+  const rollbackSql = [
+    "-- Exact rollback for the reviewed one-time legacy Location import.",
+    `DELETE FROM \`locations\` WHERE \`id\` IN (${locationIds.map(sqlValue).join(", ")});`,
+    `DELETE FROM \`region\` WHERE \`id\` IN (${cityRegionIds.map(sqlValue).join(", ")});`,
+    `DELETE FROM \`region\` WHERE \`id\` IN (${provinceRegionIds.map(sqlValue).join(", ")});`,
+    "",
+  ].join("\n");
+  return {
+    sourceSha256,
+    locations,
+    newRegions,
+    applySql,
+    rollbackSql,
+    applySqlSha256: sha256(applySql),
+    rollbackSqlSha256: sha256(rollbackSql),
+  };
+}
+
+export function validateTargetPreflight({ locationCount, regionIds }) {
+  if (Number(locationCount) !== 0) {
+    throw new Error("Target V2 database must contain zero Locations");
+  }
+  if (
+    !Array.isArray(regionIds) ||
+    JSON.stringify([...regionIds].sort()) !==
+      JSON.stringify([...EXISTING_REGION_IDS].sort())
+  ) {
+    throw new Error(
+      "Target V2 Region set does not match the production bootstrap",
+    );
+  }
+}
+
+function rowsFromWrangler(filePath) {
+  const payload = JSON.parse(readFileSync(filePath, "utf8"));
+  const executions = Array.isArray(payload) ? payload : [payload];
+  if (executions.length !== 1 || executions[0]?.success !== true) {
+    throw new Error("Wrangler D1 evidence is missing one successful execution");
+  }
+  if (!Array.isArray(executions[0].results)) {
+    throw new Error("Wrangler D1 evidence does not contain result rows");
+  }
+  return executions[0].results;
+}
+
+function normalizeActualLocation(row) {
+  return {
+    ...row,
+    latitude: Number(row.latitude),
+    longitude: Number(row.longitude),
+    supported_activity_types: parseJson(
+      row.supported_activity_types,
+      null,
+      `${row.id}.supported_activity_types`,
+    ),
+    images: parseJson(row.images, null, `${row.id}.images`),
+    extra: parseJson(row.extra, null, `${row.id}.extra`),
+    created_at: Number(row.created_at),
+    updated_at: Number(row.updated_at),
+  };
+}
+
+function writePrivateJson(filePath, value) {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, {
+    mode: 0o600,
+  });
+}
+
+export function generateMigrationFiles(
+  sourcePath,
+  applyPath,
+  rollbackPath,
+  manifestPath,
+) {
+  const migration = buildLocationMigration(rowsFromWrangler(sourcePath));
+  writeFileSync(applyPath, migration.applySql, { mode: 0o600 });
+  writeFileSync(rollbackPath, migration.rollbackSql, { mode: 0o600 });
+  writePrivateJson(manifestPath, {
+    status: "reviewed",
+    sourceDatabase: "legacy-location-snapshot",
+    targetDatabase: "gomate-db-v2",
+    sourceLocationCount: migration.locations.length,
+    sourceSha256: migration.sourceSha256,
+    applySqlSha256: migration.applySqlSha256,
+    rollbackSqlSha256: migration.rollbackSqlSha256,
+    locationIds: migration.locations.map((row) => row.id),
+    newRegionIds: migration.newRegions.map((row) => row.id),
+  });
+}
+
+export function validateTargetPreflightFile(filePath) {
+  const rows = rowsFromWrangler(filePath);
+  if (rows.length !== 1)
+    throw new Error("Target preflight must return one row");
+  validateTargetPreflight({
+    locationCount: rows[0].location_count,
+    regionIds: parseJson(rows[0].region_ids, null, "region_ids"),
+  });
+}
+
+export function validatePostflightFiles(
+  sourcePath,
+  locationsPath,
+  regionsPath,
+  evidencePath,
+) {
+  const migration = buildLocationMigration(rowsFromWrangler(sourcePath));
+  const actualLocations = rowsFromWrangler(locationsPath).map(
+    normalizeActualLocation,
+  );
+  const actualRegions = rowsFromWrangler(regionsPath).map((row) => ({
+    ...row,
+    center_latitude:
+      row.center_latitude == null ? null : Number(row.center_latitude),
+    center_longitude:
+      row.center_longitude == null ? null : Number(row.center_longitude),
+    service_enabled: Number(row.service_enabled),
+    is_hot: Number(row.is_hot),
+    sort_order: Number(row.sort_order),
+    created_at: Number(row.created_at),
+    updated_at: Number(row.updated_at),
+  }));
+  assertPostflight(migration, actualLocations, actualRegions);
+  writePrivateJson(evidencePath, {
+    status: "complete",
+    sourceLocationCount: migration.locations.length,
+    targetLocationCount: actualLocations.length,
+    sourceSha256: migration.sourceSha256,
+    applySqlSha256: migration.applySqlSha256,
+    rollbackSqlSha256: migration.rollbackSqlSha256,
+    locationIds: actualLocations.map((row) => row.id),
+    newRegionIds: actualRegions.map((row) => row.id),
+  });
+}
+
+export function assertPostflight(migration, actualLocations, actualRegions) {
+  if (JSON.stringify(actualLocations) !== JSON.stringify(migration.locations)) {
+    throw new Error("Target Locations do not match the reviewed V2 projection");
+  }
+  if (JSON.stringify(actualRegions) !== JSON.stringify(migration.newRegions)) {
+    throw new Error("Target Regions do not match the reviewed V2 projection");
+  }
+}
+
+export function validatePublicLocationsFile(sourcePath, publicPath) {
+  const migration = buildLocationMigration(rowsFromWrangler(sourcePath));
+  const payload = JSON.parse(readFileSync(publicPath, "utf8"));
+  assertPublicLocations(migration, payload);
+}
+
+export function assertPublicLocations(migration, payload) {
+  const actualIds = payload?.locations?.map((row) => row.id).sort();
+  const expectedIds = migration.locations.map((row) => row.id).sort();
+  if (
+    payload?.success !== true ||
+    JSON.stringify(actualIds) !== JSON.stringify(expectedIds) ||
+    payload.nextCursor != null
+  ) {
+    throw new Error(
+      "Public Location API does not expose the complete migrated set",
+    );
+  }
+}
+
+if (process.argv[1]?.endsWith("location-migration-contract.mjs")) {
+  const [, , command, ...args] = process.argv;
+  if (command === "source" && args.length === 4) {
+    generateMigrationFiles(...args);
+  } else if (command === "target-preflight" && args.length === 1) {
+    validateTargetPreflightFile(args[0]);
+  } else if (command === "postflight" && args.length === 4) {
+    validatePostflightFiles(...args);
+  } else if (command === "public" && args.length === 2) {
+    validatePublicLocationsFile(...args);
+  } else {
+    console.error(
+      "Usage: location-migration-contract.mjs source <source-json> <apply-sql> <rollback-sql> <manifest-json> | target-preflight <json> | postflight <source-json> <locations-json> <regions-json> <evidence-json> | public <source-json> <public-json>",
+    );
+    process.exit(1);
+  }
+}

--- a/scripts/location-migration-contract.test.mjs
+++ b/scripts/location-migration-contract.test.mjs
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import {
+  EXPECTED_LEGACY_LOCATION_COUNT,
+  EXPECTED_LEGACY_LOCATION_SHA256,
+  assertPostflight,
+  assertPublicLocations,
+  buildLocationMigration,
+  validateTargetPreflight,
+} from "./location-migration-contract.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const fixtureRows = [
+  {
+    id: "location-shenzhen-test",
+    name: "深圳测试地点",
+    slug: "shenzhen-test",
+    subtitle: "测试副标题",
+    description: "深圳测试地点描述",
+    address: "深圳市",
+    city_id: "legacy-shenzhen",
+    city_name: "深圳",
+    best_season: '["spring","autumn"]',
+    cover_image: "https://example.com/shenzhen-cover.jpg",
+    images: '["https://example.com/shenzhen-cover.jpg"]',
+    coordinates: '{"lat":22.54,"lng":114.05}',
+    extra:
+      '{"facilities":["停车场"],"tips":["早出发"],"warnings":["注意天气"],"hiking":{"overview":"测试路线","tips":["带水"],"warnings":["防滑"]}}',
+    created_at: 1_700_000_000_000,
+    updated_at: 1_700_000_000_001,
+    type: "hiking",
+    difficulty: "moderate",
+    duration_min: 90,
+    duration_max: 120,
+    distance: 5.5,
+    elevation: 300,
+    parking_available: null,
+    parking_info: null,
+    gear_essential: '["登山鞋"]',
+    gear_optional: '["登山杖"]',
+    city_adcode: "440300",
+    canonical_city_name: "深圳",
+    city_province: "广东省",
+  },
+  {
+    id: "location-huizhou-test",
+    name: "惠州测试地点",
+    slug: "huizhou-test",
+    subtitle: null,
+    description: "惠州测试地点描述",
+    address: null,
+    city_id: "legacy-huizhou",
+    city_name: "惠州",
+    best_season: '["全年"]',
+    cover_image: "https://example.com/huizhou-cover.jpg",
+    images: "[]",
+    coordinates: '{"lat":23.08,"lng":114.4}',
+    extra: '{"facilities":["卫生间"],"tips":["不进入V2非徒步extra"]}',
+    created_at: 1_700_000_000_002,
+    updated_at: 1_700_000_000_003,
+    type: "leisure",
+    difficulty: null,
+    duration_min: null,
+    duration_max: null,
+    distance: null,
+    elevation: null,
+    parking_available: null,
+    parking_info: null,
+    gear_essential: null,
+    gear_optional: null,
+    city_adcode: "441300",
+    canonical_city_name: "惠州",
+    city_province: "广东省",
+  },
+];
+
+function fixtureContract() {
+  return {
+    expectedCount: fixtureRows.length,
+    expectedSha256: createHash("sha256")
+      .update(JSON.stringify(fixtureRows))
+      .digest("hex"),
+  };
+}
+
+test("legacy Location snapshot contract is immutable", () => {
+  assert.equal(EXPECTED_LEGACY_LOCATION_COUNT, 36);
+  assert.equal(
+    EXPECTED_LEGACY_LOCATION_SHA256,
+    "7685b4d2424271c2d5fc7bd871c8e25e20dbecd9a336477a4b16552b45662677",
+  );
+  assert.throws(
+    () =>
+      buildLocationMigration(fixtureRows, {
+        expectedCount: 36,
+        expectedSha256: "0".repeat(64),
+      }),
+    /snapshot/u,
+  );
+});
+
+test("transforms V1 Location fields into the strict V2 contract", () => {
+  const migration = buildLocationMigration(fixtureRows, fixtureContract());
+  assert.equal(migration.locations.length, 2);
+  assert.equal(migration.newRegions.length, 16);
+  const hiking = migration.locations.find(
+    (location) => location.id === "location-shenzhen-test",
+  );
+  const leisure = migration.locations.find(
+    (location) => location.id === "location-huizhou-test",
+  );
+  assert.deepEqual(hiking.supported_activity_types, ["hiking"]);
+  assert.deepEqual(hiking.extra, {
+    hiking: {
+      difficulty: "moderate",
+      duration_min: 90,
+      duration_max: 120,
+      distance_km: 5.5,
+      elevation_gain_m: 300,
+      best_seasons: ["spring", "autumn"],
+      gear_essential: ["登山鞋"],
+      gear_optional: ["登山杖"],
+      overview: "测试路线",
+      tips: ["带水"],
+      warnings: ["防滑"],
+    },
+    facilities: ["停车场"],
+  });
+  assert.deepEqual(leisure.extra, {
+    facilities: ["卫生间"],
+  });
+  assert.equal(leisure.region_id, "region-cn-huizhou");
+  assert.doesNotMatch(migration.applySql, /parking_|INSERT INTO `users`/iu);
+  assert.doesNotMatch(migration.applySql, /wrangler|DELETE FROM `region`/iu);
+});
+
+test("generated migration and rollback preserve the existing production hierarchy", () => {
+  const migration = buildLocationMigration(fixtureRows, fixtureContract());
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  db.exec(
+    readFileSync(path.join(root, "api/db/migrations/0000_init.sql"), "utf8"),
+  );
+  db.exec(
+    readFileSync(path.join(root, "api/db/bootstrap/regions-v1.sql"), "utf8"),
+  );
+  db.exec(migration.applySql);
+
+  assert.equal(
+    db.prepare("SELECT count(*) AS count FROM region").get().count,
+    19,
+  );
+  assert.equal(
+    db.prepare("SELECT count(*) AS count FROM locations").get().count,
+    2,
+  );
+  assert.deepEqual(
+    db
+      .prepare(
+        "SELECT id, region_id, supported_activity_types, status FROM locations ORDER BY id",
+      )
+      .all(),
+    [
+      {
+        id: "location-huizhou-test",
+        region_id: "region-cn-huizhou",
+        supported_activity_types: '["leisure"]',
+        status: "published",
+      },
+      {
+        id: "location-shenzhen-test",
+        region_id: "region-cn-shenzhen",
+        supported_activity_types: '["hiking"]',
+        status: "published",
+      },
+    ],
+  );
+
+  db.exec(migration.rollbackSql);
+  assert.equal(
+    db.prepare("SELECT count(*) AS count FROM locations").get().count,
+    0,
+  );
+  assert.deepEqual(db.prepare("SELECT id FROM region ORDER BY id").all(), [
+    { id: "region-cn" },
+    { id: "region-cn-guangdong" },
+    { id: "region-cn-shenzhen" },
+  ]);
+  db.close();
+});
+
+test("postflight and public validators reject any projection drift", () => {
+  const migration = buildLocationMigration(fixtureRows, fixtureContract());
+  assert.doesNotThrow(() =>
+    assertPostflight(migration, migration.locations, migration.newRegions),
+  );
+  assert.throws(
+    () =>
+      assertPostflight(
+        migration,
+        migration.locations.map((location) =>
+          location.id === "location-shenzhen-test"
+            ? { ...location, name: "tampered" }
+            : location,
+        ),
+        migration.newRegions,
+      ),
+    /Locations do not match/u,
+  );
+  assert.doesNotThrow(() =>
+    assertPublicLocations(migration, {
+      success: true,
+      locations: migration.locations.map(({ id }) => ({ id })),
+      nextCursor: null,
+    }),
+  );
+  assert.throws(
+    () =>
+      assertPublicLocations(migration, {
+        success: true,
+        locations: migration.locations.slice(1).map(({ id }) => ({ id })),
+        nextCursor: null,
+      }),
+    /complete migrated set/u,
+  );
+});
+
+test("production workflow is protected and limited to D1 Location migration", () => {
+  const workflow = readFileSync(
+    path.join(root, ".github/workflows/migrate-production-locations.yml"),
+    "utf8",
+  );
+  assert.match(workflow, /MIGRATE_LEGACY_LOCATIONS/u);
+  assert.match(
+    workflow,
+    /inputs\.confirm\s*==\s*'MIGRATE_LEGACY_LOCATIONS'.*github\.ref\s*==\s*'refs\/heads\/main'/u,
+  );
+  assert.match(workflow, /environment:\s*production/u);
+  assert.match(workflow, /7d17d076-202f-48f8-b343-24209cdb0ba1/u);
+  assert.match(workflow, /--env production --remote --config wrangler\.jsonc/u);
+  assert.match(workflow, /actions\/upload-artifact@v4/u);
+  assert.match(
+    workflow,
+    /name: Upload migration and rollback evidence\s+if: always\(\)\s+uses: actions\/upload-artifact@v4/u,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /wrangler\s+(?:deploy|secret|kv|r2)|migrations apply|seed\.sql|DELETE/iu,
+  );
+});
+
+test("target preflight allows only the current three Regions and zero Locations", () => {
+  assert.doesNotThrow(() =>
+    validateTargetPreflight({
+      locationCount: 0,
+      regionIds: ["region-cn", "region-cn-guangdong", "region-cn-shenzhen"],
+    }),
+  );
+  assert.throws(
+    () =>
+      validateTargetPreflight({
+        locationCount: 1,
+        regionIds: ["region-cn", "region-cn-guangdong", "region-cn-shenzhen"],
+      }),
+    /Locations/u,
+  );
+  assert.throws(
+    () => validateTargetPreflight({ locationCount: 0, regionIds: [] }),
+    /Region/u,
+  );
+});

--- a/scripts/retire-legacy-production.mjs
+++ b/scripts/retire-legacy-production.mjs
@@ -44,11 +44,19 @@ async function cloudflareRequest({
   apiToken,
   resourcePath,
   method = "GET",
+  body,
   fetchImpl,
 }) {
   const response = await fetchImpl(
     `${API_ROOT}/accounts/${encodeURIComponent(accountId)}${resourcePath}`,
-    { method, headers: { Authorization: `Bearer ${apiToken}` } },
+    {
+      method,
+      body,
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        ...(body ? { "Content-Type": "application/json" } : {}),
+      },
+    },
   );
   const payload = await response.json().catch(() => null);
   if (!response.ok || payload?.success !== true) {
@@ -57,6 +65,27 @@ async function cloudflareRequest({
     );
   }
   return payload.result;
+}
+
+async function assertLocationMigrationComplete({
+  accountId,
+  apiToken,
+  fetchImpl,
+}) {
+  const result = await cloudflareRequest({
+    accountId,
+    apiToken,
+    resourcePath: `/d1/database/${PRODUCTION_D1.id}/query`,
+    method: "POST",
+    body: JSON.stringify({
+      sql: "SELECT (SELECT count(*) FROM locations) AS location_count, (SELECT count(*) FROM region) AS region_count",
+    }),
+    fetchImpl,
+  });
+  const row = result?.[0]?.results?.[0];
+  if (Number(row?.location_count) !== 36 || Number(row?.region_count) !== 19) {
+    throw new Error("Reviewed legacy Location migration is not complete");
+  }
 }
 
 async function inventory({ accountId, apiToken, fetchImpl }) {
@@ -223,6 +252,7 @@ export async function retireLegacyProduction({
   const before = await inventory({ accountId, apiToken, fetchImpl });
   assertProductionResources(before);
   assertLegacyIdentity(before);
+  await assertLocationMigrationComplete({ accountId, apiToken, fetchImpl });
   const deleted = [];
   const apiDomain = before.domains.find(
     (domain) => domain.hostname === "api.gomate.live",

--- a/scripts/retire-legacy-production.test.mjs
+++ b/scripts/retire-legacy-production.test.mjs
@@ -9,7 +9,11 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const accountRoot =
   "https://api.cloudflare.com/client/v4/accounts/e3afbb613458022947cd9dc9f5bd6334";
 
-function initialState({ includeLegacy = true, productionService } = {}) {
+function initialState({
+  includeLegacy = true,
+  productionService,
+  productionLocationCount = 36,
+} = {}) {
   return {
     domains: [
       {
@@ -72,6 +76,7 @@ function initialState({ includeLegacy = true, productionService } = {}) {
         : []),
     ],
     buckets: [{ name: "gomate" }],
+    productionLocationCount,
   };
 }
 
@@ -107,6 +112,25 @@ function fakeCloudflare(state, requests) {
         { success: result !== null, result },
         { status: result === null ? 404 : 200 },
       );
+    }
+    if (
+      method === "POST" &&
+      relative === "/d1/database/befa3d89-6551-4a25-8a1c-670efe62a315/query"
+    ) {
+      return Response.json({
+        success: true,
+        result: [
+          {
+            success: true,
+            results: [
+              {
+                location_count: state.productionLocationCount,
+                region_count: state.productionLocationCount === 36 ? 19 : 3,
+              },
+            ],
+          },
+        ],
+      });
     }
     if (method !== "DELETE") {
       return Response.json({ success: false }, { status: 405 });
@@ -210,6 +234,26 @@ test("legacy retirement fails closed when production domain ownership drifts", a
         fetchImpl: fakeCloudflare(state, requests),
       }),
     /reviewed unified Worker/u,
+  );
+  assert.equal(
+    requests.some(({ method }) => method === "DELETE"),
+    false,
+  );
+});
+
+test("legacy retirement refuses to delete the old D1 before Location migration", async () => {
+  const state = initialState({ productionLocationCount: 0 });
+  const requests = [];
+  await assert.rejects(
+    () =>
+      retireLegacyProduction({
+        accountId: "e3afbb613458022947cd9dc9f5bd6334",
+        apiToken: "test-token",
+        baseUrl: "https://gomate.live",
+        nowImpl: () => Date.parse("2026-08-24T00:00:00Z"),
+        fetchImpl: fakeCloudflare(state, requests),
+      }),
+    /Location migration is not complete/u,
   );
   assert.equal(
     requests.some(({ method }) => method === "DELETE"),


### PR DESCRIPTION
## Summary

- add a protected one-time workflow that reads the immutable 36-row legacy Location snapshot and imports its strict V2 projection into `gomate-db-v2`
- add 5 province Regions, 11 non-Shenzhen city Regions, and 36 published Locations while preserving IDs, content, coordinates, media URLs, and timestamps
- upload exact migration/rollback evidence for 90 days, including on post-apply validation failure
- prevent Stage D from deleting the legacy D1 until the new database proves `locations=36` and `region=19`

## Safety boundary

- source D1 is read-only and pinned by UUID, row count, and SHA-256
- target must contain exactly the bootstrap 3 Regions and zero Locations
- no seed, Worker deploy, route/domain, KV, R2, secret, user, Team, Story, or tag mutation
- execution is manual, main-only, and gated by the GitHub `production` environment
- old D1 remains intact after migration

## Verification

- `pnpm@9.0.0 test:delivery`: 55/55
- migration + retirement focused tests: 12/12
- V2 migration sync: 19 tables, 8 triggers
- legacy-removal gate, Prettier, syntax checks, and `git diff --check`: pass
- real 36-row snapshot replayed locally against the V2 baseline; apply produced 19 Regions/36 Locations and exact rollback restored 3 Regions/0 Locations
