### PR TITLE
feat: add read-only Cloudflare Preview URLs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,6 +24,7 @@
 - [ ] `pnpm test:e2e:ci`（涉及关键用户流程时）
 - [ ] UI：桌面端、移动端、键盘、可访问名称和 i18n 已验证（涉及界面时）
 - [ ] 其他自动或手动验证：
+- [ ] Preview：PR 评论 URL、分支 alias、重新登录、私有读取和业务写入拦截已验证（涉及时）
 - 未运行项及原因：
 
 ## Cloudflare 与数据影响
@@ -33,6 +34,7 @@
 - [ ] 不涉及 Cloudflare 运行时或远程数据
 - [ ] Worker 代码、Static Assets、兼容日期或 flags
 - [ ] route、custom domain 或 Workers Builds 配置
+- [ ] Preview URL、alias 或 Preview host/只读认证边界
 - [ ] D1 schema、migration 或生产数据
 - [ ] R2 bucket、对象或公开 URL
 - [ ] bindings、变量、rate limit 或 secrets

--- a/README.md
+++ b/README.md
@@ -121,13 +121,13 @@ pnpm env:check
 
 PR 由 GitHub Actions 完成 `pnpm test:ci`、Worker bundle 校验和隔离 D1 E2E；合并后不再
 重复运行 GitHub CI，由 Cloudflare Workers Builds 对 `main` 做最小生产构建并自动发布。
-当前只保留一套远程生产环境：非 `main` 分支不构建 Cloudflare Preview，Preview URL 也
-关闭。线上由统一 Worker `gomate` 提供 `gomate.live`；本地开发使用根配置中的本地
-D1/R2。禁止从本机或临时命令执行生产 Worker、D1、R2、secret 或 route 写入；受保护的
-`main` 分支合并即授权 Cloudflare 自动发布，
-Workers Builds deploy command 使用 `pnpm deploy:production`，详见
-`docs/prod-change-policy.md`。如未来需要在线预览，必须先创建独立的 Worker、D1、R2 和
-secrets，不能把版本预览当作数据隔离。
+`main` 使用 `pnpm deploy:production` 发布正式 Worker；非 `main` 使用
+`pnpm deploy:preview` 上传同一 `gomate` Worker 的 Preview version，并按分支生成稳定
+alias，关联 PR 时由 Cloudflare 原生 Git 集成评论 Preview URL。Preview 使用生产 D1/R2，
+但 `WRITE_MODE=protected` 拒绝业务写入，仅允许在合法 Preview 域名上登录/退出并创建认证
+session。生产环境变量 `PREVIEW_HOST_SUFFIX` 必须配置为当前账号的
+`<account-subdomain>.workers.dev`，不可提交到仓库。禁止从本机或临时命令执行生产 Worker、
+D1、R2、secret 或 route 写入；详见 `docs/prod-change-policy.md`。
 
 ## 相关仓库
 

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ PR 由 GitHub Actions 完成 `pnpm test:ci`、Worker bundle 校验和隔离 D1 E
 `main` 使用 `pnpm deploy:production` 发布正式 Worker；非 `main` 使用
 `pnpm deploy:preview` 上传同一 `gomate` Worker 的 Preview version，并按分支生成稳定
 alias，关联 PR 时由 Cloudflare 原生 Git 集成评论 Preview URL。Preview 使用生产 D1/R2，
-但 `WRITE_MODE=protected` 拒绝业务写入，仅允许在合法 Preview 域名上登录/退出并创建认证
-session。生产环境变量 `PREVIEW_HOST_SUFFIX` 必须配置为当前账号的
+且 Preview 上传命令显式注入 `WRITE_MODE=protected` 拒绝业务写入，仅允许在合法 Preview
+域名上登录/退出并创建认证 session。生产环境变量 `PREVIEW_HOST_SUFFIX` 必须配置为当前账号的
 `<account-subdomain>.workers.dev`，不可提交到仓库。禁止从本机或临时命令执行生产 Worker、
 D1、R2、secret 或 route 写入；详见 `docs/prod-change-policy.md`。
 

--- a/docs/backend-api.md
+++ b/docs/backend-api.md
@@ -9,8 +9,11 @@ API 由统一 Cloudflare Worker 中的 Hono 应用提供，外部路径统一以
 
 - 浏览器只访问同源 `/api/*`；Astro SSR 通过 `apiApp.fetch()` 进程内分发，不 self-fetch。
 - Better Auth 只开放下表列出的产品端点，session 使用同源 HttpOnly Cookie。
