### PR TITLE
ci: avoid duplicate validation after merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: Worker CI
 
 on:
   pull_request:
-  push:
     branches: [main]
 
 concurrency:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ pnpm db:check
 
 ## 交付与生产红线
 
-- PR 通过统一的 `pnpm test:ci` 质量门禁；Cloudflare Workers Builds 负责在受保护的 `main` 分支更新后自动从 Git 构建和部署。合并已审核 PR 即授权该提交发布，不再设置第二个人工发布步骤。
+- GitHub Actions 只在目标为 `main` 的 PR 上执行统一 `validate` 质量门禁；Cloudflare Workers Builds 负责在受保护的 `main` 更新后做最小生产构建、D1 migration 和 Worker 部署。合并已审核 PR 即授权该提交发布，不在 `push main` 后重复运行 GitHub CI，也不设置第二个人工发布步骤。
 - 生产发布流水线只允许从受保护的 Cloudflare/Git 集成执行；禁止任何远程 D1、R2、Worker、route/domain 或 secret 写入绕过该流程。
 - 不在本机直接执行生产 Cloudflare 写命令，不使用 admin bypass，不把生产 secrets 放到仓库级 Actions secrets、日志、PR 或命令参数。
 - 不得用临时脚本、Dashboard 手工发布或本机命令替代 `main` 流水线。生产发布现状与限制以 `docs/prod-change-policy.md` 为准。

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > 发现有趣地点，找到同行伙伴
 
