### PR TITLE
Schedule legacy retirement for tonight

### DIFF
--- a/.github/workflows/cutover-production.yml
+++ b/.github/workflows/cutover-production.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: unified-worker-production-cutover
+  group: gomate-production-mutation
   cancel-in-progress: false
 
 jobs:
@@ -239,5 +239,5 @@ jobs:
             echo "### Unified Worker production rollout complete"
             echo "- gomate.live serves gomate-production-preview."
             echo "- WRITE_MODE is open after protected and open 30-minute observations."
-            echo "- Legacy Workers and storage remain retained for the mandatory seven-day window."
+            echo "- Legacy Workers and storage remain retained until the separately approved retirement workflow."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: deploy-unified-worker-preview
+  group: gomate-production-mutation
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/retire-legacy-production.yml
+++ b/.github/workflows/retire-legacy-production.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       confirm:
-        description: Type RETIRE_LEGACY_RESOURCES after the seven-day retention window
+        description: Type RETIRE_LEGACY_RESOURCES after the approved retirement time
         required: true
         type: string
 
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: gomate-legacy-resource-retirement
+  group: gomate-production-mutation
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/rollback-production-cutover.yml
+++ b/.github/workflows/rollback-production-cutover.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: unified-worker-production-cutover
+  group: gomate-production-mutation
   cancel-in-progress: false
 
 jobs:
@@ -38,6 +38,12 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           EXPECTED_DOMAIN_SERVICE: gomate-production-preview
         run: node scripts/production-domain.mjs assert
+      - name: Confirm the legacy rollback Worker still exists
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          EXPECTED_WORKER_SERVICE: gomate-frontend
+        run: node scripts/production-domain.mjs assert-worker
       - name: Build and prepare WRITE_MODE protected
         env:
           CLOUDFLARE_ENV: production

--- a/docs/prod-change-policy.md
+++ b/docs/prod-change-policy.md
@@ -91,7 +91,8 @@ preview 部署自动发生。
 开放写入的日志证据审批后再连续观察 30 分钟。任一阶段失败都停止后续 job。
 
 回滚只允许从 `main` 手动运行 `Roll back unified Worker production cutover` 并输入
-`ROLLBACK_PRODUCTION`：先把 unified Worker 恢复为 `WRITE_MODE=protected`，确认 503 写阻断，
+`ROLLBACK_PRODUCTION`。回滚在任何部署前必须确认旧 `gomate-frontend` Worker 仍存在；不存在时
+直接失败，不能先改变 `WRITE_MODE`。确认后先把 unified Worker 恢复为 `WRITE_MODE=protected`，确认 503 写阻断，
 再通过 Cloudflare Workers custom-domain API 把 `gomate.live` 精确重新附加到
 `gomate-frontend`。回滚不删除 V2 D1、KV、R2、Worker、版本或 secrets。
 
@@ -113,8 +114,8 @@ rollback SQL 只作为 90 天 artifact 保存，不自动执行。一次性迁�
 
 ### 阶段 D：旧资源退役
 
-阶段 C 于 2026-08-16T18:53:01Z 完成；旧资源最早只能在
-2026-08-23T18:53:01Z 后退役。从 `main` 手动运行
+阶段 C 于 2026-08-16T18:53:01Z 完成。Victor 于 2026-08-20 明确批准缩短原 7 天观察期；
+旧资源最早只能在 2026-08-20T15:00:00Z（上海时间 2026-08-20 23:00）后退役。从 `main` 手动运行
 `Retire legacy Cloudflare resources` 并输入 `RETIRE_LEGACY_RESOURCES`，且必须通过
 `production` environment 审批。流水线先证明 `gomate.live` 精确属于
 `gomate-production-preview`，并核对新 D1/KV 与共享 R2；随后只删除：
@@ -130,10 +131,16 @@ rollback SQL 只作为 90 天 artifact 保存，不自动执行。一次性迁�
 时间边界、36 条地点迁移结果或生产资源不匹配时，在首个 DELETE 前失败闭合。流水线可安全重跑：
 已经删除的精确旧资源视为完成，但新资源缺失仍立即失败。
 
+preview deploy、cutover、旧 route 回滚和阶段 D 退役共用 `gomate-production-mutation` concurrency
+group，禁止这些生产写操作并发。阶段 D 成功后旧 route 回滚永久不可用，并立即通过代码清理 PR
+删除该 workflow 与退役专用 workflow/script；今后回滚只能使用已验证的 Worker version，必要时先
+恢复 `WRITE_MODE=protected`。
+
 ## 4. 回滚
 
 - 应用回滚：核实 Worker deployment/version 对应的 commit 后，回滚到已验证版本。