-- 携带 Cookie 的非安全方法必须来自 `APP_URL` 同源；不符合要求时在读取业务 body 前返回 403。
-- 正常生产使用 `WRITE_MODE=open`；事故保护期间切换为 `protected` 后，非 GET/HEAD/OPTIONS 请求返回 503 和 `Retry-After: 60`。
+- 携带 Cookie 的非安全方法必须来自正式 `APP_URL` 或已配置且通过校验的 Preview origin；不符合要求时在读取业务 body 前返回 403。
+- 正常生产使用 `WRITE_MODE=open`；事故保护期间切换为 `protected` 后，非 GET/HEAD/OPTIONS 请求返回 503 和 `Retry-After: 60`；合法 Preview origin 仅额外允许 `POST /auth/sign-in/email` 和 `POST /auth/sign-out`。
+- Preview 的 `GET /auth/get-session` 可读取当前登录 session；Preview 禁止注册、邮箱验证、密码重置、账户资料修改和所有业务写入。
+- Preview 使用生产 D1/R2 读取真实授权数据；认证 session 写入生产 D1 是只读业务模式下唯一允许的写入例外。
+- Preview host 必须匹配 `*-gomate.<account-subdomain>.workers.dev`，其中账号后缀通过生产环境变量 `PREVIEW_HOST_SUFFIX` 配置；URL 本身不是访问控制。
 - 未匹配的 `/api` 或 `/api/*` 返回 JSON 404，不进入 Astro 页面路由。
 - 时间在 HTTP DTO 中使用 ISO 8601，在 D1 中存 Unix 毫秒。
 - 业务错误统一为 `{ success: false, error: { code, message, details? } }`。

--- a/docs/prod-change-policy.md
+++ b/docs/prod-change-policy.md
@@ -67,8 +67,9 @@ Workers Builds 的推荐配置为：
    `wrangler d1 migrations apply DB --remote --env production --config wrangler.jsonc`，只有
    migration 成功后才执行 `wrangler deploy --env production`；
 4. Preview deploy command：`pnpm deploy:preview`。脚本只执行
-   `wrangler versions upload --env production --config wrangler.jsonc --preview-alias <alias>`；
-   不执行 migration、`wrangler deploy` 或 version promotion。alias 由完整分支名稳定生成；
+   `wrangler versions upload --env production --config dist/server/wrangler.json --keep-vars --var WRITE_MODE:protected --preview-alias <alias>`；
+   命令使用同一次 Build 生成的 Astro bundle 配置，显式覆盖业务写保护并保留 Dashboard 中的 `PREVIEW_HOST_SUFFIX`，不执行 migration、
+   `wrangler deploy` 或 version promotion。alias 由完整分支名稳定生成；
 5. Deploy command 依赖同一次 Build 已生成的 `dist/`；migration 失败时不得继续部署，Worker
    发布失败也不得回滚或手工补写数据库；
 6. 当前采用单一远程环境策略：`main` 是唯一生产分支，非 `main` Preview 使用

--- a/docs/prod-change-policy.md
+++ b/docs/prod-change-policy.md
@@ -11,6 +11,7 @@
 - D1：binding `DB`，目标数据库 `gomate-db-v3`（生产数据库必须由受保护环境按名称绑定；仓库不携带旧数据库 UUID）
 - R2：binding `R2`，bucket `gomate`
 - Rate Limiting bindings：`AUTH_SIGN_IN_RATE_LIMITER`、`AUTH_SIGN_UP_RATE_LIMITER`、`AUTH_EMAIL_RATE_LIMITER`
+- Preview URL：同一 `gomate` Worker 的 version/alias Preview；不创建独立 Worker、D1 或 R2
 - 正常生产 `WRITE_MODE` 为 `open`；`protected` 只用于经过审批的事故写保护，不作为常规发布配置。
 - Cloudflare Workers Builds 的 Git 连接负责发布授权；运行时 secret（`BETTER_AUTH_SECRET`、`RESEND_API_KEY`）只在受保护 production 环境配置，仓库不保存 Cloudflare 或应用 secret。
 
@@ -49,28 +50,32 @@ Region ID `region-cn`、`region-cn-guangdong`、`region-cn-shenzhen`。
 ## 3. 发布能力
 
 PR 使用仓库内 `pnpm test:ci` 加隔离 D1 的 6 条 Chromium E2E 做可重复质量门禁。Cloudflare Workers Builds 连接 Git 仓库，
-只负责 `main` 分支的最小生产构建和自动发布；非 `main` 分支不生成远程 Preview。PR 审核与
-受保护分支是发布授权边界。所有测试、类型检查、bundle dry-run 和 size gate 都在 PR 完成；
-Workers Build 只安装锁定依赖、生成 locale 并构建当前 `main` 的 `dist/`，随后先执行目标环境
-D1 migration，再发布不可变 Worker version。
+`main` 分支执行生产构建和自动发布，所有非 `main` 分支执行远程 Preview 构建；关联 PR 时由
+Cloudflare 原生 Git 集成评论 Preview URL。PR 审核与受保护分支仍是正式发布授权边界。
+Preview 只上传不可提升的 Worker version，不执行 D1 migration。所有测试、类型检查、bundle
+dry-run 和 size gate 都在 PR 完成；Workers Build 只安装锁定依赖、生成 locale 并构建当前分支的
+`dist/`，随后按分支执行对应 deploy command。
 
 Workers Builds 的推荐配置为：
 
 1. Build command：`pnpm install --frozen-lockfile && pnpm i18n:build && pnpm build`；该阶段只生成
