### PR TITLE
docs: show main CI status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 > 发现有趣地点，找到同行伙伴
 
+[![CI](https://github.com/redisread/gomate/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/redisread/gomate/actions/workflows/ci.yml)
 [![Live](https://img.shields.io/badge/Live-gomate.live-blue)](https://gomate.live)
 
 ## 产品定位


### PR DESCRIPTION
## 目的

让 README 直接展示 `main` 分支由 `push` 触发的 GitHub Actions CI 状态，并可点击进入对应工作流页面。

## 范围

- 包含：在 README 顶部增加 `ci.yml` 的状态徽章。
- 不包含：GitHub Actions 工作流、Cloudflare Workers Builds 配置或生产部署行为变更。
- 关联 Issue / Spec / ADR：无。

## 风险与兼容性

- 风险等级：低。
- 用户可见或 API 破坏性变更：无。
- 主要失败模式与限制措施：徽章明确限定 `branch=main&event=push`，避免混入 PR 或其他分支运行状态。

## 验证证据

- [ ] `pnpm test:ci`
- [ ] `pnpm worker:types && pnpm worker:dry-run && pnpm worker:size`
- [ ] `pnpm audit --prod --audit-level high`（生产相关改动时）
- [ ] `pnpm test:e2e:ci`（涉及关键用户流程时）
- [ ] UI：桌面端、移动端、键盘、可访问名称和 i18n 已验证（涉及界面时）
- [x] 其他自动或手动验证：`git diff --check` 通过；徽章 URL、Actions 工作流页面和 `gomate.live` 均返回 HTTP 200；staged 敏感信息扫描无匹配。
- 未运行项及原因：纯 README 改动，不涉及代码、构建配置、运行时或用户流程，因此未运行应用、Worker、审计与 E2E 门禁。

## Cloudflare 与数据影响

- [x] 不涉及 Cloudflare 运行时或远程数据
- [ ] Worker 代码、Static Assets、兼容日期或 flags
- [ ] route、custom domain 或 Workers Builds 配置
- [ ] D1 schema、migration 或生产数据
- [ ] R2 bucket、对象或公开 URL
- [ ] bindings、变量、rate limit 或 secrets
- [ ] 认证、缓存、日志、trace 或隐私边界

精确目标、预期状态和影响范围：仅 README 展示层；不产生 Cloudflare 或数据写入。

### Worker 检查（适用时）

不适用。

### D1 / R2 检查（适用时）

不适用。

## 发布、验证与回滚

- 合并后的生产影响：仅 GitHub README 增加 CI 状态徽章；不改变 Worker。
- 发布后 smoke：确认 GitHub README 正常渲染徽章并能跳转到工作流页面。
- Worker 回滚目标或停止发布方式：不适用；如需撤销，回退该 README 提交。
- schema / 数据 / R2 无法随 Worker 回滚时的处理方式：不适用。
