### PR TITLE
fix: enforce registration persistence

### DIFF
--- a/docs/backend-api.md
+++ b/docs/backend-api.md
@@ -25,7 +25,7 @@ API 由统一 Cloudflare Worker 中的 Hono 应用提供，外部路径统一以
 | 方法      | 路径                            | 认证 | 用途                                   |
 | --------- | ------------------------------- | ---- | -------------------------------------- |
 | GET       | `/health`                       | 否   | 健康检查；返回 Worker version ID 与写入模式 |
-| POST      | `/auth/sign-up/email`           | 否   | 注册；固定响应避免账号枚举             |
+| POST      | `/auth/sign-up/email`           | 否   | 注册；仅在用户与 credential 账户落库后返回固定响应，避免账号枚举 |
 | POST      | `/auth/sign-in/email`           | 否   | 登录；成功响应不暴露 session token     |
 | GET、POST | `/auth/get-session`             | 可选 | 强制回源 D1 获取当前 session           |
 | POST      | `/auth/sign-out`                | 是   | 注销当前 session                       |
@@ -39,6 +39,8 @@ API 由统一 Cloudflare Worker 中的 Hono 应用提供，外部路径统一以
 除上述认证端点外，`/auth/*` 固定返回 404。验证和重置 token 只放在邮件 URL fragment，
 页面清除 fragment 后通过同源 POST body 提交；token 不得进入 path、query、日志或数据库明文。
 登录、注册和邮件发送使用 Cloudflare Rate Limiting bindings；运行时不依赖 KV 缓存。
+注册的固定成功响应还会在 Better Auth 返回后回查 D1：新用户必须同时存在 `users` 与
+`local:credential` 账户；持久化不完整时返回 5xx，不伪装成注册成功。
 
 ### Region、地点与标签
 

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -11,7 +11,7 @@ test.describe("Auth", () => {
     await page.waitForLoadState("networkidle");
     await page.locator("[data-testid='register-name']").fill(`Register ${RUN_ID}`);
     await page.locator("[data-testid='register-email']").fill(
-      `register-${RUN_ID}@e2e.gomate.test`,
+      `register-${RUN_ID}@gmail.com`,
     );
     await page.locator("[data-testid='register-password']").fill(PASSWORD);
     await page.locator("[data-testid='register-confirm-password']").fill(PASSWORD);
@@ -26,7 +26,7 @@ test.describe("Auth", () => {
 
   test("successful login redirects to home", async ({ page }) => {
     const user = await signUpUser(
-      `auth-${RUN_ID}@e2e.gomate.test`,
+      `auth-${RUN_ID}@gmail.com`,
       PASSWORD,
       `Auth ${RUN_ID}`,
     );

--- a/src/server/routes/auth.test.ts
+++ b/src/server/routes/auth.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createAuth: vi.fn(),
+  createDb: vi.fn(),
+  enforceActiveSession: vi.fn(),
+  sendPasswordResetEmail: vi.fn(),
+  issuePasswordResetChallenge: vi.fn(),
+  resetPasswordWithChallenge: vi.fn(),
+}));
+
+vi.mock("../lib/auth", () => ({
+  createAuth: mocks.createAuth,
+}));
+vi.mock("../db", () => ({
+  createDb: mocks.createDb,
+}));
+vi.mock("../lib/session-policy", () => ({
+  enforceActiveSession: mocks.enforceActiveSession,
+}));
+vi.mock("../lib/email", () => ({
+  sendPasswordResetEmail: mocks.sendPasswordResetEmail,
+}));
+vi.mock("../lib/password-reset", () => ({
+  InvalidPasswordResetTokenError: class InvalidPasswordResetTokenError extends Error {},
+  issuePasswordResetChallenge: mocks.issuePasswordResetChallenge,
+  passwordResetClientUrl: vi.fn(),
+  resetPasswordWithChallenge: mocks.resetPasswordWithChallenge,
+}));
+
+const { authRoute } = await import("./auth");
+
+const env = {
+  APP_URL: "http://localhost:5432",
+  BETTER_AUTH_SECRET: "test-secret-key-for-testing-32chars",
+  AUTH_SIGN_UP_RATE_LIMITER: {
+    limit: vi.fn().mockResolvedValue({ success: true }),
+  },
+} as never;
+
+function responseForUser(userId: string, email: string) {
+  return new Response(JSON.stringify({
+    token: null,
+    user: { id: userId, email, name: "Test User" },
+  }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function dbRows(...rows: unknown[][]) {
+  let index = 0;
+  mocks.createDb.mockReturnValue({
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn().mockResolvedValue(rows[index++] ?? []),
+        })),
+      })),
+    })),
+  });
+}
+
+async function signUp(email = "new@example.com") {
+  return authRoute.fetch(
+    new Request("http://localhost:5432/sign-up/email", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: "http://localhost:5432",
+      },
+      body: JSON.stringify({
+        email,
+        password: "password123",
+        name: "Test User",
+      }),
+    }),
+    env,
+  );
+}
+
+describe("email sign-up persistence boundary", () => {
+  it("fails instead of acknowledging a Better Auth success with no persisted user", async () => {
+    mocks.createAuth.mockReturnValue({
+      handler: vi.fn().mockResolvedValue(responseForUser("user-1", "new@example.com")),
+    });
+    dbRows([]);
+
+    const response = await signUp();
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: { code: "INTERNAL_ERROR" },
+    });
+  });
+
+  it("fails when a newly-created user has no credential account", async () => {
+    mocks.createAuth.mockReturnValue({
+      handler: vi.fn().mockResolvedValue(responseForUser("user-1", "new@example.com")),
+    });
+    dbRows([{ id: "user-1" }], []);
+
+    const response = await signUp();
+
+    expect(response.status).toBe(500);
+  });
+
+  it("keeps duplicate registration responses generic", async () => {
+    mocks.createAuth.mockReturnValue({
+      handler: vi.fn().mockResolvedValue(responseForUser("synthetic-id", "new@example.com")),
+    });
+    dbRows([{ id: "existing-user" }]);
+
+    const response = await signUp();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true });
+  });
+
+  it("does not convert Better Auth client failures into success", async () => {
+    mocks.createAuth.mockReturnValue({
+      handler: vi.fn().mockResolvedValue(new Response(JSON.stringify({
+        code: "FAILED_TO_CREATE_USER",
+      }), { status: 422 })),
+    });
+
+    const response = await signUp();
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: { code: "INTERNAL_ERROR" },
+    });
+  });
+
+  it("acknowledges a new registration only after user and credential account persist", async () => {
+    mocks.createAuth.mockReturnValue({
+      handler: vi.fn().mockResolvedValue(responseForUser("user-1", "new@example.com")),
+    });
+    dbRows([{ id: "user-1" }], [{ id: "account-1" }]);
+
+    const response = await signUp();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true });
+  });
+});

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -1,8 +1,11 @@
 import { APIErrors } from "../lib/api-errors";
 import { logger } from "../lib/logger";
 import { Hono, type Context } from "hono";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { createAuth, type Env } from "../lib/auth";
