### PR TITLE
ci: resume completed location import safely

### DIFF
--- a/.github/workflows/migrate-production-locations.yml
+++ b/.github/workflows/migrate-production-locations.yml
@@ -66,15 +66,18 @@ jobs:
           node scripts/location-migration-contract.mjs source "$SOURCE_JSON" "$APPLY_SQL" "$ROLLBACK_SQL" "$MANIFEST_JSON"
 
       - name: Prove the V2 target is ready for the exact import
+        id: target
         working-directory: frontend
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           pnpm exec wrangler d1 execute DB --env production --remote --config wrangler.jsonc --json --command "SELECT (SELECT count(*) FROM locations) AS location_count, (SELECT json_group_array(id) FROM (SELECT id FROM region ORDER BY id)) AS region_ids" > "$TARGET_PREFLIGHT_JSON"
-          node ../scripts/location-migration-contract.mjs target-preflight "$TARGET_PREFLIGHT_JSON"
+          state="$(node ../scripts/location-migration-contract.mjs target-preflight "$TARGET_PREFLIGHT_JSON")"
+          echo "state=$state" >> "$GITHUB_OUTPUT"
 
       - name: Apply the reviewed Region and Location import
+        if: steps.target.outputs.state == 'empty'
         working-directory: frontend
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/docs/prod-change-policy.md
+++ b/docs/prod-change-policy.md
@@ -123,7 +123,8 @@ ID、名称、slug、描述、坐标、HTTPS 媒体 URL 与时间戳；活动类
 Region 且 `locations=0`；写入后必须逐字段比对 36 条 V2 projection、16 条新增 Region，并通过
 `/api/locations?limit=100` 证明全部公开可读。工作流不得修改用户、队伍、故事、标签、Worker、
 route、domain、KV、R2、secret 或 migration ledger；精确 rollback SQL 只作为 90 天 artifact
-保存，不自动执行。
+保存，不自动执行。若 apply 成功后校验中断，重跑必须识别精确的 36 Location/19 Region 状态、
+跳过 apply 并只续跑 postflight；任何部分写入或额外数据都失败闭合。
 
 ### 阶段 D：旧资源退役
 