-   当前 `main` 的生产 artifact，不重复执行 PR 已通过的 `pnpm test:ci`、E2E 或 dry-run；
+   当前分支的 artifact，不重复执行 PR 已通过的 `pnpm test:ci`、E2E 或 dry-run；
 2. Build variables：`NODE_VERSION=22.13.0`、`PNPM_VERSION=11.19.0`、
    `SKIP_DEPENDENCY_INSTALL=1`；启用 build cache。仓库同时通过 `.node-version` 和
    `packageManager` 固定本地与 CI 工具链；
 3. Deploy command：`pnpm deploy:production`。脚本先执行
    `wrangler d1 migrations apply DB --remote --env production --config wrangler.jsonc`，只有
    migration 成功后才执行 `wrangler deploy --env production`；
-4. Deploy command 依赖同一次 Build 已生成的 `dist/`；migration 失败时不得继续部署，Worker
+4. Preview deploy command：`pnpm deploy:preview`。脚本只执行
+   `wrangler versions upload --env production --config wrangler.jsonc --preview-alias <alias>`；
+   不执行 migration、`wrangler deploy` 或 version promotion。alias 由完整分支名稳定生成；
+5. Deploy command 依赖同一次 Build 已生成的 `dist/`；migration 失败时不得继续部署，Worker
    发布失败也不得回滚或手工补写数据库；
-5. 当前采用单一远程环境策略：`main` 是唯一生产分支，构建脚本拒绝 Workers Builds 传入的
-   非 `main` 分支，`wrangler.jsonc` 的根配置使用本地资源，`production` 显式关闭
-   `workers_dev` 和 `preview_urls`。未来若要提供在线 Preview，必须先创建独立的 Worker、
-   D1、R2、secrets 和访问控制，不能把版本预览当作数据隔离；
-6. 发布后用 `/api/health`、SSR 页面、注册边界 smoke 和关键只读 API 做 smoke，记录 version ID、migration 结果和
+6. 当前采用单一远程环境策略：`main` 是唯一生产分支，非 `main` Preview 使用
+   `--env production` 读取正式 D1/R2；生产 `WRITE_MODE=protected` 拒绝业务写入，仅在合法
+   Preview host 上允许登录/退出所需的认证 session 写入。Preview host 后缀通过受保护环境变量
+   `PREVIEW_HOST_SUFFIX` 配置为当前账号的 `<account-subdomain>.workers.dev`，不得提交到仓库；
+7. 发布后用 `/api/health`、SSR 页面、注册边界 smoke 和关键只读 API 做 smoke，记录 version ID、migration 结果和
    构建 run URL。任何 smoke 失败都停止后续推广。
 
 ## 4. D1、KV 与 R2
@@ -94,6 +99,10 @@ Workers Builds 的推荐配置为：
 4. 数据问题使用 D1 Time Travel/备份或经单独批准的新 v3 数据库恢复；不得修改已应用 migration。
 5. R2/KV 恢复必须基于本次变更预先记录的对象/namespace 证据，不执行模糊前缀或全 bucket 删除。
 6. 任一自动验证、日志证据或人工审批缺失时停止，不用本机命令手工补写。
+
+Preview 事故先在 Workers Builds 中关闭非生产分支 Preview 或恢复 Preview deploy command；正式
+Worker 继续按受保护版本流程回滚。Preview 不执行 migration，且业务写入被拦截，因此不需要
+回滚 D1 schema；认证 session 写入仍属于共享生产认证数据，需按认证数据保留策略处理。
 
 ## 6. 可观测性与隐私
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "worker:types": "wrangler types src/server/worker-configuration.d.ts --config wrangler.jsonc --env production --check && git diff --exit-code -- src/server/worker-configuration.d.ts",
     "worker:dry-run": "node scripts/worker-dry-run.mjs",
     "worker:size": "node scripts/check-worker-bundle-size.mjs",