+import { createDb } from "../db";
+import * as schema from "../db/schema";
 import { enforceActiveSession } from "../lib/session-policy";
 import { sendPasswordResetEmail } from "../lib/email";
 import {
@@ -244,6 +247,76 @@ function noStoreJsonResponse(
   });
 }
 
+function authErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const candidate = error as {
+    code?: unknown;
+    body?: { code?: unknown; error?: { code?: unknown } };
+  };
+  const code = candidate.code ?? candidate.body?.code ?? candidate.body?.error?.code;
+  return typeof code === "string" && /^[A-Z][A-Z0-9_]{0,63}$/u.test(code)
+    ? code
+    : undefined;
+}
+
+async function responseErrorCode(response: Response): Promise<string | undefined> {
+  const payload = await response.clone().json().catch(() => null) as {
+    code?: unknown;
+    error?: { code?: unknown };
+  } | null;
+  const code = payload?.code ?? payload?.error?.code;
+  return typeof code === "string" && /^[A-Z][A-Z0-9_]{0,63}$/u.test(code)
+    ? code
+    : undefined;
+}
+
+function signUpInternalError(c: AuthContext): Response {
+  c.header("Cache-Control", "no-store");
+  c.header("Pragma", "no-cache");
+  return c.json(APIErrors.internalError("Unable to create account"), 500);
+}
+
+async function verifySignUpPersistence(
+  c: AuthContext,
+  email: string,
+  response: Response,
+): Promise<boolean> {
+  const payload = await response.clone().json().catch(() => null) as {
+    user?: { id?: unknown; email?: unknown };
+  } | null;
+  const responseUserId = typeof payload?.user?.id === "string"
+    ? payload.user.id
+    : undefined;
+  const responseEmail = typeof payload?.user?.email === "string"
+    ? payload.user.email.toLocaleLowerCase("en-US")
+    : undefined;
+  if (!responseUserId || responseEmail !== email) return false;
+
+  const db = createDb(c.env.DB);
+  const persistedUser = (await db
+    .select({ id: schema.users.id })
+    .from(schema.users)
+    .where(eq(schema.users.email, email))
+    .limit(1))[0];
+  if (!persistedUser) return false;
+
+  // Better Auth intentionally returns a synthetic user for duplicate sign-up
+  // attempts. That response is valid only when the real user already exists;
+  // it must not turn an unpersisted first registration into a 200 response.
+  if (persistedUser.id !== responseUserId) return true;
+
+  const credentialAccount = (await db
+    .select({ id: schema.accounts.id })
+    .from(schema.accounts)
+    .where(and(
+      eq(schema.accounts.userId, persistedUser.id),
+      eq(schema.accounts.issuer, "local:credential"),
+      eq(schema.accounts.accountId, persistedUser.id),
+    ))
+    .limit(1))[0];
+  return Boolean(credentialAccount);
+}
+
 async function browserSafeSignInResponse(
   c: AuthContext,
   response: Response,
@@ -328,16 +401,50 @@ async function handleEmailSignUp(c: AuthContext) {
     parsed.data.email,
   );
   if (limited) return limited;
-  const response = await createAuth(c.env, getExecutionContext(c)).handler(
-    normalizedJsonRequest(c, parsed.data),
-  );
-  if (response.status >= 500) return response;
+  let response: Response;
+  try {
+    response = await createAuth(c.env, getExecutionContext(c)).handler(
+      normalizedJsonRequest(c, parsed.data),
+    );
+  } catch (error) {
+    logger.error("auth_sign_up_failed", {
+      errorCode: authErrorCode(error),
+      errorType: error instanceof Error ? error.name : "UnknownAuthError",
+    });
+    return signUpInternalError(c);
+  }
 
-  // Better Auth intentionally synthesizes a user for duplicate registrations,
-  // while a concurrent first registration can lose the unique-email race and
-  // return a 4xx. Exposing either result creates an account-existence oracle.
-  // All expected account-level outcomes therefore collapse to the same fixed
-  // acknowledgement; unexpected adapter failures still escape as 5xx.
+  if (!response.ok) {
+    const errorCode = await responseErrorCode(response);
+    logger.error("auth_sign_up_failed", {
+      errorCode: errorCode ?? `HTTP_${response.status}`,
+      errorType: "BetterAuthResponseError",
+    });
+    if (response.status >= 500 || errorCode === "FAILED_TO_CREATE_USER") {
+      return signUpInternalError(c);
+    }
+    c.header("Cache-Control", "no-store");
+    c.header("Pragma", "no-cache");
+    return c.json(APIErrors.validationError("Unable to create account"), 400);
+  }
+
+  try {
+    if (!await verifySignUpPersistence(c, parsed.data.email, response)) {
+      logger.error("auth_sign_up_persistence_failed", {
+        errorType: "AuthPersistenceError",
+      });
+      return signUpInternalError(c);
+    }
+  } catch (error) {
+    logger.error("auth_sign_up_persistence_failed", {
+      errorType: error instanceof Error ? error.name : "UnknownDatabaseError",
+    });
+    return signUpInternalError(c);
+  }
+
+  // Better Auth intentionally synthesizes a user for duplicate registrations.
+  // Keep the fixed acknowledgement only after the persistence postcondition
+  // has been checked, so a false 200 can never hide a missing account row.
   c.header("Cache-Control", "no-store");
   return c.json(GENERIC_SIGN_UP_RESPONSE, 200);
 }


### PR DESCRIPTION
## Summary
- require successful email registration responses to correspond to a persisted D1 user
- require a persisted local:credential account for newly-created users
- stop converting Better Auth persistence failures into a generic 200 response
- add server regression tests and update the API contract documentation

## Verification
- pnpm test:ci
- pnpm test:e2e:ci (6 passed)
- local D1 aggregate after E2E: users=5, credential_accounts=5, sessions=8
- pnpm worker:types
- pnpm worker:dry-run
- pnpm worker:size

The production database was not written directly; deployment remains subject to the protected main-branch workflow.