-[![CI](https://github.com/redisread/gomate/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/redisread/gomate/actions/workflows/ci.yml)
+[![CI](https://github.com/redisread/gomate/actions/workflows/ci.yml/badge.svg?event=pull_request)](https://github.com/redisread/gomate/actions/workflows/ci.yml)
 [![Live](https://img.shields.io/badge/Live-gomate.live-blue)](https://gomate.live)
 
 ## 产品定位
@@ -66,7 +66,7 @@ pnpm db:promote-admin --email admin@test.com
 
 ### Playwright（推荐）
 
-固定保留 5 条高价值路径：首页与健康检查、登录、未登录访问保护、创建队伍、申请并审批。
+固定保留 6 条高价值路径：首页与健康检查、注册、登录、未登录访问保护、创建队伍、申请并审批。
 测试使用构建后的本地 Worker 和隔离 D1，不访问 Cloudflare 远程资源；GitHub PR CI 会自动运行。
 
 ```bash
@@ -119,8 +119,9 @@ pnpm env:check
 
 ## 部署
 
-PR 通过 `pnpm test:ci` 后由 Cloudflare Workers Builds 从 Git 构建；当前只保留一套远程生产
-环境：只有 `main` 分支允许发布，非 `main` 分支不构建 Cloudflare Preview，Preview URL 也
+PR 由 GitHub Actions 完成 `pnpm test:ci`、Worker bundle 校验和隔离 D1 E2E；合并后不再
+重复运行 GitHub CI，由 Cloudflare Workers Builds 对 `main` 做最小生产构建并自动发布。
+当前只保留一套远程生产环境：非 `main` 分支不构建 Cloudflare Preview，Preview URL 也
 关闭。线上由统一 Worker `gomate` 提供 `gomate.live`；本地开发使用根配置中的本地
 D1/R2。禁止从本机或临时命令执行生产 Worker、D1、R2、secret 或 route 写入；受保护的
 `main` 分支合并即授权 Cloudflare 自动发布，

--- a/docs/prod-change-policy.md
+++ b/docs/prod-change-policy.md
@@ -42,19 +42,22 @@ Region ID `region-cn`、`region-cn-guangdong`、`region-cn-shenzhen`。
 禁止在开发机直接运行生产 Cloudflare 写命令。只读 inventory/health 检查可以在任务范围内执行，但不得据此扩大写入权限。
 
 仓库提供 `pnpm deploy:production` 作为 Cloudflare Workers Builds 的生产部署入口；该命令只能由
-`main` 分支的 Workers Build 调用。GitHub Actions 仍只执行只读质量检查，不配置生产
-Cloudflare 或应用 secrets，也不提供本机生产写入路径。合并到 `main` 后不再等待第二次人工确认。
+`main` 分支的 Workers Build 调用。GitHub Actions 只在目标为 `main` 的 PR 上执行只读质量
+检查，不监听 `push main`，不配置生产 Cloudflare 或应用 secrets，也不提供本机生产写入路径。
+合并到 `main` 后不再等待第二次人工确认。
 
 ## 3. 发布能力
 
-PR 使用仓库内 `pnpm test:ci` 加隔离 D1 的 5 条 Chromium E2E 做可重复质量门禁。Cloudflare Workers Builds 连接 Git 仓库，
-只负责 `main` 分支的生产构建和自动发布；非 `main` 分支不生成远程 Preview。PR 审核与
-受保护分支是发布授权边界。构建阶段只做校验和 dry-run，部署阶段先执行目标环境 D1
-migration，再发布不可变 Worker version。
+PR 使用仓库内 `pnpm test:ci` 加隔离 D1 的 6 条 Chromium E2E 做可重复质量门禁。Cloudflare Workers Builds 连接 Git 仓库，
+只负责 `main` 分支的最小生产构建和自动发布；非 `main` 分支不生成远程 Preview。PR 审核与
+受保护分支是发布授权边界。所有测试、类型检查、bundle dry-run 和 size gate 都在 PR 完成；
+Workers Build 只安装锁定依赖、生成 locale 并构建当前 `main` 的 `dist/`，随后先执行目标环境
+D1 migration，再发布不可变 Worker version。
 
 Workers Builds 的推荐配置为：
 
-1. Build command：`pnpm install --frozen-lockfile && pnpm i18n:build && pnpm test:ci && pnpm worker:dry-run`；
+1. Build command：`pnpm install --frozen-lockfile && pnpm i18n:build && pnpm build`；该阶段只生成
+   当前 `main` 的生产 artifact，不重复执行 PR 已通过的 `pnpm test:ci`、E2E 或 dry-run；
 2. Build variables：`NODE_VERSION=22.13.0`、`PNPM_VERSION=11.19.0`、
    `SKIP_DEPENDENCY_INSTALL=1`；启用 build cache。仓库同时通过 `.node-version` 和
    `packageManager` 固定本地与 CI 工具链；

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:server": "vitest run --config vitest.server.config.ts",
     "test:worker": "pnpm build && pnpm test:worker:run",
     "test:worker:run": "vitest run --config vitest.worker.config.ts",
-    "test:build-guard": "node --test scripts/production-build-guard.test.mjs scripts/smoke-production-write-boundary.test.mjs",
+    "test:build-guard": "node --test scripts/ci-workflow-policy.test.mjs scripts/production-build-guard.test.mjs scripts/smoke-production-write-boundary.test.mjs",
     "test:db-reset": "node --test scripts/reset-local-db.test.mjs",
     "test:ci": "pnpm i18n:validate && pnpm test:build-guard && pnpm test:db-reset && pnpm db:check && pnpm lint && pnpm type-check && pnpm test && pnpm test:server && pnpm build && pnpm test:worker:run",
     "test:e2e": "playwright test --project=chromium",

--- a/scripts/ci-workflow-policy.test.mjs
+++ b/scripts/ci-workflow-policy.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("runs the required validation job only for pull requests targeting main", async () => {
+  const workflow = await readFile(
+    new URL("../.github/workflows/ci.yml", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(workflow, /^on:\n {2}pull_request:\n {4}branches: \[main\]$/mu);
+  assert.doesNotMatch(workflow, /^ {2}push:/mu);
+  assert.match(workflow, /^ {2}validate:$/mu);
+});


### PR DESCRIPTION
## 目的

将流水线收敛为 PR-only CI + main-only Cloudflare CD，避免同一套完整校验在 PR 和合并后重复执行。

## 变更

- GitHub `validate` 仅在目标为 `main` 的 PR 上运行，required check 名称保持不变
- 新增 CI workflow 策略测试，防止重新引入 `push main` 校验
- Workers Builds 文档改为最小生产构建：`pnpm install --frozen-lockfile && pnpm i18n:build && pnpm build`
- 合并后继续由现有 `pnpm deploy:production` 顺序执行 D1 migration、Worker deploy 和 production smoke
- 更新 CI badge、仓库规则和当前 6 条 Chromium E2E 文档

## 安全边界

- `main` 的 `validate` 仍是 strict required check
- 已启用 branch protection 的 administrator enforcement，禁止管理员直推绕过 PR 校验
- 本 PR 未修改 Cloudflare 账户配置、生产 Worker 或 D1；Cloudflare Build command 应在合并前按上述最小命令切换

## 验证

- RED：新策略测试在旧 workflow 上失败
- GREEN：`pnpm test:build-guard`，12/12
- `pnpm test:ci`
  - unit/component：261/261
  - server：22/22
  - Worker：3/3
- `pnpm worker:types`
- `pnpm worker:dry-run`
- `pnpm worker:size`：1.54 MiB gzip
- isolated D1 reset/migration replay
- `pnpm test:e2e:ci`：6/6
- `pnpm audit --prod --audit-level high`：通过（存在 1 个 moderate，不超过 high 门槛）
- `git diff --check`
- staged secret scan