### PR TITLE
fix: deploy Astro generated Worker bundle

### DIFF
--- a/scripts/deploy-production.mjs
+++ b/scripts/deploy-production.mjs
@@ -8,7 +8,7 @@ import { assertProductionDeployEnvironment } from "./production-build-guard.mjs"
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const WRANGLER = process.platform === "win32" ? "wrangler.cmd" : "wrangler";
 
-const COMMANDS = [
+export const PRODUCTION_WRANGLER_COMMANDS = [
   [
     "d1",
     "migrations",
@@ -20,7 +20,7 @@ const COMMANDS = [
     "--config",
     "wrangler.jsonc",
   ],
-  ["deploy", "--env", "production", "--config", "wrangler.jsonc"],
+  ["deploy", "--env", "production"],
 ];
 
 function runWrangler(args) {
@@ -46,10 +46,12 @@ function runWrangler(args) {
 
 async function main() {
   assertProductionDeployEnvironment();
-  for (const args of COMMANDS) await runWrangler(args);
+  for (const args of PRODUCTION_WRANGLER_COMMANDS) await runWrangler(args);
 }
 
-main().catch((error) => {
-  console.error(`❌ ${error.message}`);
-  process.exitCode = 1;
-});
+if (path.resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(`❌ ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/production-build-guard.test.mjs
+++ b/scripts/production-build-guard.test.mjs
@@ -4,6 +4,7 @@ import {
   assertProductionBuildEnvironment,
   assertProductionDeployEnvironment,
 } from "./production-build-guard.mjs";
+import { PRODUCTION_WRANGLER_COMMANDS } from "./deploy-production.mjs";
 
 test("allows local production-parity builds", () => {
   assert.doesNotThrow(() =>
@@ -58,4 +59,21 @@ test("rejects production deployment outside Workers Builds", () => {
       }),
     /只允许由 main 分支的 Workers Builds 执行/u,
   );
+});
+
+test("deploys the Astro build through Wranglers redirected config", () => {
+  assert.deepEqual(PRODUCTION_WRANGLER_COMMANDS, [
+    [
+      "d1",
+      "migrations",
+      "apply",
+      "DB",
+      "--remote",
+      "--env",
+      "production",
+      "--config",
+      "wrangler.jsonc",
+    ],
+    ["deploy", "--env", "production"],
+  ]);
 });


### PR DESCRIPTION
## Summary

- preserve the explicit root Wrangler config for D1 migration targeting
- let `wrangler deploy` follow Astros generated `.wrangler/deploy/config.json` redirect
- add a regression test for the exact migration and deploy command boundary

## Root cause

Cloudflare build `29dcd4d5-fc26-4ae2-889b-5321e0a8f9b1` completed every build gate and both D1 migrations, then failed because the deploy script passed `--config wrangler.jsonc`. That bypassed Astros generated `dist/server/wrangler.json` and made Wrangler try to bundle unresolved Astro virtual modules.

Cloudflare documents that framework tools may create `.wrangler/deploy/config.json`, and that `wrangler deploy` follows this redirect to the generated configuration.

## Verification

- regression test failed before the command fix and passes after it
- `pnpm test:ci`
- `pnpm worker:types`
- `pnpm worker:dry-run` (reports `Using redirected Wrangler configuration`)
- `pnpm worker:size`

## Production state

`0000_init.sql` and `0001_reference_data.sql` were already applied successfully to `gomate-db-v3` by the failed build. The retry is idempotent: migration apply should report no pending migrations, then deploy the generated Worker bundle with `WRITE_MODE=protected`.