### PR TITLE
Fix Stage D retirement preflight

### DIFF
--- a/docs/prod-change-policy.md
+++ b/docs/prod-change-policy.md
@@ -118,7 +118,7 @@ rollback SQL 只作为 90 天 artifact 保存，不自动执行。一次性迁�
 旧资源最早只能在 2026-08-20T15:00:00Z（上海时间 2026-08-20 23:00）后退役。从 `main` 手动运行
 `Retire legacy Cloudflare resources` 并输入 `RETIRE_LEGACY_RESOURCES`，且必须通过
 `production` environment 审批。流水线先证明 `gomate.live` 精确属于
-`gomate-production-preview`，并核对新 D1/KV 与共享 R2；随后只删除：
+`gomate-production-preview`，并核对新 D1/KV；随后只删除：
 
 - `api.gomate.live` custom domain；
 - Workers `gomate-api`、`gomate-frontend`、`gomate-production-preview-production`；
@@ -126,10 +126,16 @@ rollback SQL 只作为 90 天 artifact 保存，不自动执行。一次性迁�
 - KV `GOMATE_KV`（`638ecd78e70c48fda01904bc9c2105d8`）和
   `gomate-frontend-session`（`6e3db6b00bc4421faeb1402c2e51f7d1`）。
 
-脚本不得调用 R2 删除 API；执行后重新读取 Cloudflare inventory，并验证生产 Worker、
-`gomate-db-v2`、`gomate-cache-v2`、R2 `gomate`、health 和深圳 Region。任一名称、ID、域名归属、
+脚本不得调用任何 R2 API；这是不扩大 production token 权限且不触碰 R2 bucket/对象的结构化门禁，
+由退役合同测试扫描保证。执行前后都要重新读取其余 Cloudflare inventory，并验证生产 Worker、
+`gomate-db-v2`、`gomate-cache-v2`、health、36 条公开 Location 和深圳 Region。任一名称、ID、域名归属、
 时间边界、36 条地点迁移结果或生产资源不匹配时，在首个 DELETE 前失败闭合。流水线可安全重跑：
 已经删除的精确旧资源视为完成，但新资源缺失仍立即失败。
