### PR TITLE
ci: label pull requests by changed paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,89 @@
+# Configuration for actions/labeler v7.
+# A pull request may receive more than one label when its changes span areas.
+
+frontend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/pages/**"
+          - "src/components/**"
+          - "src/layouts/**"
+          - "src/hooks/**"
+          - "src/stores/**"
+          - "src/styles/**"
+          - "src/content/**"
+          - "src/content.config.ts"
+          - "public/**"
+          - "astro.config.mjs"
+          - "tailwind.config.ts"
+
+backend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/server/**"
+          - "src/contracts/**"
+          - "src/worker.ts"
+          - "src/middleware.ts"
+          - "src/lib/server-api.ts"
+          - "wrangler.jsonc"
+
+database:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "migrations/**"
+          - "src/server/db/**"
+          - "drizzle.config.ts"
+          - "scripts/check-migrations-sync.mjs"
+          - "scripts/reset-local-db.mjs"
+          - "scripts/reset-local-db.test.mjs"
+          - "scripts/promote-admin.mjs"
+
+i18n:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/i18n/**"
+          - "public/locales/**"
+          - "src/hooks/useI18n.ts"
+          - "src/hooks/useI18n.test.tsx"
+          - "src/hooks/useMessages.ts"
+          - "scripts/build-locales.ts"
+          - "scripts/gen-i18n-types.mjs"
+          - "scripts/validate-i18n-keys.mjs"
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "e2e/**"
+          - "tests/**"
+          - "src/__tests__/**"
+          - "src/**/__tests__/**"
+          - "src/**/*.test.*"
+          - "src/**/*.spec.*"
+          - "scripts/*.test.mjs"
+          - "playwright.config.ts"
+          - "vitest.config.ts"
+          - "vitest.server.config.ts"
+          - "vitest.worker.config.ts"
+
+actions:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - ".github/labeler.yml"
+          - "scripts/ci-workflow-policy.test.mjs"
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "package.json"
+          - "pnpm-lock.yaml"
+          - "pnpm-workspace.yaml"
+          - ".node-version"
+          - ".npmrc"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "*.md"
+          - "docs/**"
+          - ".github/**/*.md"
+          - ".codex/**"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,95 @@
+name: Pull Request Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Ensure path labels exist
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const labels = [
+              {
+                name: "frontend",
+                color: "1d76db",
+                description: "Frontend pages, components, styles, and public assets",
+              },
+              {
+                name: "backend",
+                color: "5319e7",
+                description: "API, server, contracts, and Worker runtime",
+              },
+              {
+                name: "database",
+                color: "006b75",
+                description: "D1 schema, migrations, and database tooling",
+              },
+              {
+                name: "i18n",
+                color: "fbca04",
+                description: "Translations, locale data, and i18n tooling",
+              },
+              {
+                name: "tests",
+                color: "bfdadc",
+                description: "Unit, server, Worker, or end-to-end tests",
+              },
+              {
+                name: "actions",
+                color: "2f363d",
+                description: "GitHub Actions and repository automation",
+              },
+              {
+                name: "dependencies",
+                color: "0366d6",
+                description: "Package manifests, lockfiles, and toolchain versions",
+              },
+              {
+                name: "documentation",
+                color: "0075ca",
+                description: "Documentation and contributor guidance",
+              },
+            ];
+
+            const existingLabels = await github.paginate(
+              github.rest.issues.listLabelsForRepo,
+              { ...context.repo, per_page: 100 },
+            );
+            const existingNames = new Set(
+              existingLabels.map(({ name }) => name.toLowerCase()),
+            );
+
+            for (const label of labels) {
+              if (existingNames.has(label.name.toLowerCase())) continue;
+
+              try {
+                await github.rest.issues.createLabel({ ...context.repo, ...label });
+              } catch (error) {
+                if (error.status !== 422) throw error;
+
+                // Another concurrent run may have created the same label.
+                await github.rest.issues.getLabel({
+                  ...context.repo,
+                  name: label.name,
+                });
+              }
+            }
+
+      - name: Label changed paths
+        uses: actions/labeler@v7
+        with:
+          sync-labels: true

--- a/scripts/ci-workflow-policy.test.mjs
+++ b/scripts/ci-workflow-policy.test.mjs
@@ -12,3 +12,38 @@ test("runs the required validation job only for pull requests targeting main", a
   assert.doesNotMatch(workflow, /^ {2}push:/mu);
   assert.match(workflow, /^ {2}validate:$/mu);
 });
