### PR TITLE
fix: align production Worker identity

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,7 @@ jobs:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
         run: |
           node scripts/validate-production-release.mjs
-          EXPECTED_DOMAIN_SERVICE=gomate-production-preview node scripts/production-domain.mjs assert
+          EXPECTED_DOMAIN_SERVICE=gomate node scripts/production-domain.mjs assert
 
       - name: Capture current production version
         working-directory: frontend
@@ -154,7 +154,7 @@ jobs:
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          EXPECTED_DOMAIN_SERVICE: gomate-production-preview
+          EXPECTED_DOMAIN_SERVICE: gomate
         run: node scripts/production-domain.mjs assert
 
       - name: Promote candidate to all traffic

--- a/.github/workflows/migrate-production.yml
+++ b/.github/workflows/migrate-production.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          EXPECTED_DOMAIN_SERVICE: gomate-production-preview
+          EXPECTED_DOMAIN_SERVICE: gomate
         run: node scripts/production-domain.mjs assert
 
       - name: Validate approved compatible Worker version

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          EXPECTED_DOMAIN_SERVICE: gomate-production-preview
+          EXPECTED_DOMAIN_SERVICE: gomate
         run: node scripts/production-domain.mjs assert
 
       - name: Capture current production version

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@
 - 前端入口位于 `frontend/src/pages/`，交互组件位于 `frontend/src/components/`，共享客户端调用位于 `frontend/src/lib/`。
 - API 路由位于 `api/src/routes/`，通用能力位于 `api/src/lib/`，Drizzle schema 位于 `api/src/db/schema.ts`。
 - 跨包公开类型放在 `packages/types`；不要在前后端各自维护同一 DTO 的兼容副本。
-- 生产域名是 `https://gomate.live`，当前 Cloudflare Worker 服务名为 `gomate-production-preview`（历史命名，仍是现行生产资源）。
+- 生产域名是 `https://gomate.live`，当前 Cloudflare Worker 服务名为 `gomate`。
 
 ## 工作方式
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ pnpm env:check
 
 ## 部署
 
-生产不随 `main` 自动部署。当前线上由统一 Worker `gomate-production-preview` 提供
+生产不随 `main` 自动部署。当前线上由统一 Worker `gomate` 提供
 `gomate.live`；`.github/workflows/deploy.yml` 通过 GitHub `production` protected
 environment 上传、验证并推广不可变 Worker version，D1 migration 使用独立 workflow。
 任何生产写入都必须明确目标与回滚方式并获得逐次批准。详见 `docs/prod-change-policy.md`。

--- a/docs/prod-change-policy.md
+++ b/docs/prod-change-policy.md
@@ -5,7 +5,7 @@
 ## 1. 当前生产拓扑
 
 - 生产域名：`https://gomate.live`
-- Worker 服务：`gomate-production-preview`（历史命名，现为唯一生产 Worker）
+- Worker 服务：`gomate`（唯一生产 Worker）
 - Worker 入口：`frontend/src/worker.ts`
 - API：同源 `/api/*`，进程内交给 `api/src/app.ts`
 - D1：binding `DB`，`gomate-db-v2`，UUID `befa3d89-6551-4a25-8a1c-670efe62a315`
@@ -41,7 +41,7 @@ Region ID `region-cn`、`region-cn-guangdong`、`region-cn-shenzhen`。
 仓库不在 push `main` 时自动部署。`.github/workflows/deploy.yml` 只接受 `main` 上手动输入 `DEPLOY_PRODUCTION`，并通过 GitHub `production` protected environment 执行。发布顺序固定为：
 
 1. 重跑源代码、migration、类型、测试、构建、bundle size 与 startup 门禁；
-2. 验证 `gomate.live` 仍只绑定到 `gomate-production-preview`，生产 binding、route、write mode、observability 与 secrets 声明符合仓库配置；
+2. 验证 `gomate.live` 仍只绑定到 `gomate`，生产 binding、route、write mode、observability 与 secrets 声明符合仓库配置；
 3. 使用官方 `cloudflare/wrangler-action@v4` 和仓库锁定的 Wrangler 版本执行 `versions upload`，通过 `WRANGLER_OUTPUT_FILE_PATH` 读取不可变 version ID；
 4. 保持现行版本 100% 流量，将候选版本加入 deployment 但设为 0%，通过 `Cloudflare-Workers-Version-Overrides` 请求头在 `gomate.live` 上验证候选版本；冒烟包含 health、Region 与 Astro SSR，并为 Cloudflare deployment 传播保留两分钟重试窗口；
 5. 在同一个受保护 job 内将同一个候选 version ID 提升到 100%，不得重新构建；候选、推广、观察和恢复不跨 job，避免审批等待或新 runner 初始化留下 0% 的中间 deployment；