+
+首次阶段 D [run 32383947967](https://github.com/redisread/gomate/actions/runs/32383947967)
+在首个脚本步骤失败：一个不参与删除的 Cloudflare inventory 请求返回 HTTP 200 但
+`success != true`。工作流按设计停止，未进行手工补删或代码清理；随后修复移除无关的 R2 inventory
+权限依赖，并为每个 Cloudflare 操作增加不含凭据的稳定错误标签。
 
 preview deploy、cutover、旧 route 回滚和阶段 D 退役共用 `gomate-production-mutation` concurrency
 group，禁止这些生产写操作并发。阶段 D 成功后旧 route 回滚永久不可用，并立即通过代码清理 PR

--- a/scripts/retire-legacy-production.mjs
+++ b/scripts/retire-legacy-production.mjs
@@ -42,6 +42,7 @@ function required(value, label) {
 async function cloudflareRequest({
   accountId,
   apiToken,
+  operation,
   resourcePath,
   method = "GET",
   body,
@@ -60,8 +61,14 @@ async function cloudflareRequest({
   );
   const payload = await response.json().catch(() => null);
   if (!response.ok || payload?.success !== true) {
+    const errorCodes = Array.isArray(payload?.errors)
+      ? payload.errors
+          .map((error) => error?.code)
+          .filter((code) => Number.isFinite(Number(code)))
+          .join(",")
+      : "";
     throw new Error(
-      `Cloudflare retirement request failed (${response.status})`,
+      `Cloudflare ${operation} failed (${response.status}${errorCodes ? `; codes=${errorCodes}` : ""})`,
     );
   }
   return payload.result;
@@ -75,6 +82,7 @@ async function assertLocationMigrationComplete({
   const result = await cloudflareRequest({
     accountId,
     apiToken,
+    operation: "query production D1 counts",
     resourcePath: `/d1/database/${PRODUCTION_D1.id}/query`,
     method: "POST",
     body: JSON.stringify({
@@ -89,35 +97,33 @@ async function assertLocationMigrationComplete({
 }
 
 async function inventory({ accountId, apiToken, fetchImpl }) {
-  const [domains, workers, databases, namespaces, r2] = await Promise.all([
+  const [domains, workers, databases, namespaces] = await Promise.all([
     cloudflareRequest({
       accountId,
       apiToken,
+      operation: "list Worker domains",
       resourcePath: "/workers/domains",
       fetchImpl,
     }),
     cloudflareRequest({
       accountId,
       apiToken,
+      operation: "list Workers",
       resourcePath: "/workers/scripts",
       fetchImpl,
     }),
     cloudflareRequest({
       accountId,
       apiToken,
+      operation: "list D1 databases",
       resourcePath: "/d1/database",
       fetchImpl,
     }),
     cloudflareRequest({
       accountId,
       apiToken,
+      operation: "list KV namespaces",
       resourcePath: "/storage/kv/namespaces",
-      fetchImpl,
-    }),
-    cloudflareRequest({
-      accountId,
-      apiToken,
-      resourcePath: "/r2/buckets",
       fetchImpl,
     }),
   ]);
@@ -125,12 +131,11 @@ async function inventory({ accountId, apiToken, fetchImpl }) {
     !Array.isArray(domains) ||
     !Array.isArray(workers) ||
     !Array.isArray(databases) ||
-    !Array.isArray(namespaces) ||
-    !Array.isArray(r2?.buckets)
+    !Array.isArray(namespaces)
   ) {
     throw new Error("Cloudflare retirement inventory is invalid");
   }
-  return { domains, workers, databases, namespaces, buckets: r2.buckets };
+  return { domains, workers, databases, namespaces };
 }
 
 function assertProductionResources(state) {
@@ -164,9 +169,6 @@ function assertProductionResources(state) {
     )
   ) {
     throw new Error("Production V2 KV is missing");
-  }
-  if (!state.buckets.some((bucket) => bucket.name === "gomate")) {
-    throw new Error("Shared gomate R2 bucket is missing");
   }
 }
 
@@ -210,11 +212,26 @@ function assertLegacyIdentity(state) {
   }
 }
 
-async function verifyPublicProduction({ baseUrl, fetchImpl }) {
+async function verifyPublicProduction({ baseUrl, fetchImpl, phase }) {
   const health = await fetchImpl(new URL("/api/health", baseUrl));
   const healthPayload = await health.json().catch(() => null);
   if (!health.ok || healthPayload?.status !== "ok") {
-    throw new Error("Production health failed after retirement");
+    throw new Error(`Production health failed ${phase} retirement`);
+  }
+  const locations = await fetchImpl(
+    new URL("/api/locations?limit=100", baseUrl),
+  );
+  const locationPayload = await locations.json().catch(() => null);
+  if (
+    !locations.ok ||
+    locationPayload?.success !== true ||
+    locationPayload.locations?.length !== 36 ||
+    locationPayload.total !== 36 ||
+    locationPayload.nextCursor !== null
+  ) {
+    throw new Error(
+      `Production Location verification failed ${phase} retirement`,
+    );
   }
   const regions = await fetchImpl(
     new URL(
@@ -228,7 +245,9 @@ async function verifyPublicProduction({ baseUrl, fetchImpl }) {
     regionPayload?.success !== true ||
     !regionPayload.regions?.some((region) => region.id === "region-cn-shenzhen")
   ) {
-    throw new Error("Production Region verification failed after retirement");
+    throw new Error(
+      `Production Region verification failed ${phase} retirement`,
+    );
   }
 }
 
@@ -253,6 +272,7 @@ export async function retireLegacyProduction({
   assertProductionResources(before);
   assertLegacyIdentity(before);
   await assertLocationMigrationComplete({ accountId, apiToken, fetchImpl });
+  await verifyPublicProduction({ baseUrl, fetchImpl, phase: "before" });
   const deleted = [];
   const apiDomain = before.domains.find(
     (domain) => domain.hostname === "api.gomate.live",
@@ -261,6 +281,7 @@ export async function retireLegacyProduction({
     await cloudflareRequest({
       accountId,
       apiToken,
+      operation: "delete legacy API domain",
       resourcePath: `/workers/domains/${encodeURIComponent(apiDomain.id)}`,
       method: "DELETE",
       fetchImpl,
@@ -272,6 +293,7 @@ export async function retireLegacyProduction({
       await cloudflareRequest({
         accountId,
         apiToken,
+        operation: `delete legacy Worker ${workerName}`,
         resourcePath: `/workers/scripts/${encodeURIComponent(workerName)}`,
         method: "DELETE",
         fetchImpl,
@@ -283,6 +305,7 @@ export async function retireLegacyProduction({
     await cloudflareRequest({
       accountId,
       apiToken,
+      operation: "delete legacy D1",
       resourcePath: `/d1/database/${LEGACY_D1.id}`,
       method: "DELETE",
       fetchImpl,
@@ -294,6 +317,7 @@ export async function retireLegacyProduction({
       await cloudflareRequest({
         accountId,
         apiToken,
+        operation: `delete legacy KV ${target.title}`,
         resourcePath: `/storage/kv/namespaces/${target.id}`,
         method: "DELETE",
         fetchImpl,
@@ -314,7 +338,7 @@ export async function retireLegacyProduction({
   ) {
     throw new Error("Legacy Cloudflare resource retirement is incomplete");
   }
-  await verifyPublicProduction({ baseUrl, fetchImpl });
+  await verifyPublicProduction({ baseUrl, fetchImpl, phase: "after" });
   return { deleted };
 }
 
@@ -328,7 +352,7 @@ if (
         "### Legacy Cloudflare retirement complete",
         ...deleted.map((resource) => `- Deleted ${resource}`),
         "- Preserved gomate-production-preview, gomate-db-v2, gomate-cache-v2, and R2 gomate.",
-        "- Verified gomate.live health and Shenzhen Region after retirement.",
+        "- Verified gomate.live health, 36 Locations, and Shenzhen Region before and after retirement.",
       ];
       if (process.env.GITHUB_STEP_SUMMARY) {
         appendFileSync(

--- a/scripts/retire-legacy-production.test.mjs
+++ b/scripts/retire-legacy-production.test.mjs
@@ -75,7 +75,6 @@ function initialState({
           ]
         : []),
     ],
-    buckets: [{ name: "gomate" }],
     productionLocationCount,
   };
 }
@@ -87,6 +86,17 @@ function fakeCloudflare(state, requests) {
     requests.push({ url: value, method });
     if (value === "https://gomate.live/api/health") {
       return Response.json({ status: "ok" });
+    }
+    if (value === "https://gomate.live/api/locations?limit=100") {
+      return Response.json({
+        success: true,
+        locations: Array.from(
+          { length: state.productionLocationCount },
+          (_, index) => ({ id: index }),
+        ),
+        total: state.productionLocationCount,
+        nextCursor: null,
+      });
     }
     if (value.startsWith("https://gomate.live/api/regions?")) {
       return Response.json({
@@ -105,9 +115,7 @@ function fakeCloudflare(state, requests) {
               ? state.databases
               : relative === "/storage/kv/namespaces"
                 ? state.namespaces
-                : relative === "/r2/buckets"
-                  ? { buckets: state.buckets }
-                  : null;
+                : null;
       return Response.json(
         { success: result !== null, result },
         { status: result === null ? 404 : 200 },
@@ -200,8 +208,11 @@ test("legacy retirement deletes only reviewed legacy resources", async () => {
   assert.equal(state.workers[0].id, "gomate-production-preview");
   assert.equal(state.databases.length, 1);
   assert.equal(state.namespaces.length, 1);
-  assert.deepEqual(state.buckets, [{ name: "gomate" }]);
   assert.equal(requests.filter(({ method }) => method === "DELETE").length, 7);
+  assert.equal(
+    requests.some(({ url }) => url.includes("/r2/")),
+    false,
+  );
 });
 
 test("legacy retirement is idempotent after reviewed resources are absent", async () => {
@@ -261,6 +272,58 @@ test("legacy retirement refuses to delete the old D1 before Location migration",
   );
 });
 
+test("legacy retirement verifies public Locations before and after deletion", async () => {
+  const state = initialState();
+  const requests = [];
+  await retireLegacyProduction({
+    accountId: "e3afbb613458022947cd9dc9f5bd6334",
+    apiToken: "test-token",
+    baseUrl: "https://gomate.live",
+    nowImpl: () => Date.parse("2026-08-24T00:00:00Z"),
+    fetchImpl: fakeCloudflare(state, requests),
+  });
+  assert.equal(
+    requests.filter(
+      ({ url }) => url === "https://gomate.live/api/locations?limit=100",
+    ).length,
+    2,
+  );
+});
+
+test("Cloudflare failures identify the safe operation without leaking credentials", async () => {
+  const state = initialState();
+  const requests = [];
+  const fake = fakeCloudflare(state, requests);
+  await assert.rejects(
+    () =>
+      retireLegacyProduction({
+        accountId: "e3afbb613458022947cd9dc9f5bd6334",
+        apiToken: "test-token",
+        baseUrl: "https://gomate.live",
+        nowImpl: () => Date.parse("2026-08-24T00:00:00Z"),
+        fetchImpl: async (url, init) => {
+          if (String(url).endsWith("/workers/scripts")) {
+            return Response.json({
+              success: false,
+              errors: [{ code: 10000, message: "permission denied" }],
+            });
+          }
+          return fake(url, init);
+        },
+      }),
+    (error) => {
+      assert.match(error.message, /list Workers/u);
+      assert.match(error.message, /10000/u);
+      assert.doesNotMatch(error.message, /test-token/u);
+      return true;
+    },
+  );
+  assert.equal(
+    requests.some(({ method }) => method === "DELETE"),
+    false,
+  );
+});
+
 test("legacy retirement workflow is protected and has no R2 deletion", () => {
   const workflow = readFileSync(
     path.join(root, ".github/workflows/retire-legacy-production.yml"),
@@ -272,4 +335,9 @@ test("legacy retirement workflow is protected and has no R2 deletion", () => {
   assert.match(workflow, /group:\s*gomate-production-mutation/u);
   assert.match(workflow, /retire-legacy-production\.mjs/u);
   assert.doesNotMatch(workflow, /wrangler\s+r2|migrations apply|seed\.sql/iu);
+  const script = readFileSync(
+    path.join(root, "scripts/retire-legacy-production.mjs"),
+    "utf8",
+  );
+  assert.doesNotMatch(script, /\/r2\//u);
 });


### PR DESCRIPTION
## Summary
- remove the unrelated R2 inventory read from Stage D; the retirement script now makes no R2 API call
- add operation-scoped Cloudflare error codes without credentials
- verify health, exactly 36 Locations, and Shenzhen Region both before and after deletion
- document failed run 32383947967 and the fail-closed recovery

## Safety
- deletion allowlist is unchanged
- production Worker, V2 D1/KV, R2, gomate.live, secrets, and environment remain outside the delete set
- R2 preservation is enforced structurally by rejecting every /r2/ call in the retirement script
- retry remains protected by the production environment and shared production-mutation concurrency group

## Verification
- check:legacy-removal
- test:delivery (48/48)
- API migration sync (19 tables, 8 triggers)
- Prettier, YAML parse, git diff --check

Cloudflare documents that listing R2 buckets requires Workers R2 Storage Read: https://developers.cloudflare.com/api/resources/r2/subresources/buckets/methods/list/