+
+test("labels pull requests from trusted path rules", async () => {
+  const [workflow, config] = await Promise.all([
+    readFile(
+      new URL("../.github/workflows/labeler.yml", import.meta.url),
+      "utf8",
+    ),
+    readFile(new URL("../.github/labeler.yml", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(workflow, /^ {2}pull_request_target:$/mu);
+  assert.match(workflow, /^ {2}contents: read$/mu);
+  assert.match(workflow, /^ {2}pull-requests: write$/mu);
+  assert.match(workflow, /^ {2}issues: write$/mu);
+  assert.match(workflow, /uses: actions\/github-script@v9/u);
+  assert.match(workflow, /github\.rest\.issues\.createLabel/u);
+  assert.match(workflow, /uses: actions\/labeler@v7/u);
+  assert.match(workflow, /^ {10}sync-labels: true$/mu);
+  assert.doesNotMatch(workflow, /actions\/checkout|^\s*run:/mu);
+
+  for (const [label, representativePath] of [
+    ["frontend", "src/components/**"],
+    ["backend", "src/server/**"],
+    ["database", "migrations/**"],
+    ["i18n", "public/locales/**"],
+    ["tests", "e2e/**"],
+    ["actions", ".github/workflows/**"],
+    ["dependencies", "pnpm-lock.yaml"],
+    ["documentation", "docs/**"],
+  ]) {
+    assert.match(config, new RegExp(`^${label}:$`, "mu"));
+    assert.ok(config.includes(`- "${representativePath}"`));
+    assert.ok(workflow.includes(`name: "${label}"`));
+  }
+});


### PR DESCRIPTION
## 目的

根据 Pull Request 修改的项目路径自动添加模块标签，降低人工分类成本，并让前端、后端、数据库、i18n、测试和自动化改动更容易筛选。

## 范围

- 包含：8 类路径标签配置；自动创建缺失标签；同步移除不再匹配的标签；CI 配置契约测试
- 不包含：按标题、PR 大小或发布类型打标；修改现有业务 CI、Worker 发布或数据流程
- 关联 Issue / Spec / ADR：无

## 风险与兼容性

- 风险等级：低
- 用户可见或 API 破坏性变更：无
- 主要失败模式与限制措施：`pull_request_target` 具有标签写权限，但工作流不 checkout 或执行 PR 代码；契约测试会阻止引入 `run` 或 `actions/checkout`。首次引入该工作流的 PR 不会给自身打标，合并后的后续 PR 开始生效。

## 验证证据

- [x] `pnpm test:ci`：前端 267、服务端 37、Worker 3 项测试全部通过
- [ ] `pnpm worker:types && pnpm worker:dry-run && pnpm worker:size`
- [ ] `pnpm audit --prod --audit-level high`（生产相关改动时）
- [ ] `pnpm test:e2e:ci`（涉及关键用户流程时）
- [ ] UI：桌面端、移动端、键盘、可访问名称和 i18n 已验证（涉及界面时）
- [x] 其他自动或手动验证：Labeler 契约测试、YAML 解析、内嵌 JavaScript 语法、Prettier、`git diff --check`
- [ ] Preview：PR 评论 URL、分支 alias、重新登录、私有读取和业务写入拦截已验证（涉及时）
- 未运行项及原因：不涉及生产依赖审计、浏览器用户流程、UI、Preview 或 Worker bundle 变更。

## Cloudflare 与数据影响

- [x] 不涉及 Cloudflare 运行时或远程数据
- [ ] Worker 代码、Static Assets、兼容日期或 flags
- [ ] route、custom domain 或 Workers Builds 配置
- [ ] Preview URL、alias 或 Preview host/只读认证边界
- [ ] D1 schema、migration 或生产数据
- [ ] R2 bucket、对象或公开 URL
- [ ] bindings、变量、rate limit 或 secrets
- [ ] 认证、缓存、日志、trace 或隐私边界

精确目标、预期状态和影响范围：仅新增 GitHub PR 标签自动化；首次后续 PR 运行时创建仓库中缺失的模块标签，并按变更路径应用标签。

### Worker 检查（适用时）

不适用。

### D1 / R2 检查（适用时）

- migration / 对象范围：不涉及
- 全新本地 D1 重放结果：`pnpm test:ci` 中的数据库重建测试通过
- 当前与上一 Worker version 的 schema 兼容性：不涉及
- 数据或对象恢复方式：不涉及

## 发布、验证与回滚

- 合并后的生产影响：无 Worker 或数据发布影响；仅启用 GitHub PR 标签工作流
- 发布后 smoke：创建或更新一个修改匹配路径的 PR，确认对应标签被添加
- Worker 回滚目标或停止发布方式：不涉及；如需停用可回退该提交或禁用 `Pull Request Labeler` 工作流
- schema / 数据 / R2 无法随 Worker 回滚时的处理方式：不涉及
