### PR TITLE
chore: move CI actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,15 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 11.19.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.13.0
           cache: pnpm


### PR DESCRIPTION
## Summary

- upgrade `actions/checkout` from v4 to v7
- upgrade `actions/setup-node` from v4 to v7
- upgrade `pnpm/action-setup` from v4 to v6
- keep application Node 22.13.0 and pnpm 11.19.0 unchanged

All three upgraded Action majors declare `runs.using: node24`, removing the GitHub-hosted runner deprecation annotation without changing the projects runtime toolchain.

## Verification

- workflow YAML passes Prettier validation
- `pnpm test:ci`
- `pnpm worker:types`
- `pnpm worker:dry-run`
- `pnpm worker:size`

The PR run itself is the runtime acceptance test: it must complete without the Node.js 20 deprecation annotation before merge.