### PR TITLE
feat: add map glass lens interaction and fix i18n hydration

### DIFF
--- a/src/__tests__/china-map.test.tsx
+++ b/src/__tests__/china-map.test.tsx
@@ -87,6 +87,22 @@ describe("ChinaMap", () => {
     const hitTarget = document.querySelector('circle[fill="transparent"]');
     expect(Number(hitTarget?.getAttribute("r"))).toBe(12);
 
+    fireEvent.mouseEnter(screen.getByLabelText("梧桐山"));
+    const lens = screen.getByTestId("map-glass-lens");
+    expect(lens).toHaveAttribute("aria-hidden", "true");
+    expect(lens.querySelector('g[filter="url(#map-glass-filter)"]')).not.toBeNull();
+    expect(lens.querySelector('circle[data-testid="map-glass-border"]')).not.toBeNull();
+    expect(lens.querySelector('[role="button"]')).toBeNull();
+
+    fireEvent.mouseLeave(screen.getByRole("group"));
+    expect(screen.queryByTestId("map-glass-lens")).not.toBeInTheDocument();
+
+    const point = screen.getByLabelText("梧桐山");
+    fireEvent.focus(point);
+    expect(screen.getByTestId("map-glass-lens")).toBeInTheDocument();
+    fireEvent.blur(point);
+    expect(screen.queryByTestId("map-glass-lens")).not.toBeInTheDocument();
+
     await waitFor(() => {
       expect(screen.queryByLabelText("四姑娘山")).not.toBeInTheDocument();
     });

--- a/src/components/features/home/china-map.tsx
+++ b/src/components/features/home/china-map.tsx
@@ -53,6 +53,15 @@ interface Tooltip {
   subtitle?: string;
 }
 
+interface MapLens {
+  x: number;
+  y: number;
+  radius: number;
+}
+
+const MAP_LENS_RADIUS = 32;
+const MAP_LENS_SCALE = 1.16;
+
 function provinceFill(count: number, max: number): string {
   if (count === 0) return "#f2ede7";
   const t = 0.35 + 0.65 * (count / Math.max(1, max));
@@ -100,6 +109,7 @@ export function ChinaMap({ className }: { className?: string }) {
   const [tooltip, setTooltip] = React.useState<Tooltip | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [focusedProvince, setFocusedProvince] = React.useState<string | null>(null);
+  const [lens, setLens] = React.useState<MapLens | null>(null);
   const [isTransitioning, setIsTransitioning] = React.useState(false);
   const transitionTimer = React.useRef<number | null>(null);
   const pushedMapState = React.useRef(false);
@@ -182,6 +192,7 @@ export function ChinaMap({ className }: { className?: string }) {
       pushedMapState.current = false;
       setFocusedProvince(province);
       setTooltip(null);
+      setLens(null);
       setIsTransitioning(false);
     };
 
@@ -210,6 +221,7 @@ export function ChinaMap({ className }: { className?: string }) {
 
   const leaveProvince = () => {
     setTooltip(null);
+    setLens(null);
     if (pushedMapState.current) {
       pushedMapState.current = false;
       window.history.back();
@@ -226,6 +238,7 @@ export function ChinaMap({ className }: { className?: string }) {
       return;
     }
     setTooltip(null);
+    setLens(null);
     setIsTransitioning(true);
     if (!focusedProvince) {
       pushedMapState.current = true;
@@ -268,6 +281,7 @@ export function ChinaMap({ className }: { className?: string }) {
       title: point.name,
       subtitle: regionSubtitle,
     });
+    setLens({ x: position.x, y: position.y, radius: MAP_LENS_RADIUS });
   };
 
   const handleInteractiveKeyDown = (event: React.KeyboardEvent, action: () => void) => {
@@ -289,7 +303,10 @@ export function ChinaMap({ className }: { className?: string }) {
               : t("home.mapAriaLabel")
           }
           className="block h-auto w-full select-none"
-          onMouseLeave={() => setTooltip(null)}
+          onMouseLeave={() => {
+            setTooltip(null);
+            setLens(null);
+          }}
         >
           <g
             transform={`matrix(${mapTransform.scale} 0 0 ${mapTransform.scale} ${mapTransform.translateX} ${mapTransform.translateY})`}
@@ -336,6 +353,10 @@ export function ChinaMap({ className }: { className?: string }) {
                     onMouseDown={(event) => event.preventDefault()}
                     onMouseEnter={() => handlePointEnter(point)}
                     onFocus={() => handlePointEnter(point)}
+                    onBlur={() => {
+                      setTooltip(null);
+                      setLens(null);
+                    }}
                     onClick={() => {
                       window.location.href = `/locations/${point.id}`;
                     }}
@@ -360,6 +381,115 @@ export function ChinaMap({ className }: { className?: string }) {
               );
             })}
           </g>
+
+          {lens && (
+            <g
+              data-testid="map-glass-lens"
+              aria-hidden="true"
+              className="map-glass-lens-effect pointer-events-none motion-reduce:hidden"
+            >
+              <defs>
+                <clipPath id="map-glass-clip" clipPathUnits="userSpaceOnUse">
+                  <circle cx={lens.x} cy={lens.y} r={lens.radius} />
+                </clipPath>
+                <filter
+                  id="map-glass-filter"
+                  x={lens.x - lens.radius - 8}
+                  y={lens.y - lens.radius - 8}
+                  width={(lens.radius + 8) * 2}
+                  height={(lens.radius + 8) * 2}
+                  filterUnits="userSpaceOnUse"
+                  filterRes="160"
+                >
+                  <feTurbulence
+                    type="fractalNoise"
+                    baseFrequency="0.035"
+                    numOctaves="1"
+                    seed="7"
+                    result="lensNoise"
+                  />
+                  <feDisplacementMap
+                    in="SourceGraphic"
+                    in2="lensNoise"
+                    scale="5"
+                    xChannelSelector="R"
+                    yChannelSelector="G"
+                  />
+                </filter>
+                <radialGradient id="map-glass-shine" cx="30%" cy="24%" r="76%">
+                  <stop offset="0%" stopColor="var(--background)" stopOpacity="0.32" />
+                  <stop offset="52%" stopColor="var(--background)" stopOpacity="0.05" />
+                  <stop offset="100%" stopColor="var(--primary)" stopOpacity="0.2" />
+                </radialGradient>
+              </defs>
+
+              <g
+                clipPath="url(#map-glass-clip)"
+                filter="url(#map-glass-filter)"
+                transform={`translate(${lens.x} ${lens.y}) scale(${MAP_LENS_SCALE}) translate(${-lens.x} ${-lens.y})`}
+              >
+                <g
+                  transform={`matrix(${mapTransform.scale} 0 0 ${mapTransform.scale} ${mapTransform.translateX} ${mapTransform.translateY})`}
+                >
+                  {svgPaths.map((path) => {
+                    const count = provinceCount.get(path.name) ?? 0;
+                    const isFocused = focusedProvince === path.name;
+                    return (
+                      <path
+                        key={path.name}
+                        d={path.d}
+                        fill={provinceFill(count, maxCount)}
+                        stroke="#ffffff"
+                        strokeWidth={isFocused ? 1.4 : 0.6}
+                        opacity={focusedProvince && !isFocused ? 0.2 : 1}
+                      />
+                    );
+                  })}
+
+                  {mapPoints.map((point) => {
+                    const position = projectChina(point.latitude, point.longitude);
+                    return (
+                      <circle
+                        key={point.id}
+                        cx={position.x}
+                        cy={position.y}
+                        r={getMapMarkerRadius(focusedProvince ? 5.5 : 5, mapTransform.scale)}
+                        fill="var(--primary)"
+                        stroke="#fff"
+                        strokeWidth={1.2}
+                        vectorEffect="non-scaling-stroke"
+                      />
+                    );
+                  })}
+                </g>
+              </g>
+
+              <circle
+                cx={lens.x}
+                cy={lens.y}
+                r={lens.radius}
+                fill="url(#map-glass-shine)"
+              />
+              <circle
+                data-testid="map-glass-border"
+                cx={lens.x}
+                cy={lens.y}
+                r={lens.radius - 1}
+                fill="none"
+                stroke="var(--background)"
+                strokeOpacity="0.72"
+                strokeWidth="1.5"
+                vectorEffect="non-scaling-stroke"
+              />
+              <circle
+                cx={lens.x - lens.radius * 0.32}
+                cy={lens.y - lens.radius * 0.36}
+                r={lens.radius * 0.12}
+                fill="var(--background)"
+                opacity="0.38"
+              />
+            </g>
+          )}
         </svg>
 
         {focusedProvince && (

--- a/src/hooks/useI18n.test.tsx
+++ b/src/hooks/useI18n.test.tsx
@@ -1,0 +1,35 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const i18nMocks = vi.hoisted(() => ({
+  getLocale: vi.fn(() => "zh-CN" as const),
+  getNamespaceData: vi.fn(() => ({ home: "首页" })),
+  loadNamespaces: vi.fn(async () => ({ nav: { home: "首页" } })),
+  t: vi.fn(() => "首页"),
+}));
+
+vi.mock("@/i18n", () => i18nMocks);
+
+import { useI18n } from "./useI18n";
+
+describe("useI18n hydration", () => {
+  it("keeps the first client render aligned with SSR when namespaces are cached", async () => {
+    const firstRender: Array<{ loading: boolean; text: string; data: unknown }> = [];
+    const { result } = renderHook(() => {
+      const state = useI18n(["nav"]);
+      firstRender.push({
+        loading: state.loading,
+        text: state.t("nav.home"),
+        data: state.getNsData(),
+      });
+      return state;
+    });
+
+    expect(firstRender[0]).toEqual({ loading: true, text: "", data: null });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.t("nav.home")).toBe("首页");
+    expect(result.current.getNsData()).toEqual({ nav: { home: "首页" } });
+  });
+});

--- a/src/hooks/useI18n.ts
+++ b/src/hooks/useI18n.ts
@@ -4,7 +4,7 @@
  * - Accepts optional namespace list for auto-loading
  * - Reads locale from cookie on client side
  * - Provides t() function with loaded translations
- * - 同步检查 SSR 缓存，避免首屏闪烁
+ * - 保持 SSR 与客户端 hydration 的首帧一致
  */
 
 import * as React from "react";
@@ -25,7 +25,7 @@ interface UseI18nReturn {
 
 /**
  * 同步检查所有 namespace 是否已在缓存中
- * 用于 SSR  hydration 后立即判断 loading 状态
+ * 用于 hydration 后立即判断 loading 状态
  */
 function areAllNsCached(nsList: string[] | undefined, locale: Locale): boolean {
   if (!nsList || nsList.length === 0) return true;
@@ -44,8 +44,8 @@ function areAllNsCached(nsList: string[] | undefined, locale: Locale): boolean {
  */
 export function useI18n(nsList?: string[]): UseI18nReturn {
   const [locale, setLocale] = React.useState<Locale>(getLocale());
-  // 同步检查缓存：如果 SSR 数据已注入，直接设置 loading=false
-  const [loading, setLoading] = React.useState(() => !areAllNsCached(nsList, getLocale()));
+  // SSR 与客户端首帧必须使用相同的 loading 状态；客户端在 effect 中复用 SSR 缓存。
+  const [loading, setLoading] = React.useState(() => Boolean(nsList?.length));
 
   React.useEffect(() => {
     if (!nsList || nsList.length === 0) {
@@ -95,14 +95,14 @@ export function useI18n(nsList?: string[]): UseI18nReturn {
   );
 
   const getNsData = React.useCallback(() => {
-    if (!nsList || nsList.length === 0) return null;
+    if (loading || !nsList || nsList.length === 0) return null;
     const results: Record<string, unknown> = {};
     for (const ns of nsList) {
       const data = getNamespaceData(ns, locale);
       if (data) results[ns] = data;
     }
     return Object.keys(results).length > 0 ? results : null;
-  }, [locale, nsList]);
+  }, [loading, locale, nsList]);
 
   return { t: tFn, getNsData, locale, loading };
 }


### PR DESCRIPTION
## Summary

- add a glass-lens hover/focus effect to map markers while preserving the existing click targets and province zoom behavior
- keep i18n text and structured namespace data in a deterministic loading state during the first client render
- add regression coverage for marker lens interactions and i18n hydration alignment

## Verification

- `pnpm i18n:build`
- `pnpm i18n:validate`
- `pnpm lint`
- `pnpm type-check`
- `pnpm test` — 262 passed
- `pnpm test:server` — 27 passed
- `pnpm build`
- Chrome smoke checks for /, /help, /terms, and /privacy — no hydration mismatch logs