--- a/frontend/wrangler.jsonc
+++ b/frontend/wrangler.jsonc
@@ -78,7 +78,7 @@
   },
   "env": {
     "production": {
-      "name": "gomate-production-preview",
+      "name": "gomate",
       "routes": [{ "pattern": "gomate.live", "custom_domain": true }],
       "assets": {
         "directory": "./dist",

--- a/scripts/production-domain.mjs
+++ b/scripts/production-domain.mjs
@@ -4,7 +4,7 @@ import { pathToFileURL } from "node:url";
 
 const API_ROOT = "https://api.cloudflare.com/client/v4";
 const ZONE_ID = "0b714cd4257332034b3c4c0c099feb9e";
-const ALLOWED_TARGET_SERVICES = new Set(["gomate-production-preview"]);
+const ALLOWED_TARGET_SERVICES = new Set(["gomate"]);
 const DEFAULT_RETRY_DELAY_MS = 5_000;
 
 function required(value, label) {

--- a/scripts/production-release.test.mjs
+++ b/scripts/production-release.test.mjs
@@ -86,7 +86,7 @@ function sourceConfig() {
     version_metadata: { binding: "CF_VERSION_METADATA" },
     env: {
       production: {
-        name: "gomate-production-preview",
+        name: "gomate",
         routes: [{ pattern: "gomate.live", custom_domain: true }],
         assets: {
           directory: "./dist",
@@ -103,7 +103,7 @@ function sourceConfig() {
 function builtConfig() {
   return {
     targetEnvironment: "production",
-    name: "gomate-production-preview",
+    name: "gomate",
     main: "entry.mjs",
     no_bundle: true,
     compatibility_date: "2026-06-18",
@@ -180,13 +180,13 @@ test("Wrangler structured output yields the exact uploaded version", () => {
     JSON.stringify({
       type: "version-upload",
       version: 1,
-      worker_name: "gomate-production-preview",
+      worker_name: "gomate",
       version_id: versionId,
     }),
   ].join("\n");
   assert.deepEqual(parseVersionUploadOutput(output), {
     versionId,
-    workerName: "gomate-production-preview",
+    workerName: "gomate",
   });
   assert.throws(
     () => parseVersionUploadOutput('{"type":"command-failed"}\n'),
@@ -320,7 +320,7 @@ test("candidate smoke pins every request to the uploaded version", async () => {
     calls.every(
       ({ headers }) =>
         headers.get("Cloudflare-Workers-Version-Overrides") ===
-        `gomate-production-preview="${versionId}"`,
+        `gomate="${versionId}"`,
     ),
   );
 });
@@ -533,4 +533,8 @@ test("production workflows use Wrangler Action immutable versions and explicit r
   assert.match(migration, /production-version-allowlist/u);
   assert.match(migration, /cloudflare\/wrangler-action@v4/u);
   assert.match(migration, /d1 migrations apply/u);
+  for (const workflow of [release, rollback, migration]) {
+    assert.match(workflow, /EXPECTED_DOMAIN_SERVICE(?:=|: )gomate/u);
+    assert.doesNotMatch(workflow, /gomate-production-preview/u);
+  }
 });

--- a/scripts/release-versions.mjs
+++ b/scripts/release-versions.mjs
@@ -79,7 +79,7 @@ export function parseVersionUploadOutput(value) {
     upload.version_id ?? upload.versionId,
   );
   const workerName = upload.worker_name ?? upload.workerName;
-  if (workerName !== "gomate-production-preview") {
+  if (workerName !== "gomate") {
     throw new Error("Uploaded version belongs to an unexpected Worker");
   }
   return { versionId, workerName };

--- a/scripts/smoke-production-version.mjs
+++ b/scripts/smoke-production-version.mjs
@@ -6,7 +6,7 @@ import { pathToFileURL } from "node:url";
 import { assertWorkerVersionId } from "./release-versions.mjs";
 
 const REQUEST_ID_PATTERN = /^[a-z0-9-]{36,96}$/iu;
-const WORKER_NAME = "gomate-production-preview";
+const WORKER_NAME = "gomate";
 const wait = (delay) => new Promise((resolve) => setTimeout(resolve, delay));
 
 function productionOrigin(value) {

--- a/scripts/validate-production-release.mjs
+++ b/scripts/validate-production-release.mjs
@@ -14,7 +14,7 @@ const BUILT_CONFIG_PATH = path.join(
   "server",
   "wrangler.json",
 );
-const WORKER_NAME = "gomate-production-preview";
+const WORKER_NAME = "gomate";
 const COMPATIBILITY_DATE = "2026-06-18";
 const D1_ID = "befa3d89-6551-4a25-8a1c-670efe62a315";
 const KV_ID = "f9904d1fa72140c18067e07d541ca92b";


### PR DESCRIPTION
## Summary

- target the actual Cloudflare Worker service `gomate` in the production Wrangler environment
- update release, rollback, migration, domain, upload-output, and version-override guards
- update the current deployment documentation and add regression coverage against the retired name

## Validation

- `pnpm exec prettier --check ...`
- `pnpm check:legacy-removal`
- `pnpm test:delivery`
- API lint, type-check, build, 360 tests, and migration sync
- frontend i18n validation, lint, type-check, 271 tests, and production build
- Wrangler types check, deploy dry-run, bundle-size check, and startup analysis
- `pnpm audit --prod --audit-level high` (no high or critical findings)

## Production impact

This PR does not deploy or mutate Cloudflare resources. It keeps production deployment manual behind the GitHub `production` protected environment. The next approved production release will upload and promote an immutable version of the existing `gomate` Worker.

## Rollback

Revert this PR before the next production release. If a later approved release fails, use the existing protected rollback workflow to restore the previously verified `gomate` Worker version.