-- route 回滚：将 `gomate.live` 恢复到旧 Worker；不要删除新资源。
+- route 回滚：仅在阶段 D 前且旧 Worker 存在时允许恢复到旧 Worker；阶段 D 后只能回滚统一 Worker
+  version，不得重建旧 split deployment。
 - 数据回滚：地点导入前由 workflow 生成精确 rollback SQL 并保存 90 天；该 SQL 仍需单独批准，
   且只能在没有新 Team/Story 引用迁入地点时执行。出现 schema 或写入问题时先把
   `WRITE_MODE` 恢复为 `protected`，再从 D1 Time Travel/备份恢复或创建新的 V2

--- a/scripts/production-cutover.test.mjs
+++ b/scripts/production-cutover.test.mjs
@@ -10,6 +10,7 @@ import {
 } from "./prepare-production-cutover.mjs";
 import {
   assertProductionDomain,
+  assertWorkerExists,
   attachProductionDomain,
 } from "./production-domain.mjs";
 import { observeProduction } from "./observe-production.mjs";
@@ -211,6 +212,42 @@ test("domain audit rejects the accidental suffixed Worker after cutover", async 
   );
 });
 
+test("rollback preflight requires the exact legacy Worker before any mutation", async () => {
+  const calls = [];
+  await assert.doesNotReject(() =>
+    assertWorkerExists({
+      accountId: "e3afbb613458022947cd9dc9f5bd6334",
+      apiToken: "test-token",
+      expectedService: "gomate-frontend",
+      fetchImpl: async (url, init) => {
+        calls.push({ url: String(url), init });
+        return Response.json({
+          success: true,
+          result: [{ id: "gomate-frontend" }],
+        });
+      },
+    }),
+  );
+  assert.equal(calls.length, 1);
+  assert.match(calls[0].url, /\/workers\/scripts$/u);
+  assert.equal(calls[0].init?.method, undefined);
+
+  await assert.rejects(
+    () =>
+      assertWorkerExists({
+        accountId: "e3afbb613458022947cd9dc9f5bd6334",
+        apiToken: "test-token",
+        expectedService: "gomate-frontend",
+        fetchImpl: async () =>
+          Response.json({
+            success: true,
+            result: [{ id: "gomate-production-preview" }],
+          }),
+      }),
+    /rollback Worker is unavailable/u,
+  );
+});
+
 test("rollback reattaches only the exact hostname, zone, and approved Worker", async () => {
   let request;
   await attachProductionDomain({
@@ -363,6 +400,18 @@ test("cutover and rollback workflows are protected and narrowly scoped", () => {
     path.join(root, ".github/workflows/rollback-production-cutover.yml"),
     "utf8",
   );
+  const deploy = readFileSync(
+    path.join(root, ".github/workflows/deploy.yml"),
+    "utf8",
+  );
+  const retire = readFileSync(
+    path.join(root, ".github/workflows/retire-legacy-production.yml"),
+    "utf8",
+  );
+  for (const workflow of [deploy, cutover, rollback, retire]) {
+    assert.match(workflow, /group:\s*gomate-production-mutation/u);
+    assert.match(workflow, /cancel-in-progress:\s*false/u);
+  }
   assert.match(cutover, /CUTOVER_PRODUCTION/u);
   assert.match(cutover, /github\.ref\s*==\s*'refs\/heads\/main'/u);
   assert.match(cutover, /environment:\s*production/gu);
@@ -390,6 +439,14 @@ test("cutover and rollback workflows are protected and narrowly scoped", () => {
   );
   assert.match(rollback, /ROLLBACK_PRODUCTION/u);
   assert.match(rollback, /gomate-frontend/u);
+  const legacyPreflight = rollback.indexOf(
+    "production-domain.mjs assert-worker",
+  );
+  const protectedBuild = rollback.indexOf(
+    "Build and prepare WRITE_MODE protected",
+  );
+  assert.ok(legacyPreflight >= 0 && legacyPreflight < protectedBuild);
+  assert.match(rollback, /EXPECTED_WORKER_SERVICE:\s*gomate-frontend/u);
   assert.match(rollback, /mode=protected|--mode protected/u);
   assert.doesNotMatch(rollback, /DELETE FROM|wrangler\s+r2|wrangler\s+kv/iu);
 });

--- a/scripts/production-domain.mjs
+++ b/scripts/production-domain.mjs
@@ -17,7 +17,8 @@ function required(value, label) {
 }
 
 function nonNegativeInteger(value, label, fallback) {
-  const candidate = value === undefined || value === "" ? fallback : Number(value);
+  const candidate =
+    value === undefined || value === "" ? fallback : Number(value);
   if (!Number.isInteger(candidate) || candidate < 0) {
     throw new Error(`${label} must be a non-negative integer`);
   }
@@ -38,9 +39,15 @@ function expectedServiceSet(value) {
   return new Set(services);
 }
 
-async function cloudflareRequest({ accountId, apiToken, fetchImpl, init }) {
+async function cloudflareRequest({
+  accountId,
+  apiToken,
+  fetchImpl,
+  resourcePath = "/workers/domains",
+  init,
+}) {
   const response = await fetchImpl(
-    `${API_ROOT}/accounts/${encodeURIComponent(accountId)}/workers/domains`,
+    `${API_ROOT}/accounts/${encodeURIComponent(accountId)}${resourcePath}`,
     {
       ...init,
       headers: {
@@ -56,6 +63,33 @@ async function cloudflareRequest({ accountId, apiToken, fetchImpl, init }) {
     );
   }
   return payload.result;
+}
+
+export async function assertWorkerExists({
+  accountId = process.env.CLOUDFLARE_ACCOUNT_ID,
+  apiToken = process.env.CLOUDFLARE_API_TOKEN,
+  expectedService = process.env.EXPECTED_WORKER_SERVICE,
+  fetchImpl = fetch,
+} = {}) {
+  accountId = required(accountId, "CLOUDFLARE_ACCOUNT_ID");
+  apiToken = required(apiToken, "CLOUDFLARE_API_TOKEN");
+  expectedService = required(expectedService, "EXPECTED_WORKER_SERVICE");
+  if (!ALLOWED_TARGET_SERVICES.has(expectedService)) {
+    throw new Error("EXPECTED_WORKER_SERVICE is not an approved Worker");
+  }
+  const workers = await cloudflareRequest({
+    accountId,
+    apiToken,
+    fetchImpl,
+    resourcePath: "/workers/scripts",
+  });
+  if (
+    !Array.isArray(workers) ||
+    !workers.some((worker) => worker?.id === expectedService)
+  ) {
+    throw new Error("Expected rollback Worker is unavailable");
+  }
+  console.log(`Verified rollback Worker ${expectedService} exists.`);
 }
 
 export async function assertProductionDomain({
@@ -84,13 +118,19 @@ export async function assertProductionDomain({
     DEFAULT_RETRY_DELAY_MS,
   );
   if (retryDelayMs === 0 && timeoutMs > 0) {
-    throw new Error("DOMAIN_ASSERT_RETRY_DELAY_MS must be positive when retrying");
+    throw new Error(
+      "DOMAIN_ASSERT_RETRY_DELAY_MS must be positive when retrying",
+    );
   }
   const deadline = nowImpl() + timeoutMs;
 
   while (true) {
     try {
-      const domains = await cloudflareRequest({ accountId, apiToken, fetchImpl });
+      const domains = await cloudflareRequest({
+        accountId,
+        apiToken,
+        fetchImpl,
+      });
       if (!Array.isArray(domains)) {
         throw new Error("Cloudflare custom-domain inventory is invalid");
       }
@@ -166,11 +206,13 @@ if (
   const operation =
     command === "assert"
       ? assertProductionDomain
-      : command === "attach"
-        ? attachProductionDomain
-        : null;
+      : command === "assert-worker"
+        ? assertWorkerExists
+        : command === "attach"
+          ? attachProductionDomain
+          : null;
   if (!operation) {
-    console.error("Usage: production-domain.mjs assert|attach");
+    console.error("Usage: production-domain.mjs assert|assert-worker|attach");
     process.exit(1);
   }
   operation().catch((error) => {

--- a/scripts/retire-legacy-production.mjs
+++ b/scripts/retire-legacy-production.mjs
@@ -6,7 +6,7 @@ import { pathToFileURL } from "node:url";
 const API_ROOT = "https://api.cloudflare.com/client/v4";
 const ACCOUNT_ID = "e3afbb613458022947cd9dc9f5bd6334";
 const ZONE_ID = "0b714cd4257332034b3c4c0c099feb9e";
-const RETIRE_NOT_BEFORE = Date.parse("2026-08-23T18:53:01Z");
+const RETIRE_NOT_BEFORE = Date.parse("2026-08-20T15:00:00Z");
 const PRODUCTION_WORKER = "gomate-production-preview";
 const PRODUCTION_D1 = {
   id: "befa3d89-6551-4a25-8a1c-670efe62a315",
@@ -246,7 +246,7 @@ export async function retireLegacyProduction({
     throw new Error("Legacy retirement target is not the reviewed production");
   }
   if (nowImpl() < RETIRE_NOT_BEFORE) {
-    throw new Error("Mandatory seven-day retention window has not elapsed");
+    throw new Error("approved legacy retirement time has not been reached");
   }
 
   const before = await inventory({ accountId, apiToken, fetchImpl });

--- a/scripts/retire-legacy-production.test.mjs
+++ b/scripts/retire-legacy-production.test.mjs
@@ -158,7 +158,7 @@ function fakeCloudflare(state, requests) {
   };
 }
 
-test("legacy retirement fails before the mandatory seven-day boundary", async () => {
+test("legacy retirement fails before the explicitly approved boundary", async () => {
   let fetched = false;
   await assert.rejects(
     () =>
@@ -166,13 +166,13 @@ test("legacy retirement fails before the mandatory seven-day boundary", async ()
         accountId: "e3afbb613458022947cd9dc9f5bd6334",
         apiToken: "test-token",
         baseUrl: "https://gomate.live",
-        nowImpl: () => Date.parse("2026-08-23T18:53:00Z"),
+        nowImpl: () => Date.parse("2026-08-20T14:59:59Z"),
         fetchImpl: async () => {
           fetched = true;
           throw new Error("must not fetch");
         },
       }),
-    /seven-day retention/u,
+    /approved legacy retirement time/u,
   );
   assert.equal(fetched, false);
 });
@@ -184,7 +184,7 @@ test("legacy retirement deletes only reviewed legacy resources", async () => {
     accountId: "e3afbb613458022947cd9dc9f5bd6334",
     apiToken: "test-token",
     baseUrl: "https://gomate.live",
-    nowImpl: () => Date.parse("2026-08-23T18:53:01Z"),
+    nowImpl: () => Date.parse("2026-08-20T15:00:00Z"),
     fetchImpl: fakeCloudflare(state, requests),
   });
   assert.deepEqual(result.deleted, [
@@ -269,6 +269,7 @@ test("legacy retirement workflow is protected and has no R2 deletion", () => {
   assert.match(workflow, /RETIRE_LEGACY_RESOURCES/u);
   assert.match(workflow, /github\.ref\s*==\s*'refs\/heads\/main'/u);
   assert.match(workflow, /environment:\s*production/u);
+  assert.match(workflow, /group:\s*gomate-production-mutation/u);
   assert.match(workflow, /retire-legacy-production\.mjs/u);
   assert.doesNotMatch(workflow, /wrangler\s+r2|migrations apply|seed\.sql/iu);
 });


### PR DESCRIPTION
## Summary

- move the exact Stage D not-before boundary to 2026-08-20 23:00 Asia/Shanghai following explicit approval to shorten the original observation period
- serialize preview deploy, cutover, legacy rollback, and retirement under one production mutation concurrency group
- make legacy rollback prove `gomate-frontend` still exists before any build, deployment, or `WRITE_MODE` change

## Safety boundary

- the legacy deletion allowlist, Cloudflare API paths, production protected environment, and manual confirmation remain unchanged
- no deployment, migration, route change, database write, or Cloudflare deletion occurs by merging this PR
- `gomate-production-preview`, `gomate.live`, V2 D1/KV, R2, production secrets, 36 Locations, and 19 Regions remain protected by existing preflight/postflight checks

## Verification

- `pnpm test:delivery` — 46/46 passed outside the sandbox
- focused cutover/retirement tests — 17/17 passed after formatting
- workflow YAML parse check
- Prettier check
- `git diff --check`
- fresh-context adversarial review found two P1s; both were fixed and re-review found no remaining contract violation

## Rollback

Revert this PR before the retirement workflow runs to restore the original 2026-08-23 boundary and prior concurrency groups. After successful Stage D deletion, old route rollback is intentionally unavailable.
