### PR TITLE
ci: read legacy D1 snapshot by UUID

### DIFF
--- a/.github/workflows/migrate-production-locations.yml
+++ b/.github/workflows/migrate-production-locations.yml
@@ -54,19 +54,16 @@ jobs:
         run: node --test scripts/location-migration-contract.test.mjs
 
       - name: Read and validate the immutable legacy Location snapshot
-        working-directory: frontend
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          for attempt in 1 2 3; do
-            if pnpm exec wrangler d1 execute 7d17d076-202f-48f8-b343-24209cdb0ba1 --remote --json --command "SELECT l.*, c.adcode AS city_adcode, c.name AS canonical_city_name, c.province AS city_province FROM locations l JOIN cities c ON c.id = l.city_id ORDER BY l.id" > "$SOURCE_JSON"; then
-              break
-            fi
-            if [ "$attempt" -eq 3 ]; then exit 1; fi
-            sleep 5
-          done
-          node ../scripts/location-migration-contract.mjs source "$SOURCE_JSON" "$APPLY_SQL" "$ROLLBACK_SQL" "$MANIFEST_JSON"
+          curl --fail --silent --show-error --retry 2 --retry-all-errors \
+            --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            --json '{"sql":"SELECT l.*, c.adcode AS city_adcode, c.name AS canonical_city_name, c.province AS city_province FROM locations l JOIN cities c ON c.id = l.city_id ORDER BY l.id"}' \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/d1/database/7d17d076-202f-48f8-b343-24209cdb0ba1/query" \
+            > "$SOURCE_JSON"
+          node scripts/location-migration-contract.mjs source "$SOURCE_JSON" "$APPLY_SQL" "$ROLLBACK_SQL" "$MANIFEST_JSON"
 
       - name: Prove the V2 target is ready for the exact import
         working-directory: frontend

--- a/scripts/location-migration-contract.mjs
+++ b/scripts/location-migration-contract.mjs
@@ -558,16 +558,23 @@ export function validateTargetPreflight({ locationCount, regionIds }) {
   }
 }
 
