### PR TITLE
fix: refresh navbar session state after login

### DIFF
--- a/src/__tests__/navbar-auth-state.test.tsx
+++ b/src/__tests__/navbar-auth-state.test.tsx
@@ -3,9 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Navbar } from "../components/layout/navbar";
 
 const fetchCurrentUserMock = vi.fn();
+const refreshCurrentUserMock = vi.fn();
 
 vi.mock("@/lib/api", () => ({
   fetchCurrentUser: (...args: unknown[]) => fetchCurrentUserMock(...args),
+  refreshCurrentUser: (...args: unknown[]) => refreshCurrentUserMock(...args),
 }));
 
 vi.mock("@/lib/auth-client", () => ({
@@ -29,7 +31,10 @@ vi.mock("../components/layout/locale-toggle", () => ({ LocaleToggle: () => null 
 vi.mock("../components/theme-toggle", () => ({ ThemeToggle: () => null }));
 
 describe("Navbar auth state", () => {
-  beforeEach(() => fetchCurrentUserMock.mockReset());
+  beforeEach(() => {
+    fetchCurrentUserMock.mockReset();
+    refreshCurrentUserMock.mockReset();
+  });
 
   it("does not flash guest actions while authentication is loading", async () => {
     let resolveUser: ((user: null) => void) | undefined;
@@ -53,5 +58,52 @@ describe("Navbar auth state", () => {
 
     expect(await screen.findByTestId("nav-login")).toBeInTheDocument();
     expect(screen.getByTestId("nav-register")).toBeInTheDocument();
+  });
+
+  it("refreshes the user menu when the page is shown again after login", async () => {
+    fetchCurrentUserMock.mockResolvedValue(null);
+    refreshCurrentUserMock.mockResolvedValue({
+      id: "user-1",
+      name: "Test User",
+      nickname: "Tester",
+      email: "test@example.com",
+      image: null,
+      extra: {},
+    });
+
+    render(<Navbar />);
+    expect(await screen.findByTestId("nav-login")).toBeInTheDocument();
+
+    await act(async () => {
+      const event = new Event("pageshow");
+      Object.defineProperty(event, "persisted", { value: true });
+      window.dispatchEvent(event);
+    });
+
+    expect(await screen.findByTestId("nav-create-team")).toBeInTheDocument();
+    expect(screen.queryByTestId("nav-login")).not.toBeInTheDocument();
+    expect(refreshCurrentUserMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes the user menu when the tab becomes visible again", async () => {
+    fetchCurrentUserMock.mockResolvedValue(null);
+    refreshCurrentUserMock.mockResolvedValue({
+      id: "user-1",
+      name: "Test User",
+      nickname: "Tester",
+      email: "test@example.com",
+      image: null,
+      extra: {},
+    });
+
+    render(<Navbar />);
+    expect(await screen.findByTestId("nav-login")).toBeInTheDocument();
+
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(await screen.findByTestId("nav-create-team")).toBeInTheDocument();
+    expect(refreshCurrentUserMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { authClient } from "@/lib/auth-client";
 import { Mountain, Menu, X, User, Settings, Plus, LogOut, Heart, ChevronDown, MessageCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { fetchCurrentUser } from "@/lib/api";
+import { fetchCurrentUser, refreshCurrentUser } from "@/lib/api";
 import { Avatar } from "@/components/ui/avatar";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { LocaleToggle } from "@/components/layout/locale-toggle";
@@ -65,13 +65,31 @@ export function Navbar({ className }: NavbarProps) {
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
 
-  // 获取登录会话（两步加载，绕过 KV 缓存）
-  React.useEffect(() => {
-    (async () => {
-      const u = await fetchCurrentUser(); // 静默失败，不跳转
+  const updateSession = React.useCallback((refresh: boolean) => {
+    const request = refresh ? refreshCurrentUser() : fetchCurrentUser();
+    void request.then((u) => {
       setSession(u ? { user: u as { id: string; name: string; nickname?: string; email: string; image?: string } } : null);
-    })();
+    });
   }, []);
+
+  // 获取登录会话，并在页面恢复后重新读取，避免旧访客态永久驻留。
+  React.useEffect(() => {
+    updateSession(false);
+
+    const onPageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) updateSession(true);
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") updateSession(true);
+    };
+
+    window.addEventListener("pageshow", onPageShow);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      window.removeEventListener("pageshow", onPageShow);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [updateSession]);
 
   // 移动菜单打开时锁定滚动
   React.useEffect(() => {

--- a/src/lib/__tests__/api.test.ts
+++ b/src/lib/__tests__/api.test.ts
@@ -6,6 +6,8 @@ import {
   apiPost,
   fetchAPI,
   fetchPublicAPI,
+  fetchCurrentUser,
+  refreshCurrentUser,
   getApiErrorMessage,
 } from "../api";
 
@@ -78,5 +80,20 @@ describe("same-origin API client", () => {
       "top-level",
     );
     expect(getApiErrorMessage(null, "fallback")).toBe("fallback");
+  });
+
+  it("can refresh a previously memoized guest session", async () => {
+    mockFetch
+      .mockResolvedValueOnce(new Response('{"user":null}', { status: 200 }))
+      .mockResolvedValueOnce(new Response('{"user":{"id":"user-1"}}', { status: 200 }));
+
+    await expect(fetchCurrentUser()).resolves.toBeNull();
+    await expect(refreshCurrentUser()).resolves.toMatchObject({ id: "user-1" });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      "/api/users/me",
+      expect.objectContaining({ cache: "no-store", credentials: "include" }),
+    );
   });
 });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -151,7 +151,7 @@ let currentUserMemo: Promise<import("./types").SessionUser | null> | null = null
 
 async function loadCurrentUser(): Promise<import("./types").SessionUser | null> {
   try {
-    const userRes = await fetchAPI("/users/me");
+    const userRes = await fetchAPI("/users/me", { cache: "no-store" });
     if (!userRes.ok) return null;
     const userData = await userRes.json();
     return userData.user ?? null;
@@ -162,6 +162,22 @@ async function loadCurrentUser(): Promise<import("./types").SessionUser | null> 
 
 export function fetchCurrentUser(redirectOnFail?: string): Promise<import("./types").SessionUser | null> {
   if (!currentUserMemo) currentUserMemo = loadCurrentUser();
+  return currentUserMemo.then((user) => {
+    if (!user && redirectOnFail) window.location.href = redirectOnFail;
+    return user;
+  });
+}
+
+/**
+ * 重新读取当前登录用户，绕过同页 memo。
+ *
+ * 登录发生在其他标签页、页面从 bfcache 恢复或认证 Cookie 刚刚建立时，
+ * 旧的访客结果不能继续代表当前会话；调用方应在这些状态边界使用本函数。
+ */
+export function refreshCurrentUser(
+  redirectOnFail?: string,
+): Promise<import("./types").SessionUser | null> {
+  currentUserMemo = loadCurrentUser();
   return currentUserMemo.then((user) => {
     if (!user && redirectOnFail) window.location.href = redirectOnFail;
     return user;

--- a/src/server/routes/users/index.ts
+++ b/src/server/routes/users/index.ts
@@ -318,6 +318,8 @@ export function buildPendingJoinRequestsPageQuery(
 }
 
 usersRoute.get("/me", async (c) => {
+  c.header("Cache-Control", "no-store");
+  c.header("Pragma", "no-cache");
   const userId = await currentUserId(c);
   if (!userId) return c.json(APIErrors.unauthorized(), 401);
   const db = createDb(c.env.DB);


### PR DESCRIPTION
## Summary

- refresh the current-user request when a page is restored from bfcache or becomes visible again
- bypass stale browser/API cache for `/api/users/me`
- add regression coverage for `pageshow`, `visibilitychange`, and memo refresh behavior

This fixes the case where a successful login leaves the top-right navigation showing guest actions.

## Verification

- `pnpm lint`
- `pnpm type-check`
- `pnpm test` (264 passed)
- `pnpm test:server` (27 passed)
- `pnpm i18n:build`
- `pnpm i18n:validate`
- `pnpm build`
- local browser verification of session refresh events

The local untracked `tasks/` directory is intentionally excluded from this PR.