### PR TITLE
test: cover auth page hydration

### DIFF
--- a/docs/frontend-pages.md
+++ b/docs/frontend-pages.md
@@ -65,5 +65,6 @@
 - SSR 使用 [`src/lib/server-api.ts`](../src/lib/server-api.ts) 进程内调用 API，不请求自身域名。
 - [`src/worker.ts`](../src/worker.ts) 将 `/api/*` 交给 Hono，其余请求交给 Astro 官方 Cloudflare handler。
 - 用户可见文案全部来自 i18n；locale 变化后运行 build、validate、lint、type-check、test 和 build 门禁。
+- React island 的 i18n 首次渲染必须在 SSR 与浏览器端保持同一加载态；浏览器在 hydration 后再消费页面注入的 namespace 缓存。
 - 只有需要客户端状态的交互使用 React island；纯展示保持 Astro SSR。
 - UI 规则与验证清单见 [`design-system.md`](design-system.md)。

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -6,6 +6,19 @@ const RUN_ID = Date.now().toString(36);
 const PASSWORD = "test1234";
 
 test.describe("Auth", () => {
+  test("login page hydrates without client errors", async ({ page }) => {
+    const pageErrors: Error[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error));
+
+    await page.goto("/login");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.locator("h1")).toHaveText(/\S/u);
+    await expect(page.locator("[data-testid='login-email']")).toBeVisible();
+    await expect(page.locator("[data-testid='login-password']")).toBeVisible();
+    expect(pageErrors.map((error) => error.message)).toEqual([]);
+  });
+
   test("registration form reaches email verification state", async ({ page }) => {
     await page.goto("/register");
     await page.waitForLoadState("networkidle");


### PR DESCRIPTION
## Summary

- add a production-build Playwright regression for the login page
- require translated content and both credential fields to render
- fail on any browser page error during authentication-page hydration
- document the SSR/client i18n hydration invariant

## Context

Production testing reproduced 7 React hydration errors on the login page. The underlying useI18n implementation fix was merged concurrently in PR #596 before this branch was pushed. This PR is rebased onto that fix and adds the missing authentication-specific browser regression so the failure cannot silently return.

## Verification

- before PR #596: regression test failed with React errors 425, 418, and 423
- after PR #596: focused Playwright regression passes with 0 page errors
- useI18n unit regression: 1 passed
- full pre-rebase gates for this change passed: i18n build/validation, lint, type-check, 264 frontend tests, 27 server tests, database migration check, production build, and 3 Worker tests

No production database mutation, credentials, local tasks directory, or direct deployment is included.