-function rowsFromWrangler(filePath) {
-  const payload = JSON.parse(readFileSync(filePath, "utf8"));
-  const executions = Array.isArray(payload) ? payload : [payload];
+export function rowsFromD1Payload(payload) {
+  const executions = Array.isArray(payload)
+    ? payload
+    : payload?.success === true && Array.isArray(payload.result)
+      ? payload.result
+      : [payload];
   if (executions.length !== 1 || executions[0]?.success !== true) {
-    throw new Error("Wrangler D1 evidence is missing one successful execution");
+    throw new Error("D1 evidence is missing one successful execution");
   }
   if (!Array.isArray(executions[0].results)) {
-    throw new Error("Wrangler D1 evidence does not contain result rows");
+    throw new Error("D1 evidence does not contain result rows");
   }
   return executions[0].results;
+}
+
+function rowsFromD1(filePath) {
+  return rowsFromD1Payload(JSON.parse(readFileSync(filePath, "utf8")));
 }
 
 function normalizeActualLocation(row) {
@@ -599,7 +606,7 @@ export function generateMigrationFiles(
   rollbackPath,
   manifestPath,
 ) {
-  const migration = buildLocationMigration(rowsFromWrangler(sourcePath));
+  const migration = buildLocationMigration(rowsFromD1(sourcePath));
   writeFileSync(applyPath, migration.applySql, { mode: 0o600 });
   writeFileSync(rollbackPath, migration.rollbackSql, { mode: 0o600 });
   writePrivateJson(manifestPath, {
@@ -616,7 +623,7 @@ export function generateMigrationFiles(
 }
 
 export function validateTargetPreflightFile(filePath) {
-  const rows = rowsFromWrangler(filePath);
+  const rows = rowsFromD1(filePath);
   if (rows.length !== 1)
     throw new Error("Target preflight must return one row");
   validateTargetPreflight({
@@ -631,11 +638,11 @@ export function validatePostflightFiles(
   regionsPath,
   evidencePath,
 ) {
-  const migration = buildLocationMigration(rowsFromWrangler(sourcePath));
-  const actualLocations = rowsFromWrangler(locationsPath).map(
+  const migration = buildLocationMigration(rowsFromD1(sourcePath));
+  const actualLocations = rowsFromD1(locationsPath).map(
     normalizeActualLocation,
   );
-  const actualRegions = rowsFromWrangler(regionsPath).map((row) => ({
+  const actualRegions = rowsFromD1(regionsPath).map((row) => ({
     ...row,
     center_latitude:
       row.center_latitude == null ? null : Number(row.center_latitude),
@@ -670,7 +677,7 @@ export function assertPostflight(migration, actualLocations, actualRegions) {
 }
 
 export function validatePublicLocationsFile(sourcePath, publicPath) {
-  const migration = buildLocationMigration(rowsFromWrangler(sourcePath));
+  const migration = buildLocationMigration(rowsFromD1(sourcePath));
   const payload = JSON.parse(readFileSync(publicPath, "utf8"));
   assertPublicLocations(migration, payload);
 }

--- a/scripts/location-migration-contract.test.mjs
+++ b/scripts/location-migration-contract.test.mjs
@@ -11,6 +11,7 @@ import {
   assertPostflight,
   assertPublicLocations,
   buildLocationMigration,
+  rowsFromD1Payload,
   validateTargetPreflight,
 } from "./location-migration-contract.mjs";
 
@@ -102,6 +103,23 @@ test("legacy Location snapshot contract is immutable", () => {
         expectedSha256: "0".repeat(64),
       }),
     /snapshot/u,
+  );
+});
+
+test("accepts only one successful Wrangler or Cloudflare REST D1 query", () => {
+  const execution = { success: true, results: fixtureRows };
+  assert.deepEqual(rowsFromD1Payload([execution]), fixtureRows);
+  assert.deepEqual(
+    rowsFromD1Payload({ success: true, result: [execution] }),
+    fixtureRows,
+  );
+  assert.throws(
+    () => rowsFromD1Payload({ success: false, errors: [{ code: 9109 }] }),
+    /one successful execution/u,
+  );
+  assert.throws(
+    () => rowsFromD1Payload({ success: true, result: [execution, execution] }),
+    /one successful execution/u,
   );
 });
 
@@ -249,6 +267,14 @@ test("production workflow is protected and limited to D1 Location migration", ()
     /name: Initialize private migration evidence paths[\s\S]*umask 077[\s\S]*RUNNER_TEMP[\s\S]*GITHUB_ENV/u,
   );
   assert.match(workflow, /7d17d076-202f-48f8-b343-24209cdb0ba1/u);
+  assert.match(
+    workflow,
+    /api\.cloudflare\.com\/client\/v4\/accounts\/\$CLOUDFLARE_ACCOUNT_ID\/d1\/database\/7d17d076-202f-48f8-b343-24209cdb0ba1\/query/u,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /wrangler d1 execute 7d17d076-202f-48f8-b343-24209cdb0ba1/u,
+  );
   assert.match(workflow, /--env production --remote --config wrangler\.jsonc/u);
   assert.match(workflow, /actions\/upload-artifact@v4/u);
   assert.match(


### PR DESCRIPTION
## Summary

- read the legacy D1 snapshot through Cloudflare's UUID-addressed Query REST API
- keep the old database identity pinned without relying on Wrangler, whose execute command accepts only a name or binding
- accept and validate both Wrangler and Cloudflare REST D1 result envelopes
- retain the existing production binding path for all target preflight, apply, and postflight operations

## Evidence

- failed run #31999240912 stopped at the source-read step; target preflight and apply were never executed
- Cloudflare official Query API accepts a database UUID and D1 Read/Write token
- complete delivery suite: 56/56
- focused parser/workflow tests: 7/7
- Prettier and `git diff --check`: pass
