### PR TITLE
fix: keep map markers small when zoomed

### DIFF
--- a/src/__tests__/china-map.test.tsx
+++ b/src/__tests__/china-map.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ChinaMap } from "../components/features/home/china-map";
+import { getMapMarkerRadius } from "../lib/china-map";
 
 vi.mock("@/hooks/useI18n", () => ({
   useI18n: () => ({
@@ -81,6 +82,11 @@ describe("ChinaMap", () => {
     expect(screen.getByText(/中国 \/ 广东省/)).toBeInTheDocument();
     expect(screen.getByLabelText("梧桐山")).toBeInTheDocument();
 
+    const marker = document.querySelector('circle[fill="var(--primary)"]');
+    expect(Number(marker?.getAttribute("r"))).toBeCloseTo(getMapMarkerRadius(5.5, 3));
+    const hitTarget = document.querySelector('circle[fill="transparent"]');
+    expect(Number(hitTarget?.getAttribute("r"))).toBe(12);
+
     await waitFor(() => {
       expect(screen.queryByLabelText("四姑娘山")).not.toBeInTheDocument();
     });
@@ -88,5 +94,10 @@ describe("ChinaMap", () => {
     fireEvent.click(guangdong);
 
     expect(historyBack).toHaveBeenCalledOnce();
+  });
+
+  it("calculates marker radii in the map's unscaled coordinate space", () => {
+    expect(getMapMarkerRadius(5, 1)).toBe(5);
+    expect(getMapMarkerRadius(5, 3)).toBeCloseTo(5 / 3);
   });
 });

--- a/src/components/features/home/china-map.tsx
+++ b/src/components/features/home/china-map.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, MapPinned } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import {
   getMapTransform,
+  getMapMarkerRadius,
   MAP_PROVINCE_PARAM,
   parseMapProvince,
   projectChina,
@@ -347,10 +348,11 @@ export function ChinaMap({ className }: { className?: string }) {
                   <circle
                     cx={position.x}
                     cy={position.y}
-                    r={focusedProvince ? 5.5 : 5}
+                    r={getMapMarkerRadius(focusedProvince ? 5.5 : 5, mapTransform.scale)}
                     fill="var(--primary)"
                     stroke="#fff"
                     strokeWidth={1.2}
+                    vectorEffect="non-scaling-stroke"
                     pointerEvents="none"
                     className="transition-[r] duration-150 motion-reduce:transition-none"
                   />

--- a/src/lib/china-map.ts
+++ b/src/lib/china-map.ts
@@ -52,6 +52,11 @@ export function transformMapPoint(point: MapPointPosition, transform: MapTransfo
   };
 }
 
+/** Keep marker geometry stable while the map content is zoomed. */
+export function getMapMarkerRadius(radius: number, mapScale: number): number {
+  return radius / mapScale;
+}
+
 export function parseMapProvince(search: string): string | null {
   const province = new URLSearchParams(search).get(MAP_PROVINCE_PARAM);
   return province && PROVINCE_CENTERS[province] ? province : null;


### PR DESCRIPTION
## Summary
- keep visible map markers visually stable when a province is zoomed to 3x
- keep the marker stroke from scaling with the map
- preserve the larger transparent click target for easy interaction
- add regression coverage for zoomed marker radius and hit area

## Verification
- `pnpm test` — 60 files, 261 tests passed
- `pnpm test:server` — 7 files, 21 tests passed
- `pnpm lint` passed
- `pnpm type-check` passed
- `pnpm build` passed
- isolated browser screenshot/DOM check confirmed marker radius changes from `5` to `1.8333` at map scale `3`, while the hit target remains `12`

The local browser also surfaced pre-existing dev-only hydration/500 warnings unrelated to this change.