--- a/scripts/location-migration-contract.mjs
+++ b/scripts/location-migration-contract.mjs
@@ -544,18 +544,40 @@ export function buildLocationMigration(
 }
 
 export function validateTargetPreflight({ locationCount, regionIds }) {
-  if (Number(locationCount) !== 0) {
-    throw new Error("Target V2 database must contain zero Locations");
-  }
-  if (
-    !Array.isArray(regionIds) ||
-    JSON.stringify([...regionIds].sort()) !==
+  const normalizedRegionIds = Array.isArray(regionIds)
+    ? [...regionIds].sort()
+    : null;
+  if (Number(locationCount) === 0) {
+    if (
+      JSON.stringify(normalizedRegionIds) !==
       JSON.stringify([...EXISTING_REGION_IDS].sort())
-  ) {
+    ) {
+      throw new Error(
+        "Target V2 Region set does not match the production bootstrap",
+      );
+    }
+    return "empty";
+  }
+  const migratedRegionIds = [
+    ...EXISTING_REGION_IDS,
+    ...PROVINCES.map((region) => region.id),
+    ...[...CITY_BY_CODE.values()]
+      .filter((region) => !region.existing)
+      .map((region) => region.id),
+  ].sort();
+  if (Number(locationCount) !== EXPECTED_LEGACY_LOCATION_COUNT) {
     throw new Error(
-      "Target V2 Region set does not match the production bootstrap",
+      "Target V2 database contains a partial or unexpected Locations set",
     );
   }
+  if (
+    JSON.stringify(normalizedRegionIds) !== JSON.stringify(migratedRegionIds)
+  ) {
+    throw new Error(
+      "Target V2 Region set does not match the reviewed migrated set",
+    );
+  }
+  return "applied";
 }
 
 export function rowsFromD1Payload(payload) {
@@ -626,7 +648,7 @@ export function validateTargetPreflightFile(filePath) {
   const rows = rowsFromD1(filePath);
   if (rows.length !== 1)
     throw new Error("Target preflight must return one row");
-  validateTargetPreflight({
+  return validateTargetPreflight({
     locationCount: rows[0].location_count,
     regionIds: parseJson(rows[0].region_ids, null, "region_ids"),
   });
@@ -668,10 +690,18 @@ export function validatePostflightFiles(
 }
 
 export function assertPostflight(migration, actualLocations, actualRegions) {
-  if (JSON.stringify(actualLocations) !== JSON.stringify(migration.locations)) {
+  const byId = (left, right) =>
+    left.id < right.id ? -1 : left.id > right.id ? 1 : 0;
+  if (
+    JSON.stringify([...actualLocations].sort(byId)) !==
+    JSON.stringify([...migration.locations].sort(byId))
+  ) {
     throw new Error("Target Locations do not match the reviewed V2 projection");
   }
-  if (JSON.stringify(actualRegions) !== JSON.stringify(migration.newRegions)) {
+  if (
+    JSON.stringify([...actualRegions].sort(byId)) !==
+    JSON.stringify([...migration.newRegions].sort(byId))
+  ) {
     throw new Error("Target Regions do not match the reviewed V2 projection");
   }
 }
@@ -701,7 +731,7 @@ if (process.argv[1]?.endsWith("location-migration-contract.mjs")) {
   if (command === "source" && args.length === 4) {
     generateMigrationFiles(...args);
   } else if (command === "target-preflight" && args.length === 1) {
-    validateTargetPreflightFile(args[0]);
+    console.log(validateTargetPreflightFile(args[0]));
   } else if (command === "postflight" && args.length === 4) {
     validatePostflightFiles(...args);
   } else if (command === "public" && args.length === 2) {

--- a/scripts/location-migration-contract.test.mjs
+++ b/scripts/location-migration-contract.test.mjs
@@ -216,7 +216,11 @@ test("generated migration and rollback preserve the existing production hierarch
 test("postflight and public validators reject any projection drift", () => {
   const migration = buildLocationMigration(fixtureRows, fixtureContract());
   assert.doesNotThrow(() =>
-    assertPostflight(migration, migration.locations, migration.newRegions),
+    assertPostflight(
+      migration,
+      [...migration.locations].reverse(),
+      [...migration.newRegions].reverse(),
+    ),
   );
   assert.throws(
     () =>
@@ -271,6 +275,8 @@ test("production workflow is protected and limited to D1 Location migration", ()
     workflow,
     /api\.cloudflare\.com\/client\/v4\/accounts\/\$CLOUDFLARE_ACCOUNT_ID\/d1\/database\/7d17d076-202f-48f8-b343-24209cdb0ba1\/query/u,
   );
+  assert.match(workflow, /id: target/u);
+  assert.match(workflow, /if: steps\.target\.outputs\.state == 'empty'/u);
   assert.doesNotMatch(
     workflow,
     /wrangler d1 execute 7d17d076-202f-48f8-b343-24209cdb0ba1/u,
@@ -288,11 +294,25 @@ test("production workflow is protected and limited to D1 Location migration", ()
 });
 
 test("target preflight allows only the current three Regions and zero Locations", () => {
-  assert.doesNotThrow(() =>
+  assert.equal(
     validateTargetPreflight({
       locationCount: 0,
       regionIds: ["region-cn", "region-cn-guangdong", "region-cn-shenzhen"],
     }),
+    "empty",
+  );
+  const migration = buildLocationMigration(fixtureRows, fixtureContract());
+  assert.equal(
+    validateTargetPreflight({
+      locationCount: 36,
+      regionIds: [
+        "region-cn",
+        "region-cn-guangdong",
+        "region-cn-shenzhen",
+        ...migration.newRegions.map((region) => region.id),
+      ],
+    }),
+    "applied",
   );
   assert.throws(
     () =>


### PR DESCRIPTION
## Summary

- compare postflight Location and Region projections after canonical binary ID sorting, independent of SQLite versus JavaScript locale ordering
- classify the target as either exact empty bootstrap or exact already-applied 36 Location/19 Region state
- skip apply on the already-applied state and resume only the full D1/public API postflight
- reject every partial or unexpected target state

## Incident evidence

- run #31999748454 successfully applied the reviewed SQL, then failed only at order-sensitive postflight comparison
- migration artifact hashes exactly match the reviewed values: apply `c069dd31...c9fc6`, rollback `e4b664f9...116f`
- old D1 remains intact; no rollback or repeat apply has been attempted

## Verification

- complete delivery suite: 56/56
- focused migration + retirement tests: 13/13
- regression test proves reversed row order is accepted while field drift is rejected
- Prettier and `git diff --check`: pass
