### PR TITLE
ci: initialize migration paths at runtime

### DIFF
--- a/.github/workflows/migrate-production-locations.yml
+++ b/.github/workflows/migrate-production-locations.yml
@@ -24,16 +24,22 @@ jobs:
     environment: production
     env:
       CLOUDFLARE_ENV: production
-      SOURCE_JSON: ${{ runner.temp }}/legacy-locations.json
-      TARGET_PREFLIGHT_JSON: ${{ runner.temp }}/location-target-preflight.json
-      APPLY_SQL: ${{ runner.temp }}/locations-v1.sql
-      ROLLBACK_SQL: ${{ runner.temp }}/locations-v1.rollback.sql
-      MANIFEST_JSON: ${{ runner.temp }}/location-migration-manifest.json
-      LOCATIONS_JSON: ${{ runner.temp }}/location-postflight.json
-      REGIONS_JSON: ${{ runner.temp }}/location-region-postflight.json
-      EVIDENCE_JSON: ${{ runner.temp }}/location-migration-evidence.json
-      PUBLIC_JSON: ${{ runner.temp }}/location-public-api.json
     steps:
+      - name: Initialize private migration evidence paths
+        run: |
+          umask 077
+          {
+            echo "SOURCE_JSON=$RUNNER_TEMP/legacy-locations.json"
+            echo "TARGET_PREFLIGHT_JSON=$RUNNER_TEMP/location-target-preflight.json"
+            echo "APPLY_SQL=$RUNNER_TEMP/locations-v1.sql"
+            echo "ROLLBACK_SQL=$RUNNER_TEMP/locations-v1.rollback.sql"
+            echo "MANIFEST_JSON=$RUNNER_TEMP/location-migration-manifest.json"
+            echo "LOCATIONS_JSON=$RUNNER_TEMP/location-postflight.json"
+            echo "REGIONS_JSON=$RUNNER_TEMP/location-region-postflight.json"
+            echo "EVIDENCE_JSON=$RUNNER_TEMP/location-migration-evidence.json"
+            echo "PUBLIC_JSON=$RUNNER_TEMP/location-public-api.json"
+          } >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:

--- a/scripts/location-migration-contract.test.mjs
+++ b/scripts/location-migration-contract.test.mjs
@@ -242,6 +242,12 @@ test("production workflow is protected and limited to D1 Location migration", ()
     /inputs\.confirm\s*==\s*'MIGRATE_LEGACY_LOCATIONS'.*github\.ref\s*==\s*'refs\/heads\/main'/u,
   );
   assert.match(workflow, /environment:\s*production/u);
+  const jobHeader = workflow.slice(0, workflow.indexOf("    steps:"));
+  assert.doesNotMatch(jobHeader, /\$\{\{\s*runner\.temp\s*\}\}/u);
+  assert.match(
+    workflow,
+    /name: Initialize private migration evidence paths[\s\S]*umask 077[\s\S]*RUNNER_TEMP[\s\S]*GITHUB_ENV/u,
+  );
   assert.match(workflow, /7d17d076-202f-48f8-b343-24209cdb0ba1/u);
   assert.match(workflow, /--env production --remote --config wrangler\.jsonc/u);
   assert.match(workflow, /actions\/upload-artifact@v4/u);


### PR DESCRIPTION
## Summary

- initialize migration evidence paths after the GitHub runner starts, using `RUNNER_TEMP` and `GITHUB_ENV`
- remove invalid job-level `runner.temp` expressions that prevented `workflow_dispatch` from being created
- keep evidence files private with `umask 077`
- add a regression guard that rejects runner context in the job header

## Evidence

- the original dispatch was rejected before a run was created, so no D1 write occurred
- focused migration contract tests: 6/6
- Prettier and `git diff --check`: pass