-    "deploy:production": "node scripts/deploy-production.mjs"
+    "deploy:production": "node scripts/deploy-production.mjs",
+    "deploy:preview": "node scripts/deploy-preview.mjs"
   },
   "dependencies": {
     "@astrojs/cloudflare": "^14.2.3",

--- a/scripts/deploy-preview.mjs
+++ b/scripts/deploy-preview.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  previewAliasForBranch,
+  previewWranglerCommand,
+} from "./preview-alias.mjs";
+import { assertPreviewDeployEnvironment } from "./production-build-guard.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const WRANGLER = process.platform === "win32" ? "wrangler.cmd" : "wrangler";
+
+export function previewDeployCommand(environment = process.env) {
+  assertPreviewDeployEnvironment(environment);
+  const alias = previewAliasForBranch(environment.WORKERS_CI_BRANCH);
+  return { alias, args: previewWranglerCommand(alias) };
+}
+
+function runWrangler(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(WRANGLER, args, {
+      cwd: ROOT,
+      env: { ...process.env, CLOUDFLARE_ENV: "production" },
+      stdio: "inherit",
+      shell: process.platform === "win32",
+    });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (signal) {
+        reject(new Error(`wrangler stopped by ${signal}`));
+      } else if (code !== 0) {
+        reject(new Error(`wrangler exited with code ${code ?? 1}`));
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+async function main() {
+  const { alias, args } = previewDeployCommand();
+  console.log(`Uploading Preview version with alias ${alias}`);
+  await runWrangler(args);
+}
+
+if (path.resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(`❌ ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/preview-alias.mjs
+++ b/scripts/preview-alias.mjs
@@ -8,7 +8,7 @@ function branchHash(branch) {
 }
 
 function branchSlug(branch) {
-  const ascii = branch.normalize("NFKD").replace(/[^\x00-\x7F]/g, "");
+  const ascii = branch.normalize("NFKD").replace(/[^\p{ASCII}]/gu, "");
   return ascii.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "branch";
 }
 

--- a/scripts/preview-alias.mjs
+++ b/scripts/preview-alias.mjs
@@ -1,0 +1,51 @@
+import { createHash } from "node:crypto";
+
+export const DEFAULT_WORKER_NAME = "gomate";
+export const MAX_DNS_LABEL_LENGTH = 63;
+
+function branchHash(branch) {
+  return createHash("sha256").update(branch, "utf8").digest("hex").slice(0, 8);
+}
+
+function branchSlug(branch) {
+  const ascii = branch.normalize("NFKD").replace(/[^\x00-\x7F]/g, "");
+  return ascii.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "branch";
+}
+
+export function previewAliasForBranch(
+  branch,
+  workerName = DEFAULT_WORKER_NAME,
+) {
+  if (typeof branch !== "string" || branch.trim() === "") {
+    throw new Error("Preview alias requires WORKERS_CI_BRANCH");
+  }
+  if (branch === "main") {
+    throw new Error("Preview aliases are not created for main");
+  }
+  if (!/^[a-z0-9][a-z0-9-]*$/u.test(workerName)) {
+    throw new Error("Worker name must be a DNS-compatible label");
+  }
+
+  const hash = branchHash(branch);
+  const prefix = `b-${branchSlug(branch)}`;
+  const maxAliasLength = MAX_DNS_LABEL_LENGTH - workerName.length - 1;
+  const slugLength = Math.max(1, maxAliasLength - prefix.length - 1 - hash.length);
+  const trimmedPrefix = prefix.slice(0, prefix.length - branchSlug(branch).length + slugLength).replace(/-+$/u, "");
+  return `${trimmedPrefix}-${hash}`;
+}
+
+export function previewWranglerCommand(alias) {
+  if (!/^[a-z][a-z0-9-]*$/u.test(alias)) {
+    throw new Error("Preview alias is not DNS-compatible");
+  }
+  return [
+    "versions",
+    "upload",
+    "--env",
+    "production",
+    "--config",
+    "wrangler.jsonc",
+    "--preview-alias",
+    alias,
+  ];
+}

--- a/scripts/preview-alias.mjs
+++ b/scripts/preview-alias.mjs
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 
 export const DEFAULT_WORKER_NAME = "gomate";
 export const MAX_DNS_LABEL_LENGTH = 63;
+export const PREVIEW_WRANGLER_CONFIG = "dist/server/wrangler.json";
 
 function branchHash(branch) {
   return createHash("sha256").update(branch, "utf8").digest("hex").slice(0, 8);
@@ -44,7 +45,10 @@ export function previewWranglerCommand(alias) {
     "--env",
     "production",
     "--config",
-    "wrangler.jsonc",
+    PREVIEW_WRANGLER_CONFIG,
+    "--keep-vars",
+    "--var",
+    "WRITE_MODE:protected",
     "--preview-alias",
     alias,
   ];

--- a/scripts/preview-alias.test.mjs
+++ b/scripts/preview-alias.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  MAX_DNS_LABEL_LENGTH,
+  previewAliasForBranch,
+} from "./preview-alias.mjs";
+
+test("creates a stable DNS-safe alias for a branch", () => {
+  const alias = previewAliasForBranch("Feature/Preview_URL");
+
+  assert.equal(alias, previewAliasForBranch("Feature/Preview_URL"));
+  assert.match(alias, /^[a-z][a-z0-9-]*$/u);
+  assert.ok(alias.length + 1 + "gomate".length <= MAX_DNS_LABEL_LENGTH);
+});
+
+test("keeps normalized branch collisions distinct", () => {
+  assert.notEqual(
+    previewAliasForBranch("feature/a"),
+    previewAliasForBranch("feature-a"),
+  );
+});
+
+test("bounds long and non-ASCII branch names", () => {
+  const alias = previewAliasForBranch(`${"很长的分支名/".repeat(30)}release`);
+
+  assert.match(alias, /^[a-z][a-z0-9-]*$/u);
+  assert.ok(alias.length + 1 + "gomate".length <= MAX_DNS_LABEL_LENGTH);
+});
+
+test("does not create an alias for main", () => {
+  assert.throws(() => previewAliasForBranch("main"), /main/u);
+});

--- a/scripts/production-build-guard.mjs
+++ b/scripts/production-build-guard.mjs
@@ -28,7 +28,6 @@ export function assertProductionBuildEnvironment(environment = process.env) {
   ) {
     throw new Error("生产构建只允许 CLOUDFLARE_ENV=production");
   }
-
 }
 
 export function assertPreviewDeployEnvironment(environment = process.env) {

--- a/scripts/production-build-guard.mjs
+++ b/scripts/production-build-guard.mjs
@@ -17,8 +17,8 @@ export function assertProductionWriteMode(environment = process.env) {
 
 /**
  * Keep the one-environment release policy fail-closed in Workers Builds.
- * Local builds may run without Workers CI metadata, but a Workers Build must
- * come from the production branch and select the production Cloudflare env.
+ * Local builds may run without Workers CI metadata, while both production and
+ * non-production branches build against the production-compatible Worker env.
  */
 export function assertProductionBuildEnvironment(environment = process.env) {
   const selectedEnvironment = environment.CLOUDFLARE_ENV;
@@ -29,11 +29,24 @@ export function assertProductionBuildEnvironment(environment = process.env) {
     throw new Error("生产构建只允许 CLOUDFLARE_ENV=production");
   }
 
+}
+
+export function assertPreviewDeployEnvironment(environment = process.env) {
+  const selectedEnvironment = environment.CLOUDFLARE_ENV;
   if (
-    environment.WORKERS_CI === "1" &&
-    environment.WORKERS_CI_BRANCH !== "main"
+    selectedEnvironment &&
+    selectedEnvironment !== PRODUCTION_ENVIRONMENT
   ) {
-    throw new Error("Workers Builds 只允许 main 分支进行生产构建");
+    throw new Error("Preview 构建只允许 CLOUDFLARE_ENV=production");
+  }
+  if (environment.WORKERS_CI !== "1") {
+    throw new Error("Preview 部署只允许由 Workers Builds 执行");
+  }
+  if (!environment.WORKERS_CI_BRANCH) {
+    throw new Error("Preview 部署缺少 WORKERS_CI_BRANCH");
+  }
+  if (environment.WORKERS_CI_BRANCH === "main") {
+    throw new Error("Preview 部署不允许使用 main 分支");
   }
 }
 

--- a/scripts/production-build-guard.test.mjs
+++ b/scripts/production-build-guard.test.mjs
@@ -6,8 +6,10 @@ import {
   assertProductionDeployEnvironment,
   assertProductionWriteMode,
   parseJsonc,
+  assertPreviewDeployEnvironment,
 } from "./production-build-guard.mjs";
 import { PRODUCTION_WRANGLER_COMMANDS } from "./deploy-production.mjs";
+import { previewDeployCommand } from "./deploy-preview.mjs";
 
 test("allows local production-parity builds", () => {
   assert.doesNotThrow(() =>
@@ -25,14 +27,13 @@ test("allows the production branch in Workers Builds", () => {
   );
 });
 
-test("rejects non-production Workers Builds branches", () => {
-  assert.throws(
-    () =>
-      assertProductionBuildEnvironment({
-        WORKERS_CI: "1",
-        WORKERS_CI_BRANCH: "feature/example",
-      }),
-    /只允许 main/u,
+test("allows non-main branches to build Preview versions", () => {
+  assert.doesNotThrow(() =>
+    assertProductionBuildEnvironment({
+      CLOUDFLARE_ENV: "production",
+      WORKERS_CI: "1",
+      WORKERS_CI_BRANCH: "feature/example",
+    }),
   );
 });
 
@@ -90,6 +91,53 @@ test("rejects production deployment outside Workers Builds", () => {
       }),
     /只允许由 main 分支的 Workers Builds 执行/u,
   );
+});
+
+test("allows Preview deployment only from a non-main Workers Build", () => {
+  assert.doesNotThrow(() =>
+    assertPreviewDeployEnvironment({
+      CLOUDFLARE_ENV: "production",
+      WORKERS_CI: "1",
+      WORKERS_CI_BRANCH: "feature/example",
+    }),
+  );
+});
+
+test("rejects Preview deployment from main or outside Workers Builds", () => {
+  assert.throws(
+    () =>
+      assertPreviewDeployEnvironment({
+        WORKERS_CI: "1",
+        WORKERS_CI_BRANCH: "main",
+      }),
+    /不允许使用 main/u,
+  );
+  assert.throws(
+    () =>
+      assertPreviewDeployEnvironment({ WORKERS_CI_BRANCH: "feature/example" }),
+    /只允许由 Workers Builds/u,
+  );
+});
+
+test("uploads only a version with a stable branch alias", () => {
+  const result = previewDeployCommand({
+    CLOUDFLARE_ENV: "production",
+    WORKERS_CI: "1",
+    WORKERS_CI_BRANCH: "feature/example",
+  });
+  assert.match(result.alias, /^[a-z][a-z0-9-]*$/u);
+  assert.deepEqual(result.args, [
+    "versions",
+    "upload",
+    "--env",
+    "production",
+    "--config",
+    "wrangler.jsonc",
+    "--preview-alias",
+    result.alias,
+  ]);
+  assert.equal(result.args.includes("deploy"), false);
+  assert.equal(result.args.includes("migrations"), false);
 });
 
 test("deploys the Astro build through Wranglers redirected config", () => {

--- a/scripts/production-build-guard.test.mjs
+++ b/scripts/production-build-guard.test.mjs
@@ -132,7 +132,10 @@ test("uploads only a version with a stable branch alias", () => {
     "--env",
     "production",
     "--config",
-    "wrangler.jsonc",
+    "dist/server/wrangler.json",
+    "--keep-vars",
+    "--var",
+    "WRITE_MODE:protected",
     "--preview-alias",
     result.alias,
   ]);

--- a/src/server/app.test.ts
+++ b/src/server/app.test.ts
@@ -3,6 +3,7 @@ import { apiApp, type ApiBindings } from "./app";
 
 type TestOverrides = Omit<Partial<ApiBindings>, "WRITE_MODE"> & {
   WRITE_MODE?: "open" | "protected";
+  PREVIEW_HOST_SUFFIX?: string;
 };
 
 function env(overrides: TestOverrides = {}): ApiBindings {
@@ -59,6 +60,46 @@ describe("API boundary", () => {
 
     expect(response.status).toBe(503);
     expect(response.headers.get("retry-after")).toBe("60");
+  });
+
+  it("allows only the Preview sign-in boundary through write protection", async () => {
+    const response = await apiApp.fetch(
+      new Request(
+        "https://b-feature-login-12345678-gomate.account.workers.dev/auth/sign-in/email",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "{}",
+        },
+      ),
+      env({ WRITE_MODE: "protected", PREVIEW_HOST_SUFFIX: "account.workers.dev" }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("keeps Preview business writes and account mutations protected", async () => {
+    const previewEnv = env({
+      WRITE_MODE: "protected",
+      PREVIEW_HOST_SUFFIX: "account.workers.dev",
+    });
+    const businessWrite = await apiApp.fetch(
+      new Request(
+        "https://b-feature-login-12345678-gomate.account.workers.dev/contact",
+        { method: "POST", body: "{}" },
+      ),
+      previewEnv,
+    );
+    const accountWrite = await apiApp.fetch(
+      new Request(
+        "https://b-feature-login-12345678-gomate.account.workers.dev/auth/sign-up/email",
+        { method: "POST", body: "{}" },
+      ),
+      previewEnv,
+    );
+
+    expect(businessWrite.status).toBe(503);
+    expect(accountWrite.status).toBe(503);
   });
 
   it("keeps unknown API resources inside the JSON error contract", async () => {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -20,6 +20,10 @@ import storiesRoute from "./routes/stories";
 import { shareImageRoute } from "./routes/share-image";
 import { localCircleHomeRoute } from "./routes/local-circle/home";
 import { apiValidator } from "./lib/validation";
+import {
+  getRequestOrigin,
+  isPreviewAuthMutation,
+} from "./lib/preview-policy";
 
 export type WriteMode = "open" | "protected";
 
@@ -64,7 +68,8 @@ apiApp.use("*", async (c, next) => {
   const writeMode = resolveWriteMode(c.env?.WRITE_MODE);
   if (
     writeMode === "protected" &&
-    !SAFE_METHODS.has(c.req.method.toUpperCase())
+    !SAFE_METHODS.has(c.req.method.toUpperCase()) &&
+    !isPreviewAuthMutation(c.req.raw, c.req.path, c.env)
   ) {
     c.header("Retry-After", String(WRITE_PROTECTION_RETRY_SECONDS));
     return c.json(APIErrors.writeProtected(), 503);
@@ -79,15 +84,11 @@ apiApp.use("*", async (c, next) => {
     return;
   }
 
-  let allowedOrigin: string;
-  try {
-    const configured = new URL(c.env.APP_URL);
-    if (configured.href !== `${configured.origin}/`) throw new Error("APP_URL");
-    allowedOrigin = configured.origin;
-  } catch {
+  const allowedOrigin = getRequestOrigin(c.req.raw, c.env);
+  if (!allowedOrigin) {
     return c.json(
-      APIErrors.serviceUnavailable("Origin protection unavailable"),
-      503,
+      APIErrors.forbidden("Cross-origin cookie write rejected"),
+      403,
     );
   }
 

--- a/src/server/lib/auth-config.test.ts
+++ b/src/server/lib/auth-config.test.ts
@@ -182,4 +182,48 @@ describe("createAuth security configuration", () => {
     expect(options.onAPIError).toEqual({ throw: true });
   });
 
+  it("derives Better Auth origins from the validated Preview host", async () => {
+    createAuth({
+      DB: {} as D1Database,
+      BETTER_AUTH_SECRET: "test-secret-key-for-testing-32chars",
+      APP_URL: "https://gomate.live",
+      PREVIEW_HOST_SUFFIX: "account.workers.dev",
+    } as never);
+
+    const options = mocks.betterAuth.mock.calls[0]?.[0] as {
+      baseURL: {
+        allowedHosts: string[];
+        fallback: string;
+        protocol: string;
+      };
+      trustedOrigins: (request?: Request) => (string | null)[];
+      advanced: {
+        defaultCookieAttributes: {
+          sameSite: string;
+          secure: boolean;
+          path: string;
+          domain?: string;
+        };
+      };
+    };
+
+    expect(options.baseURL).toEqual({
+      allowedHosts: ["*-gomate.account.workers.dev"],
+      fallback: "https://gomate.live",
+      protocol: "https",
+    });
+    expect(options.trustedOrigins(
+      new Request("https://b-feature-gomate.account.workers.dev/api/auth/sign-in/email"),
+    )).toEqual([
+      "https://gomate.live",
+      "https://b-feature-gomate.account.workers.dev",
+    ]);
+    expect(options.advanced.defaultCookieAttributes).toMatchObject({
+      sameSite: "lax",
+      secure: true,
+      path: "/",
+    });
+    expect(options.advanced.defaultCookieAttributes.domain).toBeUndefined();
+  });
+
 });

--- a/src/server/lib/auth.ts
+++ b/src/server/lib/auth.ts
@@ -10,6 +10,10 @@ import {
 import { logger } from "./logger";
 import { isUserActive } from "./session-policy";
 import { authPassword } from "./auth-password";
+import {
+  getAuthBaseUrl,
+  getAuthTrustedOrigins,
+} from "./preview-policy";
 
 /** Better Auth 用户类型（包含扩展字段） */
 interface AuthUser {
@@ -192,8 +196,8 @@ export function createAuth(
       },
     },
     secret: authSecret,
-    baseURL: env.APP_URL,
+    baseURL: getAuthBaseUrl(env),
     basePath: "/api/auth",
-    trustedOrigins: [env.APP_URL],
+    trustedOrigins: (request) => getAuthTrustedOrigins(request, env),
   });
 }

--- a/src/server/lib/preview-policy.test.ts
+++ b/src/server/lib/preview-policy.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  getAuthBaseUrl,
+  getRequestOrigin,
+  isPreviewAuthMutation,
+  isPreviewRequest,
+} from "./preview-policy";
+
+const env = {
+  APP_URL: "https://gomate.live",
+  PREVIEW_HOST_SUFFIX: "account.workers.dev",
+};
+
+describe("Preview request policy", () => {
+  it("accepts only gomate version and alias hosts in the configured account", () => {
+    const previewRequest = new Request(
+      "https://b-feature-login-12345678-gomate.account.workers.dev/api/health",
+    );
+
+    expect(isPreviewRequest(previewRequest, env)).toBe(true);
+    expect(getRequestOrigin(previewRequest, env)).toBe(
+      "https://b-feature-login-12345678-gomate.account.workers.dev",
+    );
+  });
+
+  it("rejects other workers, accounts, and insecure preview origins", () => {
+    expect(
+      isPreviewRequest(
+        new Request("https://other-worker.account.workers.dev/api/health"),
+        env,
+      ),
+    ).toBe(false);
+    expect(
+      isPreviewRequest(
+        new Request("https://b-feature-gomate.other.workers.dev/api/health"),
+        env,
+      ),
+    ).toBe(false);
+    expect(
+      isPreviewRequest(
+        new Request("http://b-feature-gomate.account.workers.dev/api/health"),
+        env,
+      ),
+    ).toBe(false);
+    expect(
+      getRequestOrigin(new Request("https://unknown.example/api/health"), env),
+    ).toBe(null);
+  });
+
+  it("keeps the production origin as the auth fallback", () => {
+    expect(
+      getRequestOrigin(new Request("https://gomate.live/api/auth/sign-in/email"), env),
+    ).toBe("https://gomate.live");
+    expect(getAuthBaseUrl(env)).toMatchObject({
+      allowedHosts: ["*-gomate.account.workers.dev"],
+      fallback: "https://gomate.live",
+      protocol: "https",
+    });
+  });
+
+  it("allows only sign-in and sign-out mutations on a valid Preview host", () => {
+    const request = new Request(
+      "https://b-feature-login-12345678-gomate.account.workers.dev/api/auth/sign-in/email",
+      { method: "POST" },
+    );
+
+    expect(isPreviewAuthMutation(request, "/auth/sign-in/email", env)).toBe(true);
+    expect(
+      isPreviewAuthMutation(
+        new Request(request.url, { method: "POST" }),
+        "/auth/sign-out",
+        env,
+      ),
+    ).toBe(true);
+    expect(
+      isPreviewAuthMutation(
+        new Request(request.url, { method: "POST" }),
+        "/auth/sign-up/email",
+        env,
+      ),
+    ).toBe(false);
+    expect(
+      isPreviewAuthMutation(
+        new Request(request.url, { method: "POST" }),
+        "/auth/reset-password",
+        env,
+      ),
+    ).toBe(false);
+    expect(
+      isPreviewAuthMutation(
+        new Request(request.url, { method: "GET" }),
+        "/auth/sign-in/email",
+        env,
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/server/lib/preview-policy.test.ts
+++ b/src/server/lib/preview-policy.test.ts
@@ -65,10 +65,11 @@ describe("Preview request policy", () => {
     );
 
     expect(isPreviewAuthMutation(request, "/auth/sign-in/email", env)).toBe(true);
+    expect(isPreviewAuthMutation(request, "/api/auth/sign-in/email", env)).toBe(true);
     expect(
       isPreviewAuthMutation(
         new Request(request.url, { method: "POST" }),
-        "/auth/sign-out",
+        "/api/auth/sign-out",
         env,
       ),
     ).toBe(true);

--- a/src/server/lib/preview-policy.ts
+++ b/src/server/lib/preview-policy.ts
@@ -61,8 +61,9 @@ export function isPreviewAuthMutation(
   path: string,
   env: PreviewPolicyEnv,
 ): boolean {
+  const normalizedPath = path.replace(/^\/api(?=\/|$)/u, "") || "/";
   return request.method.toUpperCase() === "POST" &&
-    PREVIEW_AUTH_MUTATION_PATHS.has(path) &&
+    PREVIEW_AUTH_MUTATION_PATHS.has(normalizedPath) &&
     isPreviewRequest(request, env);
 }
 

--- a/src/server/lib/preview-policy.ts
+++ b/src/server/lib/preview-policy.ts
@@ -1,0 +1,87 @@
+const PREVIEW_AUTH_MUTATION_PATHS = new Set([
+  "/auth/sign-in/email",
+  "/auth/sign-out",
+]);
+
+export type PreviewPolicyEnv = {
+  APP_URL: string;
+  PREVIEW_HOST_SUFFIX?: string;
+};
+
+function configuredOrigin(appUrl: string): string | null {
+  try {
+    const url = new URL(appUrl);
+    if (url.href !== `${url.origin}/`) return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+function previewHostSuffix(env: PreviewPolicyEnv): string | null {
+  const suffix = env.PREVIEW_HOST_SUFFIX?.trim().toLowerCase();
+  if (!suffix || !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.workers\.dev$/u.test(suffix)) {
+    return null;
+  }
+  return suffix;
+}
+
+export function previewHostPattern(env: PreviewPolicyEnv): string | null {
+  const suffix = previewHostSuffix(env);
+  return suffix ? `*-gomate.${suffix}` : null;
+}
+
+export function isPreviewRequest(
+  request: Request,
+  env: PreviewPolicyEnv,
+): boolean {
+  const suffix = previewHostSuffix(env);
+  if (!suffix) return false;
+
+  const url = new URL(request.url);
+  if (url.protocol !== "https:" || url.port) return false;
+  const workerSuffix = `-gomate.${suffix}`;
+  if (!url.hostname.endsWith(workerSuffix)) return false;
+
+  const versionOrAlias = url.hostname.slice(0, -workerSuffix.length);
+  return /^[a-z0-9][a-z0-9-]*$/u.test(versionOrAlias);
+}
+
+export function getRequestOrigin(
+  request: Request,
+  env: PreviewPolicyEnv,
+): string | null {
+  const origin = new URL(request.url).origin;
+  if (origin === configuredOrigin(env.APP_URL)) return origin;
+  return isPreviewRequest(request, env) ? origin : null;
+}
+
+export function isPreviewAuthMutation(
+  request: Request,
+  path: string,
+  env: PreviewPolicyEnv,
+): boolean {
+  return request.method.toUpperCase() === "POST" &&
+    PREVIEW_AUTH_MUTATION_PATHS.has(path) &&
+    isPreviewRequest(request, env);
+}
+
+export function getAuthBaseUrl(env: PreviewPolicyEnv) {
+  const pattern = previewHostPattern(env);
+  if (!pattern) return env.APP_URL;
+  return {
+    allowedHosts: [pattern],
+    fallback: env.APP_URL,
+    protocol: "https" as const,
+  };
+}
+
+export function getAuthTrustedOrigins(
+  request: Request | undefined,
+  env: PreviewPolicyEnv,
+): (string | null)[] {
+  return [
+    configuredOrigin(env.APP_URL),
+    request ? getRequestOrigin(request, env) : null,
+  ];
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -76,7 +76,7 @@
       "main": "./src/worker.ts",
       "name": "gomate",
       "workers_dev": false,
-      "preview_urls": false,
+      "preview_urls": true,
       "routes": [{ "pattern": "gomate.live", "custom_domain": true }],
       "assets": {
         "directory": "./dist",


### PR DESCRIPTION
## Summary

- 为同一个 `gomate` Worker 开启 Cloudflare Preview URLs，不创建独立 Worker、D1 或 R2。
- 新增非 `main` 分支 Preview 上传命令和稳定 branch alias。
- Preview 复用生产 D1/R2 读取；上传时显式注入 `WRITE_MODE=protected`，拒绝业务写入，仅允许登录、退出及 session 读取所需的认证路径。
- 增加 Preview host 校验、动态 Better Auth origin/cookie 策略，并同步部署/API/README/PR 模板文档。

## Cloudflare 配置

合并后需在 Cloudflare Workers Builds 中配置非 `main` 分支构建，并使用：

```bash
pnpm deploy:preview
```

该命令使用同一次 Build 生成的 `dist/server/wrangler.json`，执行 Preview version upload、保留 Dashboard 变量，并覆盖 `WRITE_MODE:protected`；不会执行 migration、正式 deploy 或 promote。

同时在生产环境变量中配置真实的 `PREVIEW_HOST_SUFFIX`（例如账户对应的 `<account-subdomain>.workers.dev` 后缀）。生产发布仍只允许受保护的 `main` 流程。

## Verification

- `pnpm test:ci`
- `pnpm test:e2e:ci`（使用临时本地测试环境变量）
- `pnpm i18n:build`
- `pnpm worker:types`
- `pnpm db:check`
- `pnpm audit --prod --audit-level high`
- `pnpm worker:dry-run`
- `pnpm worker:size`
- Preview Wrangler dry-run：确认 Astro bundle、生产 D1/R2 bindings 和隐藏的 `WRITE_MODE` 变量均可解析

Cloudflare Workers Builds 的 PR 原生评论、alias 实际指向和部署后读写验收，需要在 Dashboard 配置完成后用测